### PR TITLE
Prepare owner references to support multiple pipelines

### DIFF
--- a/controllers/telemetry/metricpipeline_controller.go
+++ b/controllers/telemetry/metricpipeline_controller.go
@@ -56,12 +56,29 @@ func (r *MetricPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MetricPipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We use `Watches` instead of `Owns` to trigger a reconciliation also when owned objects without the controller flag are changed.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1alpha1.MetricPipeline{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.Service{}).
+		Watches(
+			&source.Kind{Type: &corev1.ConfigMap{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.MetricPipeline{},
+				IsController: false}).
+		Watches(
+			&source.Kind{Type: &appsv1.Deployment{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.MetricPipeline{},
+				IsController: false}).
+		Watches(
+			&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.MetricPipeline{},
+				IsController: false}).
+		Watches(
+			&source.Kind{Type: &corev1.Service{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.MetricPipeline{},
+				IsController: false}).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapSecret),

--- a/controllers/telemetry/tracepipeline_controller.go
+++ b/controllers/telemetry/tracepipeline_controller.go
@@ -54,12 +54,29 @@ func (r *TracePipelineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func (r *TracePipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We use `Watches` instead of `Owns` to trigger a reconciliation also when owned objects without the controller flag are changed.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1alpha1.TracePipeline{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&corev1.Secret{}).
-		Owns(&corev1.Service{}).
+		Watches(
+			&source.Kind{Type: &corev1.ConfigMap{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.TracePipeline{},
+				IsController: false}).
+		Watches(
+			&source.Kind{Type: &appsv1.Deployment{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.TracePipeline{},
+				IsController: false}).
+		Watches(
+			&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.TracePipeline{},
+				IsController: false}).
+		Watches(
+			&source.Kind{Type: &corev1.Service{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.TracePipeline{},
+				IsController: false}).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.mapSecret),

--- a/internal/kubernetes/utils_test.go
+++ b/internal/kubernetes/utils_test.go
@@ -161,3 +161,42 @@ func TestMergeChecksumAnnotations(t *testing.T) {
 	require.Equal(t, desired.Annotations["checksum/3"], "3")
 	require.Equal(t, desired.Annotations["checksum/4"], "4")
 }
+
+func TestMergeOwnerReference(t *testing.T) {
+	oldOwners := []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "old-deployment-1",
+			UID:        "old-deployment-uid-1",
+			Controller: &[]bool{true}[0],
+		},
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "old-deployment-2",
+			UID:        "old-deployment-uid-2",
+			Controller: &[]bool{false}[0],
+		},
+	}
+	newOwners := []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "new-deployment-1",
+			UID:        "new-deployment-uid-1",
+			Controller: &[]bool{true}[0],
+		},
+	}
+
+	merged := mergeOwnerReferences(newOwners, oldOwners)
+	require.Equal(t, 3, len(merged))
+
+	numControllers := 0
+	for _, owner := range merged {
+		if *owner.Controller {
+			numControllers++
+		}
+	}
+	require.Equal(t, 1, numControllers)
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Merge owner references when updating Kubernetes resources
- Replace `Ownes` by `Watches` during controller setup to reconcile also owners without controller flag

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17232