### PR TITLE
Watch fluentbit daemonset for deletion as well

### DIFF
--- a/controllers/telemetry/logparser_controller.go
+++ b/controllers/telemetry/logparser_controller.go
@@ -18,15 +18,10 @@ limitations under the License.
 
 import (
 	"context"
-	"fmt"
-
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/logparser"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // LogParserReconciler reconciles a Logparser object
@@ -53,25 +48,4 @@ func (r *LogParserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1alpha1.LogParser{}).
 		Complete(r)
-}
-
-func (r *LogParserReconciler) mapDaemonSets(object client.Object) []reconcile.Request {
-	daemonSet := object.(*appsv1.DaemonSet)
-
-	var requests []reconcile.Request
-	if daemonSet.Name != r.config.DaemonSet.Name || daemonSet.Namespace != r.config.DaemonSet.Namespace {
-		return requests
-	}
-
-	var allParsers telemetryv1alpha1.LogParserList
-	if err := r.List(context.Background(), &allParsers); err != nil {
-		ctrl.Log.Error(err, "DamonSet UpdateEvent: fetching LogParserList failed!", err.Error())
-		return requests
-	}
-
-	for _, parser := range allParsers.Items {
-		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: parser.Name}})
-	}
-	ctrl.Log.V(1).Info(fmt.Sprintf("DaemonSet changed event handling done: Created %d new reconciliation requests.\n", len(requests)))
-	return requests
 }

--- a/controllers/telemetry/logparser_controller.go
+++ b/controllers/telemetry/logparser_controller.go
@@ -20,18 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/reconciler/logparser"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
-	"github.com/kyma-project/telemetry-manager/internal/reconciler/logparser"
-	"github.com/kyma-project/telemetry-manager/internal/setup"
 )
 
 // LogParserReconciler reconciles a Logparser object
@@ -57,11 +52,6 @@ func (r *LogParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *LogParserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1alpha1.LogParser{}).
-		Watches(
-			&source.Kind{Type: &appsv1.DaemonSet{}},
-			handler.EnqueueRequestsFromMapFunc(r.mapDaemonSets),
-			builder.WithPredicates(setup.OnlyUpdate()),
-		).
 		Complete(r)
 }
 

--- a/controllers/telemetry/logpipeline_controller.go
+++ b/controllers/telemetry/logpipeline_controller.go
@@ -68,7 +68,7 @@ func (r *LogPipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &appsv1.DaemonSet{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapDaemonSet),
-			builder.WithPredicates(setup.OnlyUpdate()),
+			builder.WithPredicates(setup.DeleteOrUpdate()),
 		).
 		Complete(r)
 }

--- a/internal/setup/predicates.go
+++ b/internal/setup/predicates.go
@@ -5,10 +5,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-func OnlyUpdate() predicate.Predicate {
+func DeleteOrUpdate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return false },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
 		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- We should react if the fluent bit daemonset is deleted. Trigger a reconciler event in case of Fluent bit daemonset deletion so that it could be brought back
- Also logparser should not watch fluent bit daemonset as logpipeline is our main reconciler and this should be responsible for handling the fluent bit daemonset

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
