### PR TITLE
Enable unlimited retries in LogPipelines with custom output

### DIFF
--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -100,6 +100,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
     name                     stdout
     match                    log-pipeline.*
     alias                    log-pipeline-stdout
+    retry_limit              no_limits
     storage.total_limit_size 1G`
 
 	var expectedSecret = make(map[string][]byte)

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -184,6 +184,7 @@ func TestMergeSectionsConfigCustomOutput(t *testing.T) {
     name                     stdout
     match                    foo.*
     alias                    foo-stdout
+    retry_limit              no_limits
     storage.total_limit_size 1G
 
 `

--- a/internal/fluentbit/config/builder/output.go
+++ b/internal/fluentbit/config/builder/output.go
@@ -42,6 +42,7 @@ func generateCustomOutput(output *telemetryv1alpha1.Output, fsBufferLimit string
 	}
 	sb.AddConfigParam("match", fmt.Sprintf("%s.*", name))
 	sb.AddConfigParam("storage.total_limit_size", fsBufferLimit)
+	sb.AddConfigParam("retry_limit", "no_limits")
 	return sb.Build()
 }
 

--- a/internal/fluentbit/config/builder/output_test.go
+++ b/internal/fluentbit/config/builder/output_test.go
@@ -13,6 +13,7 @@ func TestCreateOutputSectionWithCustomOutput(t *testing.T) {
     name                     null
     match                    foo.*
     alias                    foo-null
+    retry_limit              no_limits
     storage.total_limit_size 1G
 
 `


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

PR #94 set the retry limit for the Fluent Bit HTTP output to unlimited to properly utilize the file system storage. Since the custom output also enforces a file system storage configuration, this PR adds the same retry behaviour to a custom output.

Changes proposed in this pull request:

- Enable unlimited retries in LogPipelines with custom output

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17113