### PR TITLE
Clean up unused dependencies before image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.2 as builder
+FROM golang:1.20.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,8 +16,8 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 COPY webhook/ webhook/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# Clean up unused (test) dependencies and build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go mod tidy && go build -a -o manager main.go
 
 # Use the fluent-bit image because we need the fluent-bit binary
 FROM eu.gcr.io/kyma-project/tpi/fluent-bit:2.0.10-050eef31

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/telemetry-manager
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/zapr v1.2.3


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Since we use one Go module for the operator code and end-to-end tests, many dependencies are unused by the operator itself. This PR adds a `go mod tidy` before building the operator to ensure test dependencies never make it into production.

Changes proposed in this pull request:

- Run go mod tidy before build
- Bump Golang to 1.20.3
- Bump Golang to 1.20 in module

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
