### PR TITLE
Restrict RBAC for telemetry manager

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,14 +8,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - get
@@ -38,22 +30,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
@@ -61,30 +37,6 @@ rules:
   - create
   - get
   - update
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - operator.kyma-project.io
   resources:
@@ -309,4 +261,12 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
   - watch

--- a/main.go
+++ b/main.go
@@ -167,23 +167,18 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:groups=operator.kyma-project.io,resources=telemetries/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=operator.kyma-project.io,resources=telemetries/finalizers,verbs=update
 
-////+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="",namespace=kyma-system,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-////+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",namespace=kyma-system,resources=services,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",namespace=kyma-system,resources=secrets,verbs=create;update;patch;delete
-////+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",namespace=kyma-system,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;
 
-////+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=apps,namespace=kyma-system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-////+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apps,namespace=kyma-system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
-////+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,namespace=kyma-system,resources=replicasets,verbs=get;list;watch
 
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=create;get;update;
 
@@ -298,12 +293,12 @@ func main() {
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
 				&corev1.Secret{}:         {},
-				&appsv1.Deployment{}:     {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kyma-system"})},
-				&appsv1.ReplicaSet{}:     {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kyma-system"})},
-				&appsv1.DaemonSet{}:      {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kyma-system"})},
-				&corev1.ConfigMap{}:      {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kyma-system"})},
-				&corev1.ServiceAccount{}: {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kyma-system"})},
-				&corev1.Service{}:        {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kyma-system"})},
+				&appsv1.Deployment{}:     {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
+				&appsv1.ReplicaSet{}:     {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
+				&appsv1.DaemonSet{}:      {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
+				&corev1.ConfigMap{}:      {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
+				&corev1.ServiceAccount{}: {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
+				&corev1.Service{}:        {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
 			},
 		}),
 	})

--- a/main.go
+++ b/main.go
@@ -293,12 +293,12 @@ func main() {
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
 				&corev1.Secret{}:         {},
-				&appsv1.Deployment{}:     {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
-				&appsv1.ReplicaSet{}:     {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
-				&appsv1.DaemonSet{}:      {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
-				&corev1.ConfigMap{}:      {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
-				&corev1.ServiceAccount{}: {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
-				&corev1.Service{}:        {Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})},
+				&appsv1.Deployment{}:     {Field: setNamespaceFieldSelector()},
+				&appsv1.ReplicaSet{}:     {Field: setNamespaceFieldSelector()},
+				&appsv1.DaemonSet{}:      {Field: setNamespaceFieldSelector()},
+				&corev1.ConfigMap{}:      {Field: setNamespaceFieldSelector()},
+				&corev1.ServiceAccount{}: {Field: setNamespaceFieldSelector()},
+				&corev1.Service{}:        {Field: setNamespaceFieldSelector()},
 			},
 		}),
 	})
@@ -386,6 +386,10 @@ func main() {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
 	}
+}
+
+func setNamespaceFieldSelector() fields.Selector {
+	return fields.SelectorFromSet(fields.Set{"metadata.namespace": telemetryNamespace})
 }
 
 func validateFlags() error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Create new cache which filters resources only from the given namespace. In order to restrict the RBAC for telemetry 
manager. 
- The cache contains resources that are filtered by namespace. Additionally secret resource is not namespace restricted. As we would like read secrets from different namespaces.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17001