### PR TITLE
remove gopkg.in/yaml.v2 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.14.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.53.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.2
 	k8s.io/apiextensions-apiserver v0.26.2
@@ -85,6 +84,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.26.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230303024457-afdc3dddf62d // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/internal/reconciler/metricpipeline/config_builder_test.go
+++ b/internal/reconciler/metricpipeline/config_builder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
@@ -154,84 +154,84 @@ func TestK8sAttributesProcessor(t *testing.T) {
 
 func TestCollectorConfigMarshalling(t *testing.T) {
 	expected := `receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: ${MY_POD_IP}:4318
-      grpc:
-        endpoint: ${MY_POD_IP}:4317
+    otlp:
+        protocols:
+            http:
+                endpoint: ${MY_POD_IP}:4318
+            grpc:
+                endpoint: ${MY_POD_IP}:4317
 exporters:
-  otlp:
-    endpoint: ${OTLP_ENDPOINT}
-    sending_queue:
-      enabled: true
-      queue_size: 512
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
-  logging:
-    verbosity: basic
+    otlp:
+        endpoint: ${OTLP_ENDPOINT}
+        sending_queue:
+            enabled: true
+            queue_size: 512
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+    logging:
+        verbosity: basic
 processors:
-  batch:
-    send_batch_size: 512
-    timeout: 10s
-    send_batch_max_size: 512
-  memory_limiter:
-    check_interval: 1s
-    limit_percentage: 75
-    spike_limit_percentage: 10
-  k8sattributes:
-    auth_type: serviceAccount
-    passthrough: false
-    extract:
-      metadata:
-      - k8s.pod.name
-      - k8s.node.name
-      - k8s.namespace.name
-      - k8s.deployment.name
-      - k8s.statefulset.name
-      - k8s.daemonset.name
-      - k8s.cronjob.name
-      - k8s.job.name
-    pod_association:
-    - sources:
-      - from: resource_attribute
-        name: k8s.pod.ip
-    - sources:
-      - from: resource_attribute
-        name: k8s.pod.uid
-    - sources:
-      - from: connection
-  resource:
-    attributes:
-    - action: insert
-      key: k8s.cluster.name
-      value: ${KUBERNETES_SERVICE_HOST}
+    batch:
+        send_batch_size: 512
+        timeout: 10s
+        send_batch_max_size: 512
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 10
+    k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+            metadata:
+                - k8s.pod.name
+                - k8s.node.name
+                - k8s.namespace.name
+                - k8s.deployment.name
+                - k8s.statefulset.name
+                - k8s.daemonset.name
+                - k8s.cronjob.name
+                - k8s.job.name
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: connection
+    resource:
+        attributes:
+            - action: insert
+              key: k8s.cluster.name
+              value: ${KUBERNETES_SERVICE_HOST}
 extensions:
-  health_check:
-    endpoint: ${MY_POD_IP}:13133
+    health_check:
+        endpoint: ${MY_POD_IP}:13133
 service:
-  pipelines:
-    metrics:
-      receivers:
-      - otlp
-      processors:
-      - memory_limiter
-      - k8sattributes
-      - resource
-      - batch
-      exporters:
-      - otlp
-      - logging
-  telemetry:
-    metrics:
-      address: ${MY_POD_IP}:8888
-    logs:
-      level: info
-  extensions:
-  - health_check
+    pipelines:
+        metrics:
+            receivers:
+                - otlp
+            processors:
+                - memory_limiter
+                - k8sattributes
+                - resource
+                - batch
+            exporters:
+                - otlp
+                - logging
+    telemetry:
+        metrics:
+            address: ${MY_POD_IP}:8888
+        logs:
+            level: info
+    extensions:
+        - health_check
 `
 
 	fakeClient := fake.NewClientBuilder().Build()
@@ -239,7 +239,6 @@ service:
 	require.NoError(t, err)
 
 	yamlBytes, err := yaml.Marshal(collectorConfig)
-
 	require.NoError(t, err)
 	require.Equal(t, expected, string(yamlBytes))
 }

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
@@ -189,130 +189,103 @@ func TestFilterProcessor(t *testing.T) {
 
 func TestCollectorConfigMarshalling(t *testing.T) {
 	expected := `receivers:
-  opencensus:
-    endpoint: ${MY_POD_IP}:55678
-  otlp:
-    protocols:
-      http:
-        endpoint: ${MY_POD_IP}:4318
-      grpc:
-        endpoint: ${MY_POD_IP}:4317
+    opencensus:
+        endpoint: ${MY_POD_IP}:55678
+    otlp:
+        protocols:
+            http:
+                endpoint: ${MY_POD_IP}:4318
+            grpc:
+                endpoint: ${MY_POD_IP}:4317
 exporters:
-  otlp:
-    endpoint: ${OTLP_ENDPOINT}
-    sending_queue:
-      enabled: true
-      queue_size: 512
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
-  logging:
-    verbosity: basic
+    otlp:
+        endpoint: ${OTLP_ENDPOINT}
+        sending_queue:
+            enabled: true
+            queue_size: 512
+        retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+    logging:
+        verbosity: basic
 processors:
-  batch:
-    send_batch_size: 512
-    timeout: 10s
-    send_batch_max_size: 512
-  memory_limiter:
-    check_interval: 1s
-    limit_percentage: 75
-    spike_limit_percentage: 10
-  k8sattributes:
-    auth_type: serviceAccount
-    passthrough: false
-    extract:
-      metadata:
-      - k8s.pod.name
-      - k8s.node.name
-      - k8s.namespace.name
-      - k8s.deployment.name
-      - k8s.statefulset.name
-      - k8s.daemonset.name
-      - k8s.cronjob.name
-      - k8s.job.name
-    pod_association:
-    - sources:
-      - from: resource_attribute
-        name: k8s.pod.ip
-    - sources:
-      - from: resource_attribute
-        name: k8s.pod.uid
-    - sources:
-      - from: connection
-  resource:
-    attributes:
-    - action: insert
-      key: k8s.cluster.name
-      value: ${KUBERNETES_SERVICE_HOST}
-  filter:
-    traces:
-      span:
-      - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"]
-        == "jaeger.kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Egress") and (resource.attributes["service.name"]
-        == "grafana.kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"]
-        == "jaeger.kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"]
-        == "grafana.kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"]
-        == "loki.kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (IsMatch(attributes["http.url"],
-        ".+/metrics") == true) and (resource.attributes["k8s.namespace.name"] == "kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (IsMatch(attributes["http.url"],
-        ".+/healthz(/.*)?") == true) and (resource.attributes["k8s.namespace.name"]
-        == "kyma-system")
-      - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (attributes["user_agent"]
-        == "vm_promscrape")
-      - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Egress") and (IsMatch(attributes["http.url"],
-        "http(s)?:\\/\\/telemetry-otlp-traces\\.kyma-system(\\..*)?:(4318|4317).*")
-        == true)
-      - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Egress") and (IsMatch(attributes["http.url"],
-        "http(s)?:\\/\\/telemetry-trace-collector-internal\\.kyma-system(\\..*)?:(55678).*")
-        == true)
-      - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"]
-        == "loki.kyma-system")
-      - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy")
-        and (attributes["OperationName"] == "Egress") and (resource.attributes["service.name"]
-        == "telemetry-fluent-bit.kyma-system")
+    batch:
+        send_batch_size: 512
+        timeout: 10s
+        send_batch_max_size: 512
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 10
+    k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+            metadata:
+                - k8s.pod.name
+                - k8s.node.name
+                - k8s.namespace.name
+                - k8s.deployment.name
+                - k8s.statefulset.name
+                - k8s.daemonset.name
+                - k8s.cronjob.name
+                - k8s.job.name
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: connection
+    resource:
+        attributes:
+            - action: insert
+              key: k8s.cluster.name
+              value: ${KUBERNETES_SERVICE_HOST}
+    filter:
+        traces:
+            span:
+                - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"] == "jaeger.kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Egress") and (resource.attributes["service.name"] == "grafana.kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"] == "jaeger.kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"] == "grafana.kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"] == "loki.kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (IsMatch(attributes["http.url"], ".+/metrics") == true) and (resource.attributes["k8s.namespace.name"] == "kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (IsMatch(attributes["http.url"], ".+/healthz(/.*)?") == true) and (resource.attributes["k8s.namespace.name"] == "kyma-system")
+                - (attributes["http.method"] == "GET") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (attributes["user_agent"] == "vm_promscrape")
+                - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Egress") and (IsMatch(attributes["http.url"], "http(s)?:\\/\\/telemetry-otlp-traces\\.kyma-system(\\..*)?:(4318|4317).*") == true)
+                - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Egress") and (IsMatch(attributes["http.url"], "http(s)?:\\/\\/telemetry-trace-collector-internal\\.kyma-system(\\..*)?:(55678).*") == true)
+                - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Ingress") and (resource.attributes["service.name"] == "loki.kyma-system")
+                - (attributes["http.method"] == "POST") and (attributes["component"] == "proxy") and (attributes["OperationName"] == "Egress") and (resource.attributes["service.name"] == "telemetry-fluent-bit.kyma-system")
 extensions:
-  health_check:
-    endpoint: ${MY_POD_IP}:13133
+    health_check:
+        endpoint: ${MY_POD_IP}:13133
 service:
-  pipelines:
-    traces:
-      receivers:
-      - opencensus
-      - otlp
-      processors:
-      - memory_limiter
-      - k8sattributes
-      - filter
-      - resource
-      - batch
-      exporters:
-      - otlp
-      - logging
-  telemetry:
-    metrics:
-      address: ${MY_POD_IP}:8888
-    logs:
-      level: info
-  extensions:
-  - health_check
+    pipelines:
+        traces:
+            receivers:
+                - opencensus
+                - otlp
+            processors:
+                - memory_limiter
+                - k8sattributes
+                - filter
+                - resource
+                - batch
+            exporters:
+                - otlp
+                - logging
+    telemetry:
+        metrics:
+            address: ${MY_POD_IP}:8888
+        logs:
+            level: info
+    extensions:
+        - health_check
 `
 
 	fakeClient := fake.NewClientBuilder().Build()
@@ -320,6 +293,8 @@ service:
 	require.NoError(t, err)
 	yamlBytes, err := yaml.Marshal(collectorConfig)
 
+	a := string(yamlBytes)
+	fmt.Println(a)
 	require.NoError(t, err)
 	require.Equal(t, expected, string(yamlBytes))
 }

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -291,8 +291,8 @@ service:
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipeline)
 	require.NoError(t, err)
-	yamlBytes, err := yaml.Marshal(collectorConfig)
 	
+	yamlBytes, err := yaml.Marshal(collectorConfig)
 	require.NoError(t, err)
 	require.Equal(t, expected, string(yamlBytes))
 }

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -291,7 +291,7 @@ service:
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipeline)
 	require.NoError(t, err)
-	
+
 	yamlBytes, err := yaml.Marshal(collectorConfig)
 	require.NoError(t, err)
 	require.Equal(t, expected, string(yamlBytes))

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -292,9 +292,7 @@ service:
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipeline)
 	require.NoError(t, err)
 	yamlBytes, err := yaml.Marshal(collectorConfig)
-
-	a := string(yamlBytes)
-	fmt.Println(a)
+	
 	require.NoError(t, err)
 	require.Equal(t, expected, string(yamlBytes))
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- The `gopkg.in/yaml.v2` dependency is used in the otelcollector config builder tests of the trace and metric pipeline to verify if the created config by the package is valid.
- The actual otel config however is created with `gopkg.in/yaml.v3`.
- This PR replaces the `v2` dependecy in the tests with the `v3`. As a result, the v2 is not explicitly required in the go.mod file

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
