### PR TITLE
Set unlimited retries for Fluent Bit http output (#94)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ tidy: ## Check if there any dirty change for go mod tidy.
 test: manifests generate fmt vet tidy envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONE: e2e-test
+e2e-test:
+	@echo "Nothing to test on release-2.12 branch"
+
 ##@ Build
 
 .PHONY: build

--- a/config/samples/http-mockserver.yaml
+++ b/config/samples/http-mockserver.yaml
@@ -26,6 +26,8 @@ spec:
       app: mockserver
   template:
     metadata:
+      annotations:
+        fluentbit.io/exclude: "True"
       labels:
         app: mockserver
       name: mockserver

--- a/controller/tracepipeline/controller_test.go
+++ b/controller/tracepipeline/controller_test.go
@@ -89,10 +89,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				}, &serviceAccount); err != nil {
 					return err
 				}
-				if err := validateOwnerReferences(serviceAccount.OwnerReferences); err != nil {
-					return err
-				}
-				return nil
+				return validateOwnerReferences(serviceAccount.OwnerReferences)
 			}, timeout, interval).Should(BeNil())
 
 			Eventually(func() error {
@@ -103,10 +100,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				}, &clusterRole); err != nil {
 					return err
 				}
-				if err := validateOwnerReferences(clusterRole.OwnerReferences); err != nil {
-					return err
-				}
-				return nil
+				return validateOwnerReferences(clusterRole.OwnerReferences)
 			}, timeout, interval).Should(BeNil())
 
 			Eventually(func() error {
@@ -117,10 +111,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				}, &clusterRoleBinding); err != nil {
 					return err
 				}
-				if err := validateOwnerReferences(clusterRoleBinding.OwnerReferences); err != nil {
-					return err
-				}
-				return nil
+				return validateOwnerReferences(clusterRoleBinding.OwnerReferences)
 			}, timeout, interval).Should(BeNil())
 
 			Eventually(func() error {
@@ -137,10 +128,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				if err := validateEnvironment(otelCollectorDeployment); err != nil {
 					return err
 				}
-				if err := validatePodAnnotations(otelCollectorDeployment); err != nil {
-					return err
-				}
-				return nil
+				return validatePodAnnotations(otelCollectorDeployment)
 			}, timeout, interval).Should(BeNil())
 
 			Eventually(func() error {
@@ -151,10 +139,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				}, &otelCollectorService); err != nil {
 					return err
 				}
-				if err := validateOwnerReferences(otelCollectorService.OwnerReferences); err != nil {
-					return err
-				}
-				return nil
+				return validateOwnerReferences(otelCollectorService.OwnerReferences)
 			}, timeout, interval).Should(BeNil())
 
 			Eventually(func() error {
@@ -168,10 +153,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				if err := validateOwnerReferences(otelCollectorConfigMap.OwnerReferences); err != nil {
 					return err
 				}
-				if err := validateCollectorConfig(otelCollectorConfigMap.Data["relay.conf"]); err != nil {
-					return err
-				}
-				return nil
+				return validateCollectorConfig(otelCollectorConfigMap.Data["relay.conf"])
 			}, timeout, interval).Should(BeNil())
 
 			Eventually(func() error {
@@ -182,10 +164,7 @@ var _ = Describe("Deploying a TracePipeline", func() {
 				}, &otelCollectorSecret); err != nil {
 					return err
 				}
-				if err := validateOwnerReferences(otelCollectorSecret.OwnerReferences); err != nil {
-					return err
-				}
-				return nil
+				return validateOwnerReferences(otelCollectorSecret.OwnerReferences)
 			}, timeout, interval).Should(BeNil())
 
 			Expect(k8sClient.Delete(ctx, tracePipeline)).Should(Succeed())

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -114,6 +114,7 @@ func TestMergeSectionsConfig(t *testing.T) {
     format                   json
     host                     localhost
     port                     443
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on

--- a/internal/fluentbit/config/builder/output.go
+++ b/internal/fluentbit/config/builder/output.go
@@ -52,6 +52,7 @@ func generateHTTPOutput(httpOutput *telemetryv1alpha1.HTTPOutput, fsBufferLimit 
 	sb.AddConfigParam("match", fmt.Sprintf("%s.*", name))
 	sb.AddConfigParam("alias", fmt.Sprintf("%s-http", name))
 	sb.AddConfigParam("storage.total_limit_size", fsBufferLimit)
+	sb.AddConfigParam("retry_limit", "no_limits")
 	sb.AddIfNotEmpty("uri", httpOutput.URI)
 	sb.AddIfNotEmpty("compress", httpOutput.Compress)
 	sb.AddIfNotEmptyOrDefault("port", httpOutput.Port, "443")

--- a/internal/fluentbit/config/builder/output_test.go
+++ b/internal/fluentbit/config/builder/output_test.go
@@ -43,6 +43,7 @@ func TestCreateOutputSectionWithHTTPOutput(t *testing.T) {
     http_passwd              password
     http_user                user
     port                     1234
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on
@@ -83,6 +84,7 @@ func TestCreateOutputSectionWithHTTPOutputWithSecretReference(t *testing.T) {
     http_passwd              ${FOO_MY_NAMESPACE_SECRET_KEY}
     http_user                user
     port                     443
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on

--- a/internal/kubernetes/utils.go
+++ b/internal/kubernetes/utils.go
@@ -254,23 +254,23 @@ func mergeChecksumAnnotations(new *metav1.ObjectMeta, old metav1.ObjectMeta) {
 	new.SetAnnotations(mergeMapsByPrefix(new.Annotations, old.Annotations, "checksum/"))
 }
 
-func mergeMapsByPrefix(new map[string]string, old map[string]string, prefix string) map[string]string {
-	if old == nil {
-		old = make(map[string]string)
+func mergeMapsByPrefix(newMap map[string]string, oldMap map[string]string, prefix string) map[string]string {
+	if oldMap == nil {
+		oldMap = make(map[string]string)
 	}
 
-	if new == nil {
-		new = make(map[string]string)
+	if newMap == nil {
+		newMap = make(map[string]string)
 	}
 
-	for k, v := range old {
-		_, hasValue := new[k]
+	for k, v := range oldMap {
+		_, hasValue := newMap[k]
 		if strings.HasPrefix(k, prefix) && !hasValue {
-			new[k] = v
+			newMap[k] = v
 		}
 	}
 
-	return new
+	return newMap
 }
 
 func GetOrCreateConfigMap(ctx context.Context, c client.Client, name types.NamespacedName) (corev1.ConfigMap, error) {

--- a/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
+++ b/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
@@ -44,6 +44,7 @@
     format                   json
     host                     127.0.0.1
     port                     443
+    retry_limit              no_limits
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on

--- a/webhook/logpipeline/validation/variable_validator.go
+++ b/webhook/logpipeline/validation/variable_validator.go
@@ -23,7 +23,7 @@ func NewVariablesValidator(client client.Client) VariablesValidator {
 	}
 }
 
-func (v *variablesValidator) Validate(context context.Context, logPipeline *telemetryv1alpha1.LogPipeline, logPipelines *telemetryv1alpha1.LogPipelineList) error {
+func (v *variablesValidator) Validate(_ context.Context, logPipeline *telemetryv1alpha1.LogPipeline, logPipelines *telemetryv1alpha1.LogPipelineList) error {
 	if len(logPipeline.Spec.Variables) == 0 {
 		return nil
 	}

--- a/webhook/logpipeline/webhook_suite_test.go
+++ b/webhook/logpipeline/webhook_suite_test.go
@@ -138,10 +138,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-		if err := conn.Close(); err != nil {
-			return err
-		}
-		return nil
+		return conn.Close()
 	}).Should(Succeed())
 
 	By("creating the necessary resources")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Include kyma-project/telemetry-manager#94 to increase Fluent Bit retry limit.

Changes proposed in this pull request:

- Set retry_limit to no_limits for Fluent Bit http output
- Do not collect logs from http-mockserver sample
- Add dummy e2e-test make target to make prow happy
- Fix linting errors

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
