### PR TITLE
Enhance pipeline lock mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ K3D ?= $(LOCALBIN)/k3d
 KUSTOMIZE_VERSION ?= v5.0.1
 CONTROLLER_TOOLS_VERSION ?= v0.11.3
 K3D_VERSION ?= v5.4.7
-GINKGO_VERSION ?= v2.9.1
+GINKGO_VERSION ?= v2.9.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/internal/kubernetes/lock.go
+++ b/internal/kubernetes/lock.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var errLogInUse = errors.New("lock is already acquired by other resources")
+var errLockInUse = errors.New("lock is already acquired by other resources")
 
 type ResourceCountLock struct {
 	client    client.Client
@@ -55,7 +55,7 @@ func (l *ResourceCountLock) TryAcquireLock(ctx context.Context, owner metav1.Obj
 		return nil
 	}
 
-	return errLogInUse
+	return errLockInUse
 }
 
 func (l *ResourceCountLock) createLock(ctx context.Context, owner metav1.Object) error {

--- a/internal/kubernetes/lock_test.go
+++ b/internal/kubernetes/lock_test.go
@@ -47,5 +47,5 @@ func TestTryAcquireLock(t *testing.T) {
 	require.NoError(t, err)
 
 	err = l.TryAcquireLock(ctx, owner3)
-	require.Equal(t, errLogInUse, err)
+	require.Equal(t, errLockInUse, err)
 }

--- a/internal/kubernetes/lock_test.go
+++ b/internal/kubernetes/lock_test.go
@@ -1,0 +1,51 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestTryAcquireLock(t *testing.T) {
+	owner1 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner1",
+			Namespace: "default",
+		},
+	}
+	owner2 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner2",
+			Namespace: "default",
+		},
+	}
+	owner3 := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owner3",
+			Namespace: "default",
+		},
+	}
+
+	lockName := types.NamespacedName{
+		Name:      "lock",
+		Namespace: "default",
+	}
+
+	ctx := context.Background()
+	fakeClient := fake.NewClientBuilder().Build()
+	l := NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, owner1)
+	require.NoError(t, err)
+
+	err = l.TryAcquireLock(ctx, owner2)
+	require.NoError(t, err)
+
+	err = l.TryAcquireLock(ctx, owner3)
+	require.Equal(t, errLogInUse, err)
+}

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -84,7 +84,8 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 		Name:      "telemetry-metricpipeline-lock",
 		Namespace: r.config.Namespace,
 	}
-	if err = kubernetes.TryAcquireLock(ctx, r.Client, lockName, pipeline); err != nil {
+	lock := kubernetes.NewResourceCountLock(r.Client, lockName, r.config.MaxPipelines)
+	if err = lock.TryAcquireLock(ctx, pipeline); err != nil {
 		lockAcquired = false
 		return err
 	}

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -100,7 +100,8 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 		Name:      "telemetry-tracepipeline-lock",
 		Namespace: r.config.Namespace,
 	}
-	if err = kubernetes.TryAcquireLock(ctx, r.Client, lockName, pipeline); err != nil {
+	lock := kubernetes.NewResourceCountLock(r.Client, lockName, r.config.MaxPipelines)
+	if err = lock.TryAcquireLock(ctx, pipeline); err != nil {
 		lockAcquired = false
 		return err
 	}

--- a/internal/resources/otelcollector/resources.go
+++ b/internal/resources/otelcollector/resources.go
@@ -19,9 +19,10 @@ type Config struct {
 	Namespace         string
 	OverrideConfigMap types.NamespacedName
 
-	Deployment DeploymentConfig
-	Service    ServiceConfig
-	Overrides  overrides.Config
+	Deployment   DeploymentConfig
+	Service      ServiceConfig
+	Overrides    overrides.Config
+	MaxPipelines int
 }
 
 type DeploymentConfig struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Enhance pipeline lock mechanism to support limiting the number of TracePipelines and MetricPipelines to a number that is larger than one. The enhanced lock implementation uses the owner list to identify the current lock holders.

Changes proposed in this pull request:

- Support limiting the pipeline count to a number larger than 1

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17223