### PR TITLE
Restore support to deploy operator with kustomize manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,14 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: deploy
+deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+.PHONY: undeploy
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= eu.gcr.io/kyma-project/telemetry-manager:v20230228-5c25a280
+IMG ?= eu.gcr.io/kyma-project/telemetry-manager:v20230301-d3eabc52
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= telemetry-manager:latest
+IMG ?= eu.gcr.io/kyma-project/telemetry-manager:v20230228-5c25a280
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 
@@ -128,8 +128,8 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.9.0
+KUSTOMIZE_VERSION ?= v5.0.0
+CONTROLLER_TOOLS_VERSION ?= v0.11.3
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/config/crd/bases/telemetry.kyma-project.io_logparsers.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logparsers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: logparsers.telemetry.kyma-project.io
 spec:

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: logpipelines.telemetry.kyma-project.io
 spec:

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: tracepipelines.telemetry.kyma-project.io
 spec:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,144 @@
+# Adds namespace to all resources.
+namespace: kyma-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: telemetry-
+
+# Labels to add to all resources and selectors.
+#labels:
+#- includeSelectors: true
+#  pairs:
+#    someName: someValue
+
+resources:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patchesStrategicMerge:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+# - manager_auth_proxy_patch.yaml
+
+
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+# Uncomment the following replacements to add the cert-manager CA injection annotations
+#replacements:
+#  - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1
+#      name: serving-cert # this name should match the one in certificate.yaml
+#      fieldPath: .metadata.namespace # namespace of the certificate CR
+#    targets:
+#      - select:
+#          kind: ValidatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: MutatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: CustomResourceDefinition
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1
+#      name: serving-cert # this name should match the one in certificate.yaml
+#      fieldPath: .metadata.name
+#    targets:
+#      - select:
+#          kind: ValidatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: MutatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: CustomResourceDefinition
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#  - source: # Add cert-manager annotation to the webhook Service
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#      fieldPath: .metadata.name # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#      fieldPath: .metadata.namespace # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,10 +9,14 @@ namespace: kyma-system
 namePrefix: telemetry-
 
 # Labels to add to all resources and selectors.
-#labels:
-#- includeSelectors: true
-#  pairs:
-#    someName: someValue
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/part-of: telemetry
+    app.kubernetes.io/name: telemetry-controller-manager
+    app.kubernetes.io/instance: telemetry-controller-manager
+    app.kubernetes.io/managed-by: kustomize
 
 resources:
 - ../crd

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,55 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager
+  namespace: system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: eu.gcr.io/kyma-project/telemetry-manager
-  newTag: v20230224-2b8fad21
+  newTag: v20230228-5c25a280

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: eu.gcr.io/kyma-project/telemetry-manager
-  newTag: v20230228-5c25a280
+  newTag: v20230301-d3eabc52

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: eu.gcr.io/kyma-project/telemetry-manager
+  newTag: v20230224-2b8fad21

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,16 +45,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - --sync-period=1h
         - --cert-dir=/tmp
-        - --telemetry-namespace=kyma-system
-        - --fluent-bit-cm-name=telemetry-fluent-bit
-        - --fluent-bit-sections-cm-name=telemetry-fluent-bit-sections
-        - --fluent-bit-parser-cm-name=telemetry-fluent-bit-parsers
-        - --fluent-bit-ds-name=telemetry-fluent-bit
-        - --fluent-bit-env-secret=telemetry-fluent-bit-env
-        - --fluent-bit-files-cm=telemetry-fluent-bit-files
-        - --fluent-bit-filesystem-buffer-limit=1G
         - --fluent-bit-cpu-limit=1
         - --fluent-bit-memory-limit=1Gi
         - --fluent-bit-cpu-request=100m
@@ -62,10 +53,6 @@ spec:
         - --fluent-bit-denied-filter-plugins=kubernetes,rewrite_tag,multiline
         - --fluent-bit-denied-output-plugins=
         - --fluent-bit-max-pipelines=5
-        - --fluent-bit-image=eu.gcr.io/kyma-project/tpi/fluent-bit:2.0.9-f89e8b78
-        - --fluent-bit-exporter-image=eu.gcr.io/kyma-project/directory-size-exporter:v20230117-64505a69
-        - --enable-tracing=true
-        - --trace-collector-image=eu.gcr.io/kyma-project/tpi/otel-collector:0.71.0-372fcb3b
         - --trace-collector-cpu-limit=1
         - --trace-collector-memory-limit=1Gi
         - --trace-collector-cpu-request=25m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/managed-by: kustomize
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        app.kubernetes.io/name: deployment
+        app.kubernetes.io/instance: controller-manager
+        app.kubernetes.io/component: manager
+        app.kubernetes.io/managed-by: kustomize
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        - --sync-period=1h
+        - --cert-dir=/tmp
+        - --telemetry-namespace=kyma-system
+        - --fluent-bit-cm-name=telemetry-fluent-bit
+        - --fluent-bit-sections-cm-name=telemetry-fluent-bit-sections
+        - --fluent-bit-parser-cm-name=telemetry-fluent-bit-parsers
+        - --fluent-bit-ds-name=telemetry-fluent-bit
+        - --fluent-bit-env-secret=telemetry-fluent-bit-env
+        - --fluent-bit-files-cm=telemetry-fluent-bit-files
+        - --fluent-bit-filesystem-buffer-limit=1G
+        - --fluent-bit-cpu-limit=1
+        - --fluent-bit-memory-limit=1Gi
+        - --fluent-bit-cpu-request=100m
+        - --fluent-bit-memory-request=50Mi
+        - --fluent-bit-denied-filter-plugins=kubernetes,rewrite_tag,multiline
+        - --fluent-bit-denied-output-plugins=
+        - --fluent-bit-max-pipelines=5
+        - --fluent-bit-image=eu.gcr.io/kyma-project/tpi/fluent-bit:2.0.9-f89e8b78
+        - --fluent-bit-exporter-image=eu.gcr.io/kyma-project/directory-size-exporter:v20230117-64505a69
+        - --enable-tracing=true
+        - --trace-collector-image=eu.gcr.io/kyma-project/tpi/otel-collector:0.71.0-372fcb3b
+        - --trace-collector-cpu-limit=1
+        - --trace-collector-memory-limit=1Gi
+        - --trace-collector-cpu-request=25m
+        - --trace-collector-memory-request=32Mi
+        - --validating-webhook-enabled=true
+        image: controller:latest
+        name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop:
+              - ALL
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,14 +1,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-service
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   namespace: system
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+  - name: http-metrics
+    port: 8080
+    targetPort: 8080
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/managed-by: kustomize

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -10,3 +10,16 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- manifests.yaml
+#- manifests.yaml
 - service.yaml
 
 configurations:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -14,7 +14,6 @@ webhooks:
       - v1beta1
       - v1
     clientConfig:
-      caBundle: Cg==
       service:
         name: telemetry-operator-webhook
         namespace: kyma-system
@@ -37,12 +36,11 @@ webhooks:
           - logpipelines
         scope: '*'
     sideEffects: None
-    timeoutSeconds: 30
+    timeoutSeconds: 15
   - admissionReviewVersions:
       - v1beta1
       - v1
     clientConfig:
-      caBundle: Cg==
       service:
         name: telemetry-operator-webhook
         namespace: kyma-system
@@ -65,4 +63,4 @@ webhooks:
           - logparsers
         scope: '*'
     sideEffects: None
-    timeoutSeconds: 30
+    timeoutSeconds: 15

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -2,12 +2,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: telemetry-webhook
-  namespace: kyma-system
+  name: operator-webhook
+  namespace: system
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: 9443
   selector:
-    app: telemetry-webhook
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/managed-by: kustomize

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.1
+	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.90.0
@@ -70,7 +71,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.1
-	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.90.0
@@ -71,6 +70,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/hack/provision-test-env.sh
+++ b/hack/provision-test-env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+kyma provision k3d --ci
+
+REGISTRY_PORT=$(k3d registry list k3d-kyma-registry -ojson | jq '.[0].portMappings."5000/tcp"[0].HostPort')
+IMG=localhost:$REGISTRY_PORT/telemetry-manager:latest
+export IMG
+
+make docker-build
+make docker-push
+make install
+
+IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Restore kustomize manifests to deploy operator
- Restore make targets to deploy

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/16909