### PR TITLE
have manager namespace-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ make undeploy
 
 ### Enable pausing reconciliations
 
-You must pause reconciliations to be able to debug the pipelines and, for example, try out a different pipeline configuration or a different OTel configuration. To pause reconciliations, create a `telemetry-override-config` in the `kyma-system` Namespace.
+You must pause reconciliations to be able to debug the pipelines and, for example, try out a different pipeline configuration or a different OTel configuration. To pause reconciliations, create a `telemetry-override-config` in the operators Namespace.
 Here is an example of such a ConfigMap:
 
 ```yaml
@@ -108,7 +108,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: telemetry-override-config
-  namespace: kyma-system
 data:
   override-config: |
     global:
@@ -131,7 +130,7 @@ The `global`, `tracing`, `logging` and `metrics` fields are optional.
 4. To reset the debug actions, perform a restart of Telemetry Manager.
 
    ```bash
-   kubectl rollout restart deployment -n kyma-system telemetry-controller-manager
+   kubectl rollout restart deployment telemetry-controller-manager
    ```
 
 **Caveats**

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,6 +53,7 @@ spec:
         - --trace-collector-cpu-request=25m
         - --trace-collector-memory-request=32Mi
         - --validating-webhook-enabled=true
+        - --manager-namespace=$(MY_POD_NAMESPACE)
         image: controller:latest
         name: manager
         securityContext:
@@ -81,5 +82,10 @@ spec:
           requests:
             cpu: 5m
             memory: 20Mi
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -191,7 +191,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
-  namespace: kyma-system
+  namespace: system
 rules:
 - apiGroups:
   - ""

--- a/config/samples/telemetry_v1alpha1_tracepipeline_jaeger.yaml
+++ b/config/samples/telemetry_v1alpha1_tracepipeline_jaeger.yaml
@@ -6,4 +6,4 @@ spec:
   output:
     otlp:
       endpoint:
-        value: http://tracing-jaeger-collector.kyma-system.svc.cluster.local:4317
+        value: http://tracing-jaeger-collector.svc.cluster.local:4317

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -16,7 +16,7 @@ webhooks:
     clientConfig:
       service:
         name: telemetry-operator-webhook
-        namespace: kyma-system
+        namespace: system
         path: /validate-logpipeline
         port: 443
     failurePolicy: Fail
@@ -43,7 +43,7 @@ webhooks:
     clientConfig:
       service:
         name: telemetry-operator-webhook
-        namespace: kyma-system
+        namespace: system
         path: /validate-logparser
         port: 443
     failurePolicy: Fail

--- a/controllers/telemetry/metricpipeline_controller_test.go
+++ b/controllers/telemetry/metricpipeline_controller_test.go
@@ -30,8 +30,8 @@ import (
 var (
 	testMetricPipelineConfig = collectorresources.Config{
 		BaseName:          "telemetry-metric-gateway",
-		Namespace:         "kyma-system",
-		OverrideConfigMap: types.NamespacedName{Name: "override-config", Namespace: "kyma-system"},
+		Namespace:         "telemetry-system",
+		OverrideConfigMap: types.NamespacedName{Name: "override-config", Namespace: "telemetry-system"},
 		Deployment: collectorresources.DeploymentConfig{
 			Image:         "otel/opentelemetry-collector-contrib:0.60.0",
 			CPULimit:      resource.MustParse("1"),
@@ -112,7 +112,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var serviceAccount corev1.ServiceAccount
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &serviceAccount); err != nil {
 				return err
 			}
@@ -123,7 +123,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var clusterRole rbacv1.ClusterRole
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &clusterRole); err != nil {
 				return err
 			}
@@ -134,7 +134,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var clusterRoleBinding rbacv1.ClusterRoleBinding
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &clusterRoleBinding); err != nil {
 				return err
 			}
@@ -145,7 +145,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var otelCollectorDeployment appsv1.Deployment
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorDeployment); err != nil {
 				return err
 			}
@@ -162,7 +162,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var otelCollectorService corev1.Service
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-otlp-metrics",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorService); err != nil {
 				return err
 			}
@@ -173,7 +173,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var otelCollectorConfigMap corev1.ConfigMap
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorConfigMap); err != nil {
 				return err
 			}
@@ -187,7 +187,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var otelCollectorSecret corev1.Secret
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorSecret); err != nil {
 				return err
 			}
@@ -198,7 +198,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var otelCollectorSecret corev1.Secret
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorSecret); err != nil {
 				return err
 			}
@@ -228,7 +228,7 @@ var _ = Describe("Deploying a MetricPipeline", Ordered, func() {
 			var otelCollectorSecret corev1.Secret
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-metric-gateway",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorSecret); err != nil {
 				return err
 			}

--- a/controllers/telemetry/suite_test.go
+++ b/controllers/telemetry/suite_test.go
@@ -108,7 +108,7 @@ var _ = BeforeSuite(func() {
 
 	kymaSystemNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kyma-system",
+			Name: "telemetry-system",
 		},
 	}
 	Expect(k8sClient.Create(ctx, kymaSystemNamespace)).Should(Succeed())

--- a/controllers/telemetry/tracepipeline_controller_test.go
+++ b/controllers/telemetry/tracepipeline_controller_test.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	testTracePipelineConfig = collectorresources.Config{
-		Namespace:         "kyma-system",
+		Namespace:         "telemetry-system",
 		BaseName:          "telemetry-trace-collector",
-		OverrideConfigMap: types.NamespacedName{Name: "override-config", Namespace: "kyma-system"},
+		OverrideConfigMap: types.NamespacedName{Name: "override-config", Namespace: "telemetry-system"},
 		Deployment: collectorresources.DeploymentConfig{
 			Image:         "otel/opentelemetry-collector-contrib:0.73.0",
 			CPULimit:      resource.MustParse("1"),
@@ -109,7 +109,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var serviceAccount corev1.ServiceAccount
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &serviceAccount); err != nil {
 				return err
 			}
@@ -120,7 +120,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var clusterRole rbacv1.ClusterRole
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &clusterRole); err != nil {
 				return err
 			}
@@ -131,7 +131,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var clusterRoleBinding rbacv1.ClusterRoleBinding
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &clusterRoleBinding); err != nil {
 				return err
 			}
@@ -142,7 +142,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var otelCollectorDeployment appsv1.Deployment
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorDeployment); err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var otelCollectorService corev1.Service
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-otlp-traces",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorService); err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var otelCollectorConfigMap corev1.ConfigMap
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorConfigMap); err != nil {
 				return err
 			}
@@ -184,7 +184,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var otelCollectorSecret corev1.Secret
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorSecret); err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var otelCollectorSecret corev1.Secret
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorSecret); err != nil {
 				return err
 			}
@@ -226,7 +226,7 @@ var _ = Describe("Deploying a TracePipeline", Ordered, func() {
 			var otelCollectorSecret corev1.Secret
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      "telemetry-trace-collector",
-				Namespace: "kyma-system",
+				Namespace: "telemetry-system",
 			}, &otelCollectorSecret); err != nil {
 				return err
 			}

--- a/internal/kubernetes/configmap_test.go
+++ b/internal/kubernetes/configmap_test.go
@@ -19,12 +19,12 @@ tracing:
   paused: true
 `
 	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "kyma-system"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "telemetry-system"},
 		Data:       map[string]string{"override-config": conf},
 	}
 	fakeClient := fake.NewClientBuilder().WithObjects(configMap).Build()
 	sut := ConfigmapProber{fakeClient}
-	cm, err := sut.ReadConfigMapOrEmpty(context.Background(), types.NamespacedName{Name: "foo", Namespace: "kyma-system"})
+	cm, err := sut.ReadConfigMapOrEmpty(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"})
 	require.NoError(t, err)
 	require.Equal(t, conf, cm)
 }
@@ -32,7 +32,7 @@ tracing:
 func TestConfigMapNotExist(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	sut := ConfigmapProber{fakeClient}
-	cm, err := sut.ReadConfigMapOrEmpty(context.Background(), types.NamespacedName{Name: "foo", Namespace: "kyma-system"})
+	cm, err := sut.ReadConfigMapOrEmpty(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"})
 	require.NoError(t, err)
 	require.Equal(t, "", cm)
 }

--- a/internal/kubernetes/daemonset_test.go
+++ b/internal/kubernetes/daemonset_test.go
@@ -35,7 +35,7 @@ func TestDaemonSetProber(t *testing.T) {
 			t.Parallel()
 
 			daemonSet := &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "kyma-system", Generation: tc.desiredGeneration},
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "telemetry-system", Generation: tc.desiredGeneration},
 				Status: appsv1.DaemonSetStatus{
 					DesiredNumberScheduled: tc.desiredScheduled,
 					NumberReady:            tc.numberReady,
@@ -47,7 +47,7 @@ func TestDaemonSetProber(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithObjects(daemonSet).Build()
 
 			sut := DaemonSetProber{fakeClient}
-			ready, err := sut.IsReady(context.Background(), types.NamespacedName{Name: "foo", Namespace: "kyma-system"})
+			ready, err := sut.IsReady(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"})
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, ready)
@@ -57,18 +57,18 @@ func TestDaemonSetProber(t *testing.T) {
 
 func TestSetAnnotation(t *testing.T) {
 	daemonSet := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "kyma-system"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "telemetry-system"},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithObjects(daemonSet).Build()
 
 	sut := DaemonSetAnnotator{fakeClient}
 
-	err := sut.SetAnnotation(context.Background(), types.NamespacedName{Name: "foo", Namespace: "kyma-system"}, "foo", "bar")
+	err := sut.SetAnnotation(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"}, "foo", "bar")
 	require.NoError(t, err)
 
 	var updatedDaemonSet appsv1.DaemonSet
-	_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "kyma-system"}, &updatedDaemonSet)
+	_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"}, &updatedDaemonSet)
 	require.Len(t, updatedDaemonSet.Spec.Template.Annotations, 1)
 	require.Contains(t, updatedDaemonSet.Spec.Template.Annotations, "foo")
 	require.Equal(t, updatedDaemonSet.Spec.Template.Annotations["foo"], "bar")

--- a/internal/kubernetes/deployment_test.go
+++ b/internal/kubernetes/deployment_test.go
@@ -33,7 +33,7 @@ func TestDeploymentProber_IsReady(t *testing.T) {
 			matchLabels["test.deployment.name"] = "test-deployment"
 
 			deployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "kyma-system"},
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "telemetry-system"},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: &tc.desiredScheduled,
 					Selector: &metav1.LabelSelector{MatchLabels: matchLabels},
@@ -46,7 +46,7 @@ func TestDeploymentProber_IsReady(t *testing.T) {
 			rs := &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
-					Namespace:       "kyma-system",
+					Namespace:       "telemetry-system",
 					Labels:          deployment.Spec.Selector.MatchLabels,
 					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, deployment.GroupVersionKind())},
 				},
@@ -71,7 +71,7 @@ func TestDeploymentProber_IsReady(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithObjects(deployment).WithLists(rsList).Build()
 
 			sut := DeploymentProber{fakeClient}
-			ready, err := sut.IsReady(context.Background(), types.NamespacedName{Name: "foo", Namespace: "kyma-system"})
+			ready, err := sut.IsReady(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"})
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, ready)

--- a/internal/reconciler/logpipeline/sync_test.go
+++ b/internal/reconciler/logpipeline/sync_test.go
@@ -47,7 +47,7 @@ var (
 )
 
 func TestSyncSectionsConfigMap(t *testing.T) {
-	sectionsCmName := types.NamespacedName{Name: "sections", Namespace: "kyma-system"}
+	sectionsCmName := types.NamespacedName{Name: "sections", Namespace: "telemetry-system"}
 	fakeClient := fake.NewClientBuilder().WithObjects(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,7 @@ alias foo`,
 }
 
 func TestSyncFilesConfigMap(t *testing.T) {
-	filesCmName := types.NamespacedName{Name: "files", Namespace: "kyma-system"}
+	filesCmName := types.NamespacedName{Name: "files", Namespace: "telemetry-system"}
 	fakeClient := fake.NewClientBuilder().WithObjects(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -315,7 +315,7 @@ func TestSyncReferencedSecrets(t *testing.T) {
 		}
 		fakeClient := fake.NewClientBuilder().WithObjects(&credsSecret).Build()
 
-		envSecretName := types.NamespacedName{Name: "env", Namespace: "kyma-system"}
+		envSecretName := types.NamespacedName{Name: "env", Namespace: "telemetry-system"}
 		sut := syncer{fakeClient, Config{EnvSecret: envSecretName}}
 		err := sut.syncReferencedSecrets(context.Background(), &allPipelines)
 		require.NoError(t, err)
@@ -337,7 +337,7 @@ func TestSyncReferencedSecrets(t *testing.T) {
 		}
 		fakeClient := fake.NewClientBuilder().WithObjects(&passwordSecret).Build()
 
-		envSecretName := types.NamespacedName{Name: "env", Namespace: "kyma-system"}
+		envSecretName := types.NamespacedName{Name: "env", Namespace: "telemetry-system"}
 		sut := syncer{fakeClient, Config{EnvSecret: envSecretName}}
 		err := sut.syncReferencedSecrets(context.Background(), &allPipelines)
 		require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestSyncReferencedSecrets(t *testing.T) {
 		}
 		fakeClient := fake.NewClientBuilder().WithObjects(&passwordSecret).Build()
 
-		envSecretName := types.NamespacedName{Name: "env", Namespace: "kyma-system"}
+		envSecretName := types.NamespacedName{Name: "env", Namespace: "telemetry-system"}
 		sut := syncer{fakeClient, Config{EnvSecret: envSecretName}}
 		err := sut.syncReferencedSecrets(context.Background(), &allPipelines)
 		require.NoError(t, err)

--- a/internal/resources/common/resources_test.go
+++ b/internal/resources/common/resources_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMakeServiceAccount(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	svcAcc := MakeServiceAccount(name)
 
 	require.NotNil(t, svcAcc)
@@ -18,7 +18,7 @@ func TestMakeServiceAccount(t *testing.T) {
 }
 
 func TestMakeClusterRole(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	clusterRole := MakeClusterRole(name)
 	expectedRules := []v1.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"namespaces", "pods"}}}
 
@@ -28,7 +28,7 @@ func TestMakeClusterRole(t *testing.T) {
 }
 
 func TestMakeClusterRoleBinding(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	clusterRoleBinding := MakeClusterRoleBinding(name)
 	svcAcc := MakeServiceAccount(name)
 	clusterRole := MakeClusterRole(name)

--- a/internal/resources/fluentbit/resources_test.go
+++ b/internal/resources/fluentbit/resources_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMakeDaemonSet(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	checksum := "foo"
 	ds := DaemonSetConfig{
 		FluentBitImage:              "foo-fluenbit",
@@ -70,7 +70,7 @@ func TestMakeDaemonSet(t *testing.T) {
 }
 
 func TestMakeMetricsService(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	service := MakeMetricsService(name)
 
 	require.NotNil(t, service)
@@ -90,7 +90,7 @@ func TestMakeMetricsService(t *testing.T) {
 }
 
 func TestMakeExporterMetricsService(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	service := MakeExporterMetricsService(name)
 
 	require.NotNil(t, service)
@@ -109,7 +109,7 @@ func TestMakeExporterMetricsService(t *testing.T) {
 }
 
 func TestMakeConfigMap(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	cm := MakeConfigMap(name)
 
 	require.NotNil(t, cm)
@@ -121,7 +121,7 @@ func TestMakeConfigMap(t *testing.T) {
 }
 
 func TestMakeLuaConfigMap(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "kyma-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	cm := MakeLuaConfigMap(name)
 
 	require.NotNil(t, cm)

--- a/internal/resources/otelcollector/resources_test.go
+++ b/internal/resources/otelcollector/resources_test.go
@@ -13,7 +13,7 @@ import (
 var (
 	config = Config{
 		BaseName:  "collector",
-		Namespace: "kyma-system",
+		Namespace: "telemetry-system",
 		Service: ServiceConfig{
 			OTLPServiceName: "collector-traces",
 		},

--- a/internal/setup/webhook_test.go
+++ b/internal/setup/webhook_test.go
@@ -15,7 +15,7 @@ import (
 var (
 	webhookService = types.NamespacedName{
 		Name:      "telemetry-operator-webhook",
-		Namespace: "kyma-system",
+		Namespace: "telemetry-system",
 	}
 	name   = "validation.webhook.telemetry.kyma-project.io"
 	labels = map[string]string{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- inject namespace of the manager via comman arg
- refactored tests to use a dummy namespace
- changed rbac files to use dummy system namespace which gets overriden by kusomization

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17195