### PR TITLE
Set unlimited retries for Fluent Bit http output

### DIFF
--- a/config/samples/http-mockserver.yaml
+++ b/config/samples/http-mockserver.yaml
@@ -26,6 +26,8 @@ spec:
       app: mockserver
   template:
     metadata:
+      annotations:
+        fluentbit.io/exclude: "True"
       labels:
         app: mockserver
       name: mockserver

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -114,6 +114,7 @@ func TestMergeSectionsConfig(t *testing.T) {
     format                   json
     host                     localhost
     port                     443
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on

--- a/internal/fluentbit/config/builder/output.go
+++ b/internal/fluentbit/config/builder/output.go
@@ -52,6 +52,7 @@ func generateHTTPOutput(httpOutput *telemetryv1alpha1.HTTPOutput, fsBufferLimit 
 	sb.AddConfigParam("match", fmt.Sprintf("%s.*", name))
 	sb.AddConfigParam("alias", fmt.Sprintf("%s-http", name))
 	sb.AddConfigParam("storage.total_limit_size", fsBufferLimit)
+	sb.AddConfigParam("retry_limit", "no_limits")
 	sb.AddIfNotEmpty("uri", httpOutput.URI)
 	sb.AddIfNotEmpty("compress", httpOutput.Compress)
 	sb.AddIfNotEmptyOrDefault("port", httpOutput.Port, "443")

--- a/internal/fluentbit/config/builder/output_test.go
+++ b/internal/fluentbit/config/builder/output_test.go
@@ -43,6 +43,7 @@ func TestCreateOutputSectionWithHTTPOutput(t *testing.T) {
     http_passwd              password
     http_user                user
     port                     1234
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on
@@ -83,6 +84,7 @@ func TestCreateOutputSectionWithHTTPOutputWithSecretReference(t *testing.T) {
     http_passwd              ${FOO_MY_NAMESPACE_SECRET_KEY}
     http_user                user
     port                     443
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on

--- a/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
+++ b/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
@@ -44,6 +44,7 @@
     format                   json
     host                     127.0.0.1
     port                     443
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Fluent Bit's default settings make only one retry attempt on a retry-able output error. With our persistent buffer usage, more retries would be beneficial.

Changes proposed in this pull request:

- Set retry_limit to no_limits for Fluent Bit http output
- Do not collect logs from http-mockserver sample

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17113