### PR TITLE
Remove kyma-system namespace from Kustomize files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ make run
 export IMG=<my container repo>
 make docker-build
 make docker-push
+kubectl create ns kyma-system
 make deploy
 ```
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,14 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    app.kubernetes.io/name: namespace
-    app.kubernetes.io/instance: system
-    app.kubernetes.io/component: manager
-    app.kubernetes.io/managed-by: kustomize
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/hack/provision-test-env.sh
+++ b/hack/provision-test-env.sh
@@ -12,5 +12,6 @@ export IMG
 make docker-build
 make docker-push
 make install
+kubectl create ns kyma-system
 
 IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy

--- a/hack/provision-test-env.sh
+++ b/hack/provision-test-env.sh
@@ -11,7 +11,6 @@ export IMG
 
 make docker-build
 make docker-push
-make install
 kubectl create ns kyma-system
 
 IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Including `kyma-system` in Kustomize files results in the lifecycle-manager deleting the `kyma-system` namespace when disabling the telemetry module which is an undesired action. Therefore, `kyma-system` namespace is removed from Kustomize files in this PR. When Kyma is deployed, the `kyma-system` namespace will already be created by the lifecycle-manager.
- Manually create the `kyma-system` namespace in the `provision-test-env.sh` script which is used in the e2e-test. This is needed as in the e2e-test we deploy the operator as standalone without the lifecycle-manager.
- Update README to manually create `kyma-system` namespace for deploying the operator as standalone without the lifecycle-manager.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
