### PR TITLE
Add aliases to otel exporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20230329-e1d53cad
+IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20230421-c40cd7f7
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: v20230329-e1d53cad
+  newTag: v20230421-c40cd7f7

--- a/controllers/telemetry/otel_test_helpers.go
+++ b/controllers/telemetry/otel_test_helpers.go
@@ -36,17 +36,7 @@ func validateCollectorConfig(configData string) error {
 		return fmt.Errorf("otlp exporter not found")
 	}
 
-	tlsConfig, found := otlpExporterConfig.(map[string]any)["tls"]
-	if !found {
-		return fmt.Errorf("tls config not found")
-	}
-
-	insecure, found := tlsConfig.(map[string]any)["insecure"]
-	if !found {
-		return fmt.Errorf("insecure flag not found")
-	}
-
-	if !insecure.(bool) {
+	if !otlpExporterConfig.TLS.Insecure {
 		return fmt.Errorf("insecure flag not set")
 	}
 

--- a/controllers/telemetry/otel_test_helpers.go
+++ b/controllers/telemetry/otel_test_helpers.go
@@ -26,12 +26,27 @@ func validatePodAnnotations(deployment appsv1.Deployment) error {
 }
 
 func validateCollectorConfig(configData string) error {
-	var config config.Config
-	if err := yaml.Unmarshal([]byte(configData), &config); err != nil {
+	var collectorConfig config.Config
+	if err := yaml.Unmarshal([]byte(configData), &collectorConfig); err != nil {
 		return err
 	}
 
-	if !config.Exporters.OTLP.TLS.Insecure {
+	otlpExporterConfig, found := collectorConfig.Exporters["otlp/dummy"]
+	if !found {
+		return fmt.Errorf("otlp exporter not found")
+	}
+
+	tlsConfig, found := otlpExporterConfig.(map[string]any)["tls"]
+	if !found {
+		return fmt.Errorf("tls config not found")
+	}
+
+	insecure, found := tlsConfig.(map[string]any)["insecure"]
+	if !found {
+		return fmt.Errorf("insecure flag not found")
+	}
+
+	if !insecure.(bool) {
 		return fmt.Errorf("insecure flag not set")
 	}
 

--- a/internal/otelcollector/config/builder/config_builder.go
+++ b/internal/otelcollector/config/builder/config_builder.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +34,9 @@ func GetExporterAliases(exporters map[string]any) []string {
 	for alias := range exporters {
 		aliases = append(aliases, alias)
 	}
+
+	// Sort to ensure deterministic order
+	sort.Strings(aliases)
 	return aliases
 }
 

--- a/internal/otelcollector/config/builder/config_builder.go
+++ b/internal/otelcollector/config/builder/config_builder.go
@@ -29,7 +29,7 @@ func getLoggingOutputAlias(pipelineName string) string {
 	return fmt.Sprintf("logging/%s", pipelineName)
 }
 
-func GetExporterAliases(exporters map[string]any) []string {
+func GetExporterAliases(exporters map[string]config.ExporterConfig) []string {
 	var aliases []string
 	for alias := range exporters {
 		aliases = append(aliases, alias)
@@ -40,7 +40,7 @@ func GetExporterAliases(exporters map[string]any) []string {
 	return aliases
 }
 
-func MakeOTLPExporterConfig(ctx context.Context, c client.Reader, otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string) (map[string]any, EnvVars, error) {
+func MakeOTLPExporterConfig(ctx context.Context, c client.Reader, otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string) (map[string]config.ExporterConfig, EnvVars, error) {
 	envVars, err := makeEnvVars(ctx, c, otlpOutput)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to make env vars: %v", err)
@@ -50,7 +50,7 @@ func MakeOTLPExporterConfig(ctx context.Context, c client.Reader, otlpOutput *te
 	return config, envVars, nil
 }
 
-func makeExporterConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string, secretData map[string][]byte) map[string]any {
+func makeExporterConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string, secretData map[string][]byte) map[string]config.ExporterConfig {
 	otlpOutputAlias := getOTLPOutputAlias(otlpOutput, pipelineName)
 	loggingOutputAlias := getLoggingOutputAlias(pipelineName)
 	headers := makeHeaders(otlpOutput)
@@ -76,9 +76,9 @@ func makeExporterConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName s
 		Verbosity: "basic",
 	}
 
-	return map[string]any{
-		otlpOutputAlias:    otlpExporterConfig,
-		loggingOutputAlias: loggingExporter,
+	return map[string]config.ExporterConfig{
+		otlpOutputAlias:    {OTLPExporterConfig: &otlpExporterConfig},
+		loggingOutputAlias: {LoggingExporterConfig: &loggingExporter},
 	}
 }
 

--- a/internal/otelcollector/config/builder/config_builder.go
+++ b/internal/otelcollector/config/builder/config_builder.go
@@ -29,7 +29,7 @@ func getLoggingOutputAlias(pipelineName string) string {
 	return fmt.Sprintf("logging/%s", pipelineName)
 }
 
-func GetExporterAliases(exporters map[string]config.ExporterConfig) []string {
+func GetExporterAliases(exporters config.ExportersConfig) []string {
 	var aliases []string
 	for alias := range exporters {
 		aliases = append(aliases, alias)
@@ -40,17 +40,17 @@ func GetExporterAliases(exporters map[string]config.ExporterConfig) []string {
 	return aliases
 }
 
-func MakeOTLPExporterConfig(ctx context.Context, c client.Reader, otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string) (map[string]config.ExporterConfig, EnvVars, error) {
+func MakeOTLPExportersConfig(ctx context.Context, c client.Reader, otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string) (config.ExportersConfig, EnvVars, error) {
 	envVars, err := makeEnvVars(ctx, c, otlpOutput)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to make env vars: %v", err)
 	}
 
-	config := makeExporterConfig(otlpOutput, pipelineName, envVars)
-	return config, envVars, nil
+	exportersConfig := makeExportersConfig(otlpOutput, pipelineName, envVars)
+	return exportersConfig, envVars, nil
 }
 
-func makeExporterConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string, secretData map[string][]byte) map[string]config.ExporterConfig {
+func makeExportersConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName string, secretData map[string][]byte) config.ExportersConfig {
 	otlpOutputAlias := getOTLPOutputAlias(otlpOutput, pipelineName)
 	loggingOutputAlias := getLoggingOutputAlias(pipelineName)
 	headers := makeHeaders(otlpOutput)
@@ -76,7 +76,7 @@ func makeExporterConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName s
 		Verbosity: "basic",
 	}
 
-	return map[string]config.ExporterConfig{
+	return config.ExportersConfig{
 		otlpOutputAlias:    {OTLPExporterConfig: &otlpExporterConfig},
 		loggingOutputAlias: {LoggingExporterConfig: &loggingExporter},
 	}
@@ -98,7 +98,7 @@ func isInsecureOutput(endpoint string) bool {
 	return len(strings.TrimSpace(endpoint)) > 0 && strings.HasPrefix(endpoint, "http://")
 }
 
-func MakeExtensionConfig() config.ExtensionsConfig {
+func MakeExtensionsConfig() config.ExtensionsConfig {
 	return config.ExtensionsConfig{
 		HealthCheck: config.EndpointConfig{
 			Endpoint: "${MY_POD_IP}:13133",

--- a/internal/otelcollector/config/builder/config_builder_test.go
+++ b/internal/otelcollector/config/builder/config_builder_test.go
@@ -51,7 +51,7 @@ func TestMakeExporterConfig(t *testing.T) {
 	require.Equal(t, envVars["OTLP_ENDPOINT"], []byte("otlp-endpoint"))
 
 	require.Contains(t, exporterConfig, "otlp/test")
-	otlpExporterConfig := exporterConfig["otlp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := exporterConfig["otlp/test"]
 
 	require.Equal(t, "${OTLP_ENDPOINT}", otlpExporterConfig.Endpoint)
 	require.True(t, otlpExporterConfig.SendingQueue.Enabled)
@@ -63,7 +63,7 @@ func TestMakeExporterConfig(t *testing.T) {
 	require.Equal(t, "300s", otlpExporterConfig.RetryOnFailure.MaxElapsedTime)
 
 	require.Contains(t, exporterConfig, "logging/test")
-	loggingExporterConfig := exporterConfig["logging/test"].(config.LoggingExporterConfig)
+	loggingExporterConfig := exporterConfig["logging/test"]
 
 	require.Equal(t, "basic", loggingExporterConfig.Verbosity)
 }
@@ -88,7 +88,7 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 	require.NotNil(t, envVars)
 
 	require.Contains(t, exporterConfig, "otlp/test")
-	otlpExporterConfig := exporterConfig["otlp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := exporterConfig["otlp/test"]
 	require.Equal(t, 1, len(otlpExporterConfig.Headers))
 	require.Equal(t, "${HEADER_AUTHORIZATION}", otlpExporterConfig.Headers["Authorization"])
 }

--- a/internal/otelcollector/config/builder/config_builder_test.go
+++ b/internal/otelcollector/config/builder/config_builder_test.go
@@ -17,7 +17,7 @@ func TestGetOutputTypeHttp(t *testing.T) {
 		Protocol: "http",
 	}
 
-	require.Equal(t, "otlphttp", GetOutputType(output))
+	require.Equal(t, "otlphttp/test", GetOutputAlias(output, "test"))
 }
 
 func TestGetOutputTypeOtlp(t *testing.T) {
@@ -26,7 +26,7 @@ func TestGetOutputTypeOtlp(t *testing.T) {
 		Protocol: "grpc",
 	}
 
-	require.Equal(t, "otlp", GetOutputType(output))
+	require.Equal(t, "otlp/test", GetOutputAlias(output, "test"))
 }
 
 func TestGetOutputTypeDefault(t *testing.T) {
@@ -34,7 +34,7 @@ func TestGetOutputTypeDefault(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	require.Equal(t, "otlp", GetOutputType(output))
+	require.Equal(t, "otlp/test", GetOutputAlias(output, "test"))
 }
 
 func TestMakeExporterConfig(t *testing.T) {
@@ -42,7 +42,7 @@ func TestMakeExporterConfig(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	exporterConfig, envVars, err := MakeOTLPExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output)
+	exporterConfig, envVars, err := MakeOTLPExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test")
 	require.NoError(t, err)
 	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
@@ -50,16 +50,22 @@ func TestMakeExporterConfig(t *testing.T) {
 	require.NotNil(t, envVars["OTLP_ENDPOINT"])
 	require.Equal(t, envVars["OTLP_ENDPOINT"], []byte("otlp-endpoint"))
 
-	require.Equal(t, "${OTLP_ENDPOINT}", exporterConfig.OTLP.Endpoint)
-	require.True(t, exporterConfig.OTLP.SendingQueue.Enabled)
-	require.Equal(t, 512, exporterConfig.OTLP.SendingQueue.QueueSize)
+	require.Contains(t, exporterConfig, "otlp/test")
+	otlpExporterConfig := exporterConfig["otlp/test"].(config.OTLPExporterConfig)
 
-	require.True(t, exporterConfig.OTLP.RetryOnFailure.Enabled)
-	require.Equal(t, "5s", exporterConfig.OTLP.RetryOnFailure.InitialInterval)
-	require.Equal(t, "30s", exporterConfig.OTLP.RetryOnFailure.MaxInterval)
-	require.Equal(t, "300s", exporterConfig.OTLP.RetryOnFailure.MaxElapsedTime)
+	require.Equal(t, "${OTLP_ENDPOINT}", otlpExporterConfig.Endpoint)
+	require.True(t, otlpExporterConfig.SendingQueue.Enabled)
+	require.Equal(t, 512, otlpExporterConfig.SendingQueue.QueueSize)
 
-	require.Equal(t, "basic", exporterConfig.Logging.Verbosity)
+	require.True(t, otlpExporterConfig.RetryOnFailure.Enabled)
+	require.Equal(t, "5s", otlpExporterConfig.RetryOnFailure.InitialInterval)
+	require.Equal(t, "30s", otlpExporterConfig.RetryOnFailure.MaxInterval)
+	require.Equal(t, "300s", otlpExporterConfig.RetryOnFailure.MaxElapsedTime)
+
+	require.Contains(t, exporterConfig, "logging")
+	loggingExporterConfig := exporterConfig["logging"].(config.LoggingExporterConfig)
+
+	require.Equal(t, "basic", loggingExporterConfig.Verbosity)
 }
 
 func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
@@ -76,13 +82,15 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 		Headers:  headers,
 	}
 
-	exporterConfig, envVars, err := MakeOTLPExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output)
+	exporterConfig, envVars, err := MakeOTLPExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test")
 	require.NoError(t, err)
 	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
 
-	require.Equal(t, 1, len(exporterConfig.OTLP.Headers))
-	require.Equal(t, "${HEADER_AUTHORIZATION}", exporterConfig.OTLP.Headers["Authorization"])
+	require.Contains(t, exporterConfig, "otlp/test")
+	otlpExporterConfig := exporterConfig["otlp/test"].(config.OTLPExporterConfig)
+	require.Equal(t, 1, len(otlpExporterConfig.Headers))
+	require.Equal(t, "${HEADER_AUTHORIZATION}", otlpExporterConfig.Headers["Authorization"])
 }
 
 func TestMakeExtensionConfig(t *testing.T) {

--- a/internal/otelcollector/config/builder/config_builder_test.go
+++ b/internal/otelcollector/config/builder/config_builder_test.go
@@ -17,7 +17,7 @@ func TestGetOutputTypeHttp(t *testing.T) {
 		Protocol: "http",
 	}
 
-	require.Equal(t, "otlphttp/test", GetOutputAlias(output, "test"))
+	require.Equal(t, "otlphttp/test", getOTLPOutputAlias(output, "test"))
 }
 
 func TestGetOutputTypeOtlp(t *testing.T) {
@@ -26,7 +26,7 @@ func TestGetOutputTypeOtlp(t *testing.T) {
 		Protocol: "grpc",
 	}
 
-	require.Equal(t, "otlp/test", GetOutputAlias(output, "test"))
+	require.Equal(t, "otlp/test", getOTLPOutputAlias(output, "test"))
 }
 
 func TestGetOutputTypeDefault(t *testing.T) {
@@ -34,7 +34,7 @@ func TestGetOutputTypeDefault(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	require.Equal(t, "otlp/test", GetOutputAlias(output, "test"))
+	require.Equal(t, "otlp/test", getOTLPOutputAlias(output, "test"))
 }
 
 func TestMakeExporterConfig(t *testing.T) {
@@ -62,8 +62,8 @@ func TestMakeExporterConfig(t *testing.T) {
 	require.Equal(t, "30s", otlpExporterConfig.RetryOnFailure.MaxInterval)
 	require.Equal(t, "300s", otlpExporterConfig.RetryOnFailure.MaxElapsedTime)
 
-	require.Contains(t, exporterConfig, "logging")
-	loggingExporterConfig := exporterConfig["logging"].(config.LoggingExporterConfig)
+	require.Contains(t, exporterConfig, "logging/test")
+	loggingExporterConfig := exporterConfig["logging/test"].(config.LoggingExporterConfig)
 
 	require.Equal(t, "basic", loggingExporterConfig.Verbosity)
 }

--- a/internal/otelcollector/config/builder/config_builder_test.go
+++ b/internal/otelcollector/config/builder/config_builder_test.go
@@ -42,7 +42,7 @@ func TestMakeExporterConfig(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	exporterConfig, envVars, err := MakeOTLPExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test")
+	exporterConfig, envVars, err := MakeOTLPExportersConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test")
 	require.NoError(t, err)
 	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
@@ -82,7 +82,7 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 		Headers:  headers,
 	}
 
-	exporterConfig, envVars, err := MakeOTLPExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test")
+	exporterConfig, envVars, err := MakeOTLPExportersConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test")
 	require.NoError(t, err)
 	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
@@ -100,6 +100,6 @@ func TestMakeExtensionConfig(t *testing.T) {
 		},
 	}
 
-	actualConfig := MakeExtensionConfig()
+	actualConfig := MakeExtensionsConfig()
 	require.Equal(t, expectedConfig, actualConfig)
 }

--- a/internal/otelcollector/config/config.go
+++ b/internal/otelcollector/config/config.go
@@ -28,12 +28,6 @@ type LoggingExporterConfig struct {
 	Verbosity string `yaml:"verbosity"`
 }
 
-type ExporterConfig struct {
-	OTLP     OTLPExporterConfig    `yaml:"otlp,omitempty"`
-	OTLPHTTP OTLPExporterConfig    `yaml:"otlphttp,omitempty"`
-	Logging  LoggingExporterConfig `yaml:"logging,omitempty"`
-}
-
 type EndpointConfig struct {
 	Endpoint string `yaml:"endpoint,omitempty"`
 }
@@ -116,11 +110,6 @@ type PipelineConfig struct {
 	Exporters  []string `yaml:"exporters"`
 }
 
-type PipelinesConfig struct {
-	Traces  *PipelineConfig `yaml:"traces,omitempty"`
-	Metrics *PipelineConfig `yaml:"metrics,omitempty"`
-}
-
 type MetricsConfig struct {
 	Address string `yaml:"address"`
 }
@@ -135,9 +124,9 @@ type TelemetryConfig struct {
 }
 
 type OTLPServiceConfig struct {
-	Pipelines  PipelinesConfig `yaml:"pipelines,omitempty"`
-	Telemetry  TelemetryConfig `yaml:"telemetry,omitempty"`
-	Extensions []string        `yaml:"extensions,omitempty"`
+	Pipelines  map[string]PipelineConfig `yaml:"pipelines,omitempty"`
+	Telemetry  TelemetryConfig           `yaml:"telemetry,omitempty"`
+	Extensions []string                  `yaml:"extensions,omitempty"`
 }
 
 type ExtensionsConfig struct {
@@ -146,7 +135,7 @@ type ExtensionsConfig struct {
 
 type Config struct {
 	Receivers  ReceiverConfig    `yaml:"receivers"`
-	Exporters  ExporterConfig    `yaml:"exporters"`
+	Exporters  map[string]any    `yaml:"exporters"`
 	Processors ProcessorsConfig  `yaml:"processors"`
 	Extensions ExtensionsConfig  `yaml:"extensions"`
 	Service    OTLPServiceConfig `yaml:"service"`

--- a/internal/otelcollector/config/config.go
+++ b/internal/otelcollector/config/config.go
@@ -16,6 +16,8 @@ type RetryOnFailureConfig struct {
 	MaxElapsedTime  string `yaml:"max_elapsed_time"`
 }
 
+type ExportersConfig map[string]ExporterConfig
+
 type ExporterConfig struct {
 	*OTLPExporterConfig    `yaml:",inline,omitempty"`
 	*LoggingExporterConfig `yaml:",inline,omitempty"`
@@ -46,7 +48,7 @@ type OTLPReceiverConfig struct {
 	Protocols ReceiverProtocols `yaml:"protocols,omitempty"`
 }
 
-type ReceiverConfig struct {
+type ReceiversConfig struct {
 	OpenCensus *EndpointConfig     `yaml:"opencensus,omitempty"`
 	OTLP       *OTLPReceiverConfig `yaml:"otlp,omitempty"`
 }
@@ -128,7 +130,7 @@ type TelemetryConfig struct {
 	Logs    LoggingConfig `yaml:"logs"`
 }
 
-type OTLPServiceConfig struct {
+type ServiceConfig struct {
 	Pipelines  map[string]PipelineConfig `yaml:"pipelines,omitempty"`
 	Telemetry  TelemetryConfig           `yaml:"telemetry,omitempty"`
 	Extensions []string                  `yaml:"extensions,omitempty"`
@@ -139,9 +141,9 @@ type ExtensionsConfig struct {
 }
 
 type Config struct {
-	Receivers  ReceiverConfig            `yaml:"receivers"`
-	Exporters  map[string]ExporterConfig `yaml:"exporters"`
-	Processors ProcessorsConfig          `yaml:"processors"`
-	Extensions ExtensionsConfig          `yaml:"extensions"`
-	Service    OTLPServiceConfig         `yaml:"service"`
+	Receivers  ReceiversConfig  `yaml:"receivers"`
+	Exporters  ExportersConfig  `yaml:"exporters"`
+	Processors ProcessorsConfig `yaml:"processors"`
+	Extensions ExtensionsConfig `yaml:"extensions"`
+	Service    ServiceConfig    `yaml:"service"`
 }

--- a/internal/otelcollector/config/config.go
+++ b/internal/otelcollector/config/config.go
@@ -16,6 +16,11 @@ type RetryOnFailureConfig struct {
 	MaxElapsedTime  string `yaml:"max_elapsed_time"`
 }
 
+type ExporterConfig struct {
+	*OTLPExporterConfig    `yaml:",inline,omitempty"`
+	*LoggingExporterConfig `yaml:",inline,omitempty"`
+}
+
 type OTLPExporterConfig struct {
 	Endpoint       string               `yaml:"endpoint,omitempty"`
 	Headers        map[string]string    `yaml:"headers,omitempty"`
@@ -134,9 +139,9 @@ type ExtensionsConfig struct {
 }
 
 type Config struct {
-	Receivers  ReceiverConfig    `yaml:"receivers"`
-	Exporters  map[string]any    `yaml:"exporters"`
-	Processors ProcessorsConfig  `yaml:"processors"`
-	Extensions ExtensionsConfig  `yaml:"extensions"`
-	Service    OTLPServiceConfig `yaml:"service"`
+	Receivers  ReceiverConfig            `yaml:"receivers"`
+	Exporters  map[string]ExporterConfig `yaml:"exporters"`
+	Processors ProcessorsConfig          `yaml:"processors"`
+	Extensions ExtensionsConfig          `yaml:"extensions"`
+	Service    OTLPServiceConfig         `yaml:"service"`
 }

--- a/internal/reconciler/metricpipeline/config_builder.go
+++ b/internal/reconciler/metricpipeline/config_builder.go
@@ -13,16 +13,16 @@ import (
 
 func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1alpha1.MetricPipeline) (*config.Config, configbuilder.EnvVars, error) {
 	output := pipeline.Spec.Output
-	exporterConfig, envVars, err := configbuilder.MakeOTLPExporterConfig(ctx, c, output.Otlp, pipeline.Name)
+	exporterConfig, envVars, err := configbuilder.MakeOTLPExportersConfig(ctx, c, output.Otlp, pipeline.Name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to make exporter config: %v", err)
 	}
 
 	outputAliases := configbuilder.GetExporterAliases(exporterConfig)
-	receiverConfig := makeReceiverConfig()
+	receiverConfig := makeReceiversConfig()
 	processorsConfig := makeProcessorsConfig()
 	serviceConfig := makeServiceConfig(outputAliases)
-	extensionConfig := configbuilder.MakeExtensionConfig()
+	extensionConfig := configbuilder.MakeExtensionsConfig()
 
 	return &config.Config{
 		Exporters:  exporterConfig,
@@ -33,8 +33,8 @@ func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1a
 	}, envVars, nil
 }
 
-func makeReceiverConfig() config.ReceiverConfig {
-	return config.ReceiverConfig{
+func makeReceiversConfig() config.ReceiversConfig {
+	return config.ReceiversConfig{
 		OTLP: &config.OTLPReceiverConfig{
 			Protocols: config.ReceiverProtocols{
 				HTTP: config.EndpointConfig{
@@ -116,7 +116,7 @@ func makeProcessorsConfig() config.ProcessorsConfig {
 	}
 }
 
-func makeServiceConfig(outputAliases []string) config.OTLPServiceConfig {
+func makeServiceConfig(outputAliases []string) config.ServiceConfig {
 	pipelines := map[string]config.PipelineConfig{
 		"metrics": {
 			Receivers:  []string{"otlp"},
@@ -124,7 +124,7 @@ func makeServiceConfig(outputAliases []string) config.OTLPServiceConfig {
 			Exporters:  outputAliases,
 		},
 	}
-	return config.OTLPServiceConfig{
+	return config.ServiceConfig{
 		Pipelines: pipelines,
 		Telemetry: config.TelemetryConfig{
 			Metrics: config.MetricsConfig{

--- a/internal/reconciler/metricpipeline/config_builder.go
+++ b/internal/reconciler/metricpipeline/config_builder.go
@@ -18,10 +18,10 @@ func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1a
 		return nil, nil, fmt.Errorf("failed to make exporter config: %v", err)
 	}
 
-	outputAlias := configbuilder.GetOutputAlias(output.Otlp, pipeline.Name)
+	outputAliases := configbuilder.GetExporterAliases(exporterConfig)
 	receiverConfig := makeReceiverConfig()
 	processorsConfig := makeProcessorsConfig()
-	serviceConfig := makeServiceConfig(outputAlias)
+	serviceConfig := makeServiceConfig(outputAliases)
 	extensionConfig := configbuilder.MakeExtensionConfig()
 
 	return &config.Config{
@@ -116,12 +116,12 @@ func makeProcessorsConfig() config.ProcessorsConfig {
 	}
 }
 
-func makeServiceConfig(outputAlias string) config.OTLPServiceConfig {
+func makeServiceConfig(outputAliases []string) config.OTLPServiceConfig {
 	pipelines := map[string]config.PipelineConfig{
 		"metrics": {
 			Receivers:  []string{"otlp"},
 			Processors: []string{"memory_limiter", "k8sattributes", "resource", "batch"},
-			Exporters:  []string{outputAlias, "logging"},
+			Exporters:  outputAliases,
 		},
 	}
 	return config.OTLPServiceConfig{

--- a/internal/reconciler/metricpipeline/config_builder.go
+++ b/internal/reconciler/metricpipeline/config_builder.go
@@ -11,20 +11,21 @@ import (
 	configbuilder "github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder"
 )
 
-func makeOtelCollectorConfig(ctx context.Context, c client.Reader, output v1alpha1.MetricPipelineOutput) (*config.Config, configbuilder.EnvVars, error) {
-	exporterConfig, envVars, err := configbuilder.MakeOTLPExporterConfig(ctx, c, output.Otlp)
+func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1alpha1.MetricPipeline) (*config.Config, configbuilder.EnvVars, error) {
+	output := pipeline.Spec.Output
+	exporterConfig, envVars, err := configbuilder.MakeOTLPExporterConfig(ctx, c, output.Otlp, pipeline.Name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to make exporter config: %v", err)
 	}
 
-	outputType := configbuilder.GetOutputType(output.Otlp)
+	outputAlias := configbuilder.GetOutputAlias(output.Otlp, pipeline.Name)
 	receiverConfig := makeReceiverConfig()
 	processorsConfig := makeProcessorsConfig()
-	serviceConfig := makeServiceConfig(outputType)
+	serviceConfig := makeServiceConfig(outputAlias)
 	extensionConfig := configbuilder.MakeExtensionConfig()
 
 	return &config.Config{
-		Exporters:  *exporterConfig,
+		Exporters:  exporterConfig,
 		Receivers:  receiverConfig,
 		Processors: processorsConfig,
 		Service:    serviceConfig,
@@ -115,15 +116,16 @@ func makeProcessorsConfig() config.ProcessorsConfig {
 	}
 }
 
-func makeServiceConfig(outputType string) config.OTLPServiceConfig {
-	return config.OTLPServiceConfig{
-		Pipelines: config.PipelinesConfig{
-			Metrics: &config.PipelineConfig{
-				Receivers:  []string{"otlp"},
-				Processors: []string{"memory_limiter", "k8sattributes", "resource", "batch"},
-				Exporters:  []string{outputType, "logging"},
-			},
+func makeServiceConfig(outputAlias string) config.OTLPServiceConfig {
+	pipelines := map[string]config.PipelineConfig{
+		"metrics": {
+			Receivers:  []string{"otlp"},
+			Processors: []string{"memory_limiter", "k8sattributes", "resource", "batch"},
+			Exporters:  []string{outputAlias, "logging"},
 		},
+	}
+	return config.OTLPServiceConfig{
+		Pipelines: pipelines,
 		Telemetry: config.TelemetryConfig{
 			Metrics: config.MetricsConfig{
 				Address: "${MY_POD_IP}:8888",

--- a/internal/reconciler/metricpipeline/config_builder_test.go
+++ b/internal/reconciler/metricpipeline/config_builder_test.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
 )
 
 var (
@@ -78,7 +77,7 @@ func TestMakeCollectorConfigEndpoint(t *testing.T) {
 	expectedEndpoint := fmt.Sprintf("${%s}", "OTLP_ENDPOINT")
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
 
-	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"]
 	require.Equal(t, expectedEndpoint, actualExporterConfig.Endpoint)
 }
 
@@ -88,7 +87,7 @@ func TestMakeCollectorConfigSecure(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"]
 	require.False(t, actualExporterConfig.TLS.Insecure)
 }
 
@@ -98,7 +97,7 @@ func TestMakeCollectorConfigInsecure(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"]
 	require.True(t, actualExporterConfig.TLS.Insecure)
 }
 
@@ -108,7 +107,7 @@ func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"]
 	headers := actualExporterConfig.Headers
 
 	authHeader, existing := headers["Authorization"]

--- a/internal/reconciler/metricpipeline/config_builder_test.go
+++ b/internal/reconciler/metricpipeline/config_builder_test.go
@@ -259,8 +259,8 @@ service:
                 - resource
                 - batch
             exporters:
-                - otlp/test
                 - logging/test
+                - otlp/test
     telemetry:
         metrics:
             address: ${MY_POD_IP}:8888

--- a/internal/reconciler/metricpipeline/config_builder_test.go
+++ b/internal/reconciler/metricpipeline/config_builder_test.go
@@ -7,40 +7,63 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
 )
 
 var (
-	metricPipeline = v1alpha1.MetricPipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Endpoint: v1alpha1.ValueType{
-				Value: "localhost",
-			},
+	metricPipeline = &v1alpha1.MetricPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
 		},
-	}
-
-	metricPipelineInsecure = v1alpha1.MetricPipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Endpoint: v1alpha1.ValueType{
-				Value: "http://localhost",
-			},
-		},
-	}
-
-	metricPipelineWithBasicAuth = v1alpha1.MetricPipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Endpoint: v1alpha1.ValueType{
-				Value: "localhost",
-			},
-			Authentication: &v1alpha1.AuthenticationOptions{
-				Basic: &v1alpha1.BasicAuthOptions{
-					User: v1alpha1.ValueType{
-						Value: "user",
+		Spec: v1alpha1.MetricPipelineSpec{
+			Output: v1alpha1.MetricPipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Endpoint: v1alpha1.ValueType{
+						Value: "localhost",
 					},
-					Password: v1alpha1.ValueType{
-						Value: "password",
+				},
+			},
+		},
+	}
+
+	metricPipelineInsecure = &v1alpha1.MetricPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.MetricPipelineSpec{
+			Output: v1alpha1.MetricPipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Endpoint: v1alpha1.ValueType{
+						Value: "http://localhost",
+					},
+				},
+			},
+		},
+	}
+
+	metricPipelineWithBasicAuth = &v1alpha1.MetricPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.MetricPipelineSpec{
+			Output: v1alpha1.MetricPipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Endpoint: v1alpha1.ValueType{
+						Value: "localhost",
+					},
+					Authentication: &v1alpha1.AuthenticationOptions{
+						Basic: &v1alpha1.BasicAuthOptions{
+							User: v1alpha1.ValueType{
+								Value: "user",
+							},
+							Password: v1alpha1.ValueType{
+								Value: "password",
+							},
+						},
 					},
 				},
 			},
@@ -53,28 +76,40 @@ func TestMakeCollectorConfigEndpoint(t *testing.T) {
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, metricPipeline)
 	require.NoError(t, err)
 	expectedEndpoint := fmt.Sprintf("${%s}", "OTLP_ENDPOINT")
-	require.Equal(t, expectedEndpoint, collectorConfig.Exporters.OTLP.Endpoint)
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	require.Equal(t, expectedEndpoint, actualExporterConfig.Endpoint)
 }
 
 func TestMakeCollectorConfigSecure(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, metricPipeline)
 	require.NoError(t, err)
-	require.False(t, collectorConfig.Exporters.OTLP.TLS.Insecure)
+
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	require.False(t, actualExporterConfig.TLS.Insecure)
 }
 
 func TestMakeCollectorConfigInsecure(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, metricPipelineInsecure)
 	require.NoError(t, err)
-	require.True(t, collectorConfig.Exporters.OTLP.TLS.Insecure)
+
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	require.True(t, actualExporterConfig.TLS.Insecure)
 }
 
 func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, metricPipelineWithBasicAuth)
 	require.NoError(t, err)
-	headers := collectorConfig.Exporters.OTLP.Headers
+
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	actualExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	headers := actualExporterConfig.Headers
 
 	authHeader, existing := headers["Authorization"]
 	require.True(t, existing)
@@ -82,17 +117,18 @@ func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 }
 
 func TestMakeServiceConfig(t *testing.T) {
-	serviceConfig := makeServiceConfig("otlp")
+	serviceConfig := makeServiceConfig("otlp/test")
 
-	require.Contains(t, serviceConfig.Pipelines.Metrics.Receivers, "otlp")
+	require.Contains(t, serviceConfig.Pipelines, "metrics")
+	require.Contains(t, serviceConfig.Pipelines["metrics"].Receivers, "otlp")
 
-	require.Equal(t, serviceConfig.Pipelines.Metrics.Processors[0], "memory_limiter")
-	require.Equal(t, serviceConfig.Pipelines.Metrics.Processors[1], "k8sattributes")
-	require.Equal(t, serviceConfig.Pipelines.Metrics.Processors[2], "resource")
-	require.Equal(t, serviceConfig.Pipelines.Metrics.Processors[3], "batch")
+	require.Equal(t, serviceConfig.Pipelines["metrics"].Processors[0], "memory_limiter")
+	require.Equal(t, serviceConfig.Pipelines["metrics"].Processors[1], "k8sattributes")
+	require.Equal(t, serviceConfig.Pipelines["metrics"].Processors[2], "resource")
+	require.Equal(t, serviceConfig.Pipelines["metrics"].Processors[3], "batch")
 
-	require.Contains(t, serviceConfig.Pipelines.Metrics.Exporters, "otlp")
-	require.Contains(t, serviceConfig.Pipelines.Metrics.Exporters, "logging")
+	require.Contains(t, serviceConfig.Pipelines["metrics"].Exporters, "otlp/test")
+	require.Contains(t, serviceConfig.Pipelines["metrics"].Exporters, "logging")
 
 	require.Equal(t, "${MY_POD_IP}:8888", serviceConfig.Telemetry.Metrics.Address)
 	require.Equal(t, "info", serviceConfig.Telemetry.Logs.Level)
@@ -161,7 +197,9 @@ func TestCollectorConfigMarshalling(t *testing.T) {
             grpc:
                 endpoint: ${MY_POD_IP}:4317
 exporters:
-    otlp:
+    logging:
+        verbosity: basic
+    otlp/test:
         endpoint: ${OTLP_ENDPOINT}
         sending_queue:
             enabled: true
@@ -171,8 +209,6 @@ exporters:
             initial_interval: 5s
             max_interval: 30s
             max_elapsed_time: 300s
-    logging:
-        verbosity: basic
 processors:
     batch:
         send_batch_size: 1024
@@ -223,7 +259,7 @@ service:
                 - resource
                 - batch
             exporters:
-                - otlp
+                - otlp/test
                 - logging
     telemetry:
         metrics:

--- a/internal/reconciler/metricpipeline/config_builder_test.go
+++ b/internal/reconciler/metricpipeline/config_builder_test.go
@@ -117,7 +117,7 @@ func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 }
 
 func TestMakeServiceConfig(t *testing.T) {
-	serviceConfig := makeServiceConfig("otlp/test")
+	serviceConfig := makeServiceConfig([]string{"otlp/test", "logging/test"})
 
 	require.Contains(t, serviceConfig.Pipelines, "metrics")
 	require.Contains(t, serviceConfig.Pipelines["metrics"].Receivers, "otlp")
@@ -128,7 +128,7 @@ func TestMakeServiceConfig(t *testing.T) {
 	require.Equal(t, serviceConfig.Pipelines["metrics"].Processors[3], "batch")
 
 	require.Contains(t, serviceConfig.Pipelines["metrics"].Exporters, "otlp/test")
-	require.Contains(t, serviceConfig.Pipelines["metrics"].Exporters, "logging")
+	require.Contains(t, serviceConfig.Pipelines["metrics"].Exporters, "logging/test")
 
 	require.Equal(t, "${MY_POD_IP}:8888", serviceConfig.Telemetry.Metrics.Address)
 	require.Equal(t, "info", serviceConfig.Telemetry.Logs.Level)
@@ -197,7 +197,7 @@ func TestCollectorConfigMarshalling(t *testing.T) {
             grpc:
                 endpoint: ${MY_POD_IP}:4317
 exporters:
-    logging:
+    logging/test:
         verbosity: basic
     otlp/test:
         endpoint: ${OTLP_ENDPOINT}
@@ -260,7 +260,7 @@ service:
                 - batch
             exporters:
                 - otlp/test
-                - logging
+                - logging/test
     telemetry:
         metrics:
             address: ${MY_POD_IP}:8888

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -116,7 +116,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 		return fmt.Errorf("failed to create otel collector cluster role Binding: %w", err)
 	}
 
-	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, pipeline.Spec.Output)
+	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, pipeline)
 	if err != nil {
 		return fmt.Errorf("failed to make otel collector config: %v", err)
 	}

--- a/internal/reconciler/tracepipeline/config_builder.go
+++ b/internal/reconciler/tracepipeline/config_builder.go
@@ -18,10 +18,10 @@ func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1a
 		return nil, nil, fmt.Errorf("failed to make exporter config: %v", err)
 	}
 
-	outputAlias := configbuilder.GetOutputAlias(output.Otlp, pipeline.Name)
+	outputAliases := configbuilder.GetExporterAliases(exporterConfig)
 	receiverConfig := makeReceiverConfig()
 	processorsConfig := makeProcessorsConfig()
-	serviceConfig := makeServiceConfig(outputAlias)
+	serviceConfig := makeServiceConfig(outputAliases)
 	extensionConfig := configbuilder.MakeExtensionConfig()
 
 	return &config.Config{
@@ -141,12 +141,12 @@ func makeSpanFilterConfig() []string {
 	}
 }
 
-func makeServiceConfig(outputAlias string) config.OTLPServiceConfig {
+func makeServiceConfig(outputAliases []string) config.OTLPServiceConfig {
 	pipelines := map[string]config.PipelineConfig{
 		"traces": {
 			Receivers:  []string{"opencensus", "otlp"},
 			Processors: []string{"memory_limiter", "k8sattributes", "filter", "resource", "batch"},
-			Exporters:  []string{outputAlias, "logging"},
+			Exporters:  outputAliases,
 		},
 	}
 	return config.OTLPServiceConfig{

--- a/internal/reconciler/tracepipeline/config_builder.go
+++ b/internal/reconciler/tracepipeline/config_builder.go
@@ -13,16 +13,16 @@ import (
 
 func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1alpha1.TracePipeline) (*config.Config, configbuilder.EnvVars, error) {
 	output := pipeline.Spec.Output
-	exporterConfig, envVars, err := configbuilder.MakeOTLPExporterConfig(ctx, c, output.Otlp, pipeline.Name)
+	exporterConfig, envVars, err := configbuilder.MakeOTLPExportersConfig(ctx, c, output.Otlp, pipeline.Name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to make exporter config: %v", err)
 	}
 
 	outputAliases := configbuilder.GetExporterAliases(exporterConfig)
-	receiverConfig := makeReceiverConfig()
+	receiverConfig := makeReceiversConfig()
 	processorsConfig := makeProcessorsConfig()
 	serviceConfig := makeServiceConfig(outputAliases)
-	extensionConfig := configbuilder.MakeExtensionConfig()
+	extensionConfig := configbuilder.MakeExtensionsConfig()
 
 	return &config.Config{
 		Exporters:  exporterConfig,
@@ -33,8 +33,8 @@ func makeOtelCollectorConfig(ctx context.Context, c client.Reader, pipeline *v1a
 	}, envVars, nil
 }
 
-func makeReceiverConfig() config.ReceiverConfig {
-	return config.ReceiverConfig{
+func makeReceiversConfig() config.ReceiversConfig {
+	return config.ReceiversConfig{
 		OpenCensus: &config.EndpointConfig{
 			Endpoint: "${MY_POD_IP}:55678",
 		},
@@ -141,7 +141,7 @@ func makeSpanFilterConfig() []string {
 	}
 }
 
-func makeServiceConfig(outputAliases []string) config.OTLPServiceConfig {
+func makeServiceConfig(outputAliases []string) config.ServiceConfig {
 	pipelines := map[string]config.PipelineConfig{
 		"traces": {
 			Receivers:  []string{"opencensus", "otlp"},
@@ -149,7 +149,7 @@ func makeServiceConfig(outputAliases []string) config.OTLPServiceConfig {
 			Exporters:  outputAliases,
 		},
 	}
-	return config.OTLPServiceConfig{
+	return config.ServiceConfig{
 		Pipelines: pipelines,
 		Telemetry: config.TelemetryConfig{
 			Metrics: config.MetricsConfig{

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -138,7 +138,7 @@ func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 }
 
 func TestMakeServiceConfig(t *testing.T) {
-	serviceConfig := makeServiceConfig("otlp/test")
+	serviceConfig := makeServiceConfig([]string{"otlp/test", "logging/test"})
 
 	require.Contains(t, serviceConfig.Pipelines, "traces")
 	require.Contains(t, serviceConfig.Pipelines["traces"].Receivers, "otlp")
@@ -151,7 +151,7 @@ func TestMakeServiceConfig(t *testing.T) {
 	require.Equal(t, serviceConfig.Pipelines["traces"].Processors[4], "batch")
 
 	require.Contains(t, serviceConfig.Pipelines["traces"].Exporters, "otlp/test")
-	require.Contains(t, serviceConfig.Pipelines["traces"].Exporters, "logging")
+	require.Contains(t, serviceConfig.Pipelines["traces"].Exporters, "logging/test")
 
 	require.Equal(t, "${MY_POD_IP}:8888", serviceConfig.Telemetry.Metrics.Address)
 	require.Equal(t, "info", serviceConfig.Telemetry.Logs.Level)
@@ -239,7 +239,7 @@ func TestCollectorConfigMarshalling(t *testing.T) {
             grpc:
                 endpoint: ${MY_POD_IP}:4317
 exporters:
-    logging:
+    logging/test:
         verbosity: basic
     otlp/test:
         endpoint: ${OTLP_ENDPOINT}
@@ -319,7 +319,7 @@ service:
                 - batch
             exporters:
                 - otlp/test
-                - logging
+                - logging/test
     telemetry:
         metrics:
             address: ${MY_POD_IP}:8888

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -7,49 +7,79 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
 )
 
 var (
-	tracePipeline = v1alpha1.TracePipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Endpoint: v1alpha1.ValueType{
-				Value: "localhost",
-			},
+	tracePipeline = &v1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
 		},
-	}
-
-	tracePipelineInsecure = v1alpha1.TracePipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Endpoint: v1alpha1.ValueType{
-				Value: "http://localhost",
-			},
-		},
-	}
-
-	tracePipelineHTTP = v1alpha1.TracePipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Protocol: "http",
-			Endpoint: v1alpha1.ValueType{
-				Value: "localhost",
-			},
-		},
-	}
-
-	tracePipelineWithBasicAuth = v1alpha1.TracePipelineOutput{
-		Otlp: &v1alpha1.OtlpOutput{
-			Endpoint: v1alpha1.ValueType{
-				Value: "localhost",
-			},
-			Authentication: &v1alpha1.AuthenticationOptions{
-				Basic: &v1alpha1.BasicAuthOptions{
-					User: v1alpha1.ValueType{
-						Value: "user",
+		Spec: v1alpha1.TracePipelineSpec{
+			Output: v1alpha1.TracePipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Endpoint: v1alpha1.ValueType{
+						Value: "localhost",
 					},
-					Password: v1alpha1.ValueType{
-						Value: "password",
+				},
+			},
+		},
+	}
+
+	tracePipelineInsecure = &v1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.TracePipelineSpec{
+			Output: v1alpha1.TracePipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Endpoint: v1alpha1.ValueType{
+						Value: "http://localhost",
+					},
+				},
+			},
+		},
+	}
+
+	tracePipelineHTTP = &v1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.TracePipelineSpec{
+			Output: v1alpha1.TracePipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Protocol: "http",
+					Endpoint: v1alpha1.ValueType{
+						Value: "localhost",
+					},
+				},
+			},
+		},
+	}
+
+	tracePipelineWithBasicAuth = &v1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.TracePipelineSpec{
+			Output: v1alpha1.TracePipelineOutput{
+				Otlp: &v1alpha1.OtlpOutput{
+					Endpoint: v1alpha1.ValueType{
+						Value: "localhost",
+					},
+					Authentication: &v1alpha1.AuthenticationOptions{
+						Basic: &v1alpha1.BasicAuthOptions{
+							User: v1alpha1.ValueType{
+								Value: "user",
+							},
+							Password: v1alpha1.ValueType{
+								Value: "password",
+							},
+						},
 					},
 				},
 			},
@@ -62,35 +92,45 @@ func TestMakeCollectorConfigEndpoint(t *testing.T) {
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipeline)
 	require.NoError(t, err)
 	expectedEndpoint := fmt.Sprintf("${%s}", "OTLP_ENDPOINT")
-	require.Equal(t, expectedEndpoint, collectorConfig.Exporters.OTLP.Endpoint)
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	require.Equal(t, expectedEndpoint, otlpExporterConfig.Endpoint)
 }
 
 func TestMakeCollectorConfigSecure(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipeline)
 	require.NoError(t, err)
-	require.False(t, collectorConfig.Exporters.OTLP.TLS.Insecure)
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	require.False(t, otlpExporterConfig.TLS.Insecure)
 }
 
 func TestMakeCollectorConfigSecureHttp(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipelineHTTP)
 	require.NoError(t, err)
-	require.False(t, collectorConfig.Exporters.OTLPHTTP.TLS.Insecure)
+	require.Contains(t, collectorConfig.Exporters, "otlphttp/test")
+	otlpExporterConfig := collectorConfig.Exporters["otlphttp/test"].(config.OTLPExporterConfig)
+	require.False(t, otlpExporterConfig.TLS.Insecure)
 }
 
 func TestMakeCollectorConfigInsecure(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipelineInsecure)
 	require.NoError(t, err)
-	require.True(t, collectorConfig.Exporters.OTLP.TLS.Insecure)
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	require.True(t, otlpExporterConfig.TLS.Insecure)
 }
 
 func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipelineWithBasicAuth)
 	require.NoError(t, err)
-	headers := collectorConfig.Exporters.OTLP.Headers
+	require.Contains(t, collectorConfig.Exporters, "otlp/test")
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	headers := otlpExporterConfig.Headers
 
 	authHeader, existing := headers["Authorization"]
 	require.True(t, existing)
@@ -98,19 +138,20 @@ func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 }
 
 func TestMakeServiceConfig(t *testing.T) {
-	serviceConfig := makeServiceConfig("otlp")
+	serviceConfig := makeServiceConfig("otlp/test")
 
-	require.Contains(t, serviceConfig.Pipelines.Traces.Receivers, "otlp")
-	require.Contains(t, serviceConfig.Pipelines.Traces.Receivers, "opencensus")
+	require.Contains(t, serviceConfig.Pipelines, "traces")
+	require.Contains(t, serviceConfig.Pipelines["traces"].Receivers, "otlp")
+	require.Contains(t, serviceConfig.Pipelines["traces"].Receivers, "opencensus")
 
-	require.Equal(t, serviceConfig.Pipelines.Traces.Processors[0], "memory_limiter")
-	require.Equal(t, serviceConfig.Pipelines.Traces.Processors[1], "k8sattributes")
-	require.Equal(t, serviceConfig.Pipelines.Traces.Processors[2], "filter")
-	require.Equal(t, serviceConfig.Pipelines.Traces.Processors[3], "resource")
-	require.Equal(t, serviceConfig.Pipelines.Traces.Processors[4], "batch")
+	require.Equal(t, serviceConfig.Pipelines["traces"].Processors[0], "memory_limiter")
+	require.Equal(t, serviceConfig.Pipelines["traces"].Processors[1], "k8sattributes")
+	require.Equal(t, serviceConfig.Pipelines["traces"].Processors[2], "filter")
+	require.Equal(t, serviceConfig.Pipelines["traces"].Processors[3], "resource")
+	require.Equal(t, serviceConfig.Pipelines["traces"].Processors[4], "batch")
 
-	require.Contains(t, serviceConfig.Pipelines.Traces.Exporters, "otlp")
-	require.Contains(t, serviceConfig.Pipelines.Traces.Exporters, "logging")
+	require.Contains(t, serviceConfig.Pipelines["traces"].Exporters, "otlp/test")
+	require.Contains(t, serviceConfig.Pipelines["traces"].Exporters, "logging")
 
 	require.Equal(t, "${MY_POD_IP}:8888", serviceConfig.Telemetry.Metrics.Address)
 	require.Equal(t, "info", serviceConfig.Telemetry.Logs.Level)
@@ -198,7 +239,9 @@ func TestCollectorConfigMarshalling(t *testing.T) {
             grpc:
                 endpoint: ${MY_POD_IP}:4317
 exporters:
-    otlp:
+    logging:
+        verbosity: basic
+    otlp/test:
         endpoint: ${OTLP_ENDPOINT}
         sending_queue:
             enabled: true
@@ -208,8 +251,6 @@ exporters:
             initial_interval: 5s
             max_interval: 30s
             max_elapsed_time: 300s
-    logging:
-        verbosity: basic
 processors:
     batch:
         send_batch_size: 512
@@ -277,7 +318,7 @@ service:
                 - resource
                 - batch
             exporters:
-                - otlp
+                - otlp/test
                 - logging
     telemetry:
         metrics:

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
 )
 
 var (
@@ -93,7 +92,7 @@ func TestMakeCollectorConfigEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	expectedEndpoint := fmt.Sprintf("${%s}", "OTLP_ENDPOINT")
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"]
 	require.Equal(t, expectedEndpoint, otlpExporterConfig.Endpoint)
 }
 
@@ -102,7 +101,7 @@ func TestMakeCollectorConfigSecure(t *testing.T) {
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipeline)
 	require.NoError(t, err)
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"]
 	require.False(t, otlpExporterConfig.TLS.Insecure)
 }
 
@@ -111,7 +110,7 @@ func TestMakeCollectorConfigSecureHttp(t *testing.T) {
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipelineHTTP)
 	require.NoError(t, err)
 	require.Contains(t, collectorConfig.Exporters, "otlphttp/test")
-	otlpExporterConfig := collectorConfig.Exporters["otlphttp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := collectorConfig.Exporters["otlphttp/test"]
 	require.False(t, otlpExporterConfig.TLS.Insecure)
 }
 
@@ -120,7 +119,7 @@ func TestMakeCollectorConfigInsecure(t *testing.T) {
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipelineInsecure)
 	require.NoError(t, err)
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"]
 	require.True(t, otlpExporterConfig.TLS.Insecure)
 }
 
@@ -129,7 +128,7 @@ func TestMakeCollectorConfigWithBasicAuth(t *testing.T) {
 	collectorConfig, _, err := makeOtelCollectorConfig(context.Background(), fakeClient, tracePipelineWithBasicAuth)
 	require.NoError(t, err)
 	require.Contains(t, collectorConfig.Exporters, "otlp/test")
-	otlpExporterConfig := collectorConfig.Exporters["otlp/test"].(config.OTLPExporterConfig)
+	otlpExporterConfig := collectorConfig.Exporters["otlp/test"]
 	headers := otlpExporterConfig.Headers
 
 	authHeader, existing := headers["Authorization"]

--- a/internal/reconciler/tracepipeline/config_builder_test.go
+++ b/internal/reconciler/tracepipeline/config_builder_test.go
@@ -318,8 +318,8 @@ service:
                 - resource
                 - batch
             exporters:
-                - otlp/test
                 - logging/test
+                - otlp/test
     telemetry:
         metrics:
             address: ${MY_POD_IP}:8888

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -132,7 +132,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 		return fmt.Errorf("failed to create otel collector cluster role Binding: %w", err)
 	}
 
-	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, pipeline.Spec.Output)
+	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, pipeline)
 	if err != nil {
 		return fmt.Errorf("failed to make otel collector config: %v", err)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Add the pipeline name as an alias with the / notation to otlp, otlphttp, and logging exporters as a preparation to support multiple trace and metric pipelines.

Changes proposed in this pull request:

- Add aliases to otel exporters

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17234