### PR TITLE
Add E2E tests for multi-pipeline support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,12 @@ tidy: ## Check if there any dirty change for go mod tidy.
 .PHONY: test
 test: manifests generate fmt vet tidy envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
-	go test -tags e2e ./test/e2e/testkit/otlp/matchers
+
+test-matchers: ginkgo
+	$(GINKGO) run --tags e2e -v ./test/e2e/testkit/otlp/matchers
 
 .PHONY: e2e-test
-e2e-test: ginkgo k3d ## Provision k3d cluster and run end-to-end tests.
+e2e-test: ginkgo k3d test-matchers ## Provision k3d cluster and run end-to-end tests.
 	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/provision-test-env.sh
 	$(GINKGO) run --tags e2e -v ./test/e2e
 	$(K3D) cluster delete kyma

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ tidy: ## Check if there any dirty change for go mod tidy.
 .PHONY: test
 test: manifests generate fmt vet tidy envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	go test -tags e2e ./test/e2e/testkit/otlp/matchers
 
 .PHONY: e2e-test
 e2e-test: ginkgo k3d ## Provision k3d cluster and run end-to-end tests.

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Metrics", func() {
 				allPipelines[newPipelineName] = newPipeline
 
 				Expect(kitk8s.CreateObjects(ctx, k8sClient, newPipeline...)).Should(Succeed())
-				metricPipelineShoudlStayPending(newPipelineName)
+				metricPipelineShouldStayPending(newPipelineName)
 			})
 		})
 
@@ -243,7 +243,7 @@ func metricPipelineShouldBeRunning(pipelineName string) {
 	}, timeout, interval).Should(BeTrue())
 }
 
-func metricPipelineShoudlStayPending(pipelineName string) {
+func metricPipelineShouldStayPending(pipelineName string) {
 	Consistently(func(g Gomega) {
 		var pipeline telemetryv1alpha1.MetricPipeline
 		key := types.NamespacedName{Name: pipelineName}

--- a/test/e2e/testkit/mocks/backend_deployment.go
+++ b/test/e2e/testkit/mocks/backend_deployment.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	replicas           = 1
-	otelCollectorImage = "otel/opentelemetry-collector-contrib:0.75.0"
+	otelCollectorImage = "otel/opentelemetry-collector-contrib:0.77.0"
 	nginxImage         = "nginx:1.23.3"
 )
 

--- a/test/e2e/testkit/otlp/matchers/metric_matchers_test.go
+++ b/test/e2e/testkit/otlp/matchers/metric_matchers_test.go
@@ -109,3 +109,43 @@ var _ = Describe("HaveGauges", func() {
 		})
 	})
 })
+
+var _ = Describe("HaveNumberOfMetrics", func() {
+	Context("with nil input", func() {
+		It("should match 0", func() {
+			success, err := HaveNumberOfMetrics(0).Match(nil)
+			Expect(err).Should(HaveOccurred())
+			Expect(success).Should(BeFalse())
+		})
+	})
+
+	Context("with empty input", func() {
+		var emptyMetrics []pmetric.Metric
+		It("should match 0", func() {
+			success, err := HaveNumberOfMetrics(0).Match(emptyMetrics)
+			Expect(err).Should(HaveOccurred())
+			Expect(success).Should(BeFalse())
+		})
+	})
+
+	Context("with input of invalid type", func() {
+		It("should error", func() {
+			success, err := HaveNumberOfMetrics(0).Match(struct{}{})
+			Expect(err).Should(HaveOccurred())
+			Expect(success).Should(BeFalse())
+		})
+	})
+
+	Context("with having metrics", func() {
+		var fileBytes []byte
+		BeforeEach(func() {
+			var err error
+			fileBytes, err = os.ReadFile("testdata/have_metrics/full_match.jsonl")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed", func() {
+			Expect(fileBytes).Should(HaveNumberOfMetrics(2))
+		})
+	})
+})

--- a/test/e2e/testkit/otlp/matchers/trace_matchers.go
+++ b/test/e2e/testkit/otlp/matchers/trace_matchers.go
@@ -37,6 +37,10 @@ func ConsistOfSpansWithIDs(expectedSpanIDs []pcommon.SpanID) types.GomegaMatcher
 
 func ConsistOfNumberOfSpans(count int) types.GomegaMatcher {
 	return gomega.WithTransform(func(actual interface{}) (int, error) {
+		if actual == nil {
+			return 0, nil
+		}
+
 		actualBytes, ok := actual.([]byte)
 		if !ok {
 			return 0, fmt.Errorf("ConsistOfNumberOfSpans requires a []byte, but got %T", actual)

--- a/test/e2e/testkit/otlp/matchers/trace_matchers.go
+++ b/test/e2e/testkit/otlp/matchers/trace_matchers.go
@@ -35,6 +35,23 @@ func ConsistOfSpansWithIDs(expectedSpanIDs []pcommon.SpanID) types.GomegaMatcher
 	}, gomega.ConsistOf(expectedSpanIDs))
 }
 
+func ConsistOfNumberOfSpans(count int) types.GomegaMatcher {
+	return gomega.WithTransform(func(actual interface{}) (int, error) {
+		actualBytes, ok := actual.([]byte)
+		if !ok {
+			return 0, fmt.Errorf("ConsistOfNumberOfSpans requires a []byte, but got %T", actual)
+		}
+
+		actualTraces, err := unmarshalOTLPJSONTraces(actualBytes)
+		if err != nil {
+			return 0, fmt.Errorf("ConsistOfNumberOfSpans requires a valid OTLP JSON document: %v", err)
+		}
+
+		actualSpans := getAllSpans(actualTraces)
+		return len(actualSpans), nil
+	}, gomega.Equal(count))
+}
+
 func ConsistOfSpansWithTraceID(expectedTraceID pcommon.TraceID) types.GomegaMatcher {
 	return gomega.WithTransform(func(actual interface{}) ([]pcommon.TraceID, error) {
 		actualBytes, ok := actual.([]byte)

--- a/test/e2e/testkit/otlp/matchers/trace_matchers_test.go
+++ b/test/e2e/testkit/otlp/matchers/trace_matchers_test.go
@@ -254,3 +254,48 @@ var _ = Describe("ConsistOfSpansWithAttributes", func() {
 		})
 	})
 })
+
+var _ = Describe("ConsistOfNumberOfSpans", func() {
+	var fileBytes []byte
+
+	Context("with nil input", func() {
+		It("should match 0", func() {
+			success, err := ConsistOfNumberOfSpans(0).Match(nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(success).Should(BeTrue())
+		})
+	})
+
+	Context("with empty input", func() {
+		It("should match 0", func() {
+			success, err := ConsistOfNumberOfSpans(0).Match([]byte{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(success).Should(BeTrue())
+		})
+	})
+
+	Context("with invalid input", func() {
+		BeforeEach(func() {
+			fileBytes = []byte{1, 2, 3}
+		})
+
+		It("should error", func() {
+			success, err := ConsistOfNumberOfSpans(0).Match(fileBytes)
+			Expect(err).Should(HaveOccurred())
+			Expect(success).Should(BeFalse())
+		})
+	})
+
+	Context("with having spans", func() {
+		BeforeEach(func() {
+			var err error
+			fileBytes, err = os.ReadFile("testdata/consist_of_spans_with_attributes/full_match.jsonl")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed", func() {
+			Expect(fileBytes).Should(ConsistOfNumberOfSpans(3))
+		})
+	})
+
+})

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -28,7 +28,9 @@ import (
 )
 
 var (
-	traceCollectorBaseName = "telemetry-trace-collector"
+	traceCollectorBaseName             = "telemetry-trace-collector"
+	maxNumberOfTracePipelines          = 3
+	tracePipelineReconciliationTimeout = 10 * time.Second
 )
 
 var _ = Describe("Tracing", func() {
@@ -113,59 +115,67 @@ var _ = Describe("Tracing", func() {
 		})
 	})
 
-	Context("When reaching the pipeline limit", func() {
-		It("Should have 3 running pipelines", func() {
-			pipeline1Objects := makeBrokenTracePipeline("pipeline-1")
-			pipeline2Objects := makeBrokenTracePipeline("pipeline-2")
-			pipeline3Objects := makeBrokenTracePipeline("pipeline-3")
-			pipeline4Objects := makeBrokenTracePipeline("pipeline-4")
+	Context("When reaching the pipeline limit", Ordered, func() {
+		allPipelines := make(map[string][]client.Object, 0)
+
+		BeforeAll(func() {
+			for i := 0; i < maxNumberOfTracePipelines; i++ {
+				pipelineName := fmt.Sprintf("pipeline-%d", i)
+				pipelineObjects := makeBrokenTracePipeline(pipelineName)
+				allPipelines[pipelineName] = pipelineObjects
+
+				Expect(kitk8s.CreateObjects(ctx, k8sClient, pipelineObjects...)).Should(Succeed())
+			}
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline2Objects...)).Should(Succeed())
-				Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline3Objects...)).Should(Succeed())
-				Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline4Objects...)).Should(Succeed())
+				for _, pipeline := range allPipelines {
+					Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline...)).Should(Succeed())
+				}
 			})
+		})
 
-			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline1Objects...)).Should(Succeed())
-			Eventually(func(g Gomega) bool {
-				var pipeline telemetryv1alpha1.TracePipeline
-				key := types.NamespacedName{Name: "pipeline-1"}
-				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
-			}, timeout, interval).Should(BeTrue())
+		It("Should have only running pipelines", func() {
+			for pipelineName := range allPipelines {
+				Eventually(func(g Gomega) {
+					var pipeline telemetryv1alpha1.TracePipeline
+					key := types.NamespacedName{Name: pipelineName}
+					g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+					g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)).To(BeTrue())
+				}, timeout, interval).Should(Succeed())
+			}
+		})
 
-			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline2Objects...)).Should(Succeed())
-			Eventually(func(g Gomega) bool {
-				var pipeline telemetryv1alpha1.TracePipeline
-				key := types.NamespacedName{Name: "pipeline-2"}
-				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
-			}, timeout, interval).Should(BeTrue())
+		It("Should have a pending pipeline", func() {
+			By("Creating an additional pipeline", func() {
+				newPipelineName := "new-pipeline"
+				newPipeline := makeBrokenTracePipeline(newPipelineName)
+				allPipelines[newPipelineName] = newPipeline
 
-			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline3Objects...)).Should(Succeed())
-			Eventually(func(g Gomega) bool {
-				var pipeline telemetryv1alpha1.TracePipeline
-				key := types.NamespacedName{Name: "pipeline-3"}
-				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
-			}, timeout, interval).Should(BeTrue())
+				Expect(kitk8s.CreateObjects(ctx, k8sClient, newPipeline...)).Should(Succeed())
+				Consistently(func(g Gomega) {
+					var pipeline telemetryv1alpha1.TracePipeline
+					key := types.NamespacedName{Name: newPipelineName}
+					g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+					g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)).To(BeFalse())
+				}, tracePipelineReconciliationTimeout, interval).Should(Succeed())
+			})
+		})
 
-			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline4Objects...)).Should(Succeed())
-			time.Sleep(10 * time.Second) // wait for reconciliation
-			var pipeline telemetryv1alpha1.TracePipeline
-			key := types.NamespacedName{Name: "pipeline-4"}
-			Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-			// We allow only 3 piplines, pipeline-4 should not be running
-			Expect(!pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning))
+		It("Should have only running pipeline", func() {
+			By("Deleting a pipeline", func() {
+				deletedPipeline := allPipelines["pipeline-0"]
+				delete(allPipelines, "pipeline-0")
 
-			Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline1Objects...)).Should(Succeed())
-			Eventually(func(g Gomega) bool {
-				var pipeline telemetryv1alpha1.TracePipeline
-				key := types.NamespacedName{Name: "pipeline-4"}
-				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-				// pipeline-4 should become running after pipeline-1 is deleted
-				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
-			}, timeout, interval).Should(BeTrue())
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, deletedPipeline...)).Should(Succeed())
+				Eventually(func(g Gomega) {
+					for pipelineName := range allPipelines {
+						var pipeline telemetryv1alpha1.TracePipeline
+						key := types.NamespacedName{Name: pipelineName}
+						g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+						g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning))
+					}
+				}).Should(Succeed())
+			})
 		})
 	})
 

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Tracing", func() {
 				allPipelines[newPipelineName] = newPipeline
 
 				Expect(kitk8s.CreateObjects(ctx, k8sClient, newPipeline...)).Should(Succeed())
-				tracePipelineShoudlStayPending(newPipelineName)
+				tracePipelineShouldStayPending(newPipelineName)
 			})
 		})
 
@@ -262,7 +262,7 @@ func tracePipelineShouldBeRunning(pipelineName string) {
 	}, timeout, interval).Should(BeTrue())
 }
 
-func tracePipelineShoudlStayPending(pipelineName string) {
+func tracePipelineShouldStayPending(pipelineName string) {
 	Consistently(func(g Gomega) {
 		var pipeline telemetryv1alpha1.TracePipeline
 		key := types.NamespacedName{Name: pipelineName}

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
+	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -30,21 +32,21 @@ var (
 )
 
 var _ = Describe("Tracing", func() {
+	var (
+		portRegistry = testkit.NewPortRegistry().
+				AddServicePort("http-otlp", 4318).
+				AddPortMapping("grpc-otlp", 4317, 30017, 4317).
+				AddPortMapping("http-metrics", 8888, 30088, 8888).
+				AddPortMapping("http-web", 80, 30090, 9090)
+
+		otlpPushURL               = fmt.Sprintf("grpc://localhost:%d", portRegistry.HostPort("grpc-otlp"))
+		metricsURL                = fmt.Sprintf("http://localhost:%d/metrics", portRegistry.HostPort("http-metrics"))
+		mockBackendTraceExportURL = fmt.Sprintf("http://localhost:%d/%s", portRegistry.HostPort("http-web"), telemetryDataFilename)
+	)
+
 	Context("When a tracepipeline exists", Ordered, func() {
-		var (
-			portRegistry = testkit.NewPortRegistry().
-					AddServicePort("http-otlp", 4318).
-					AddPortMapping("grpc-otlp", 4317, 30017, 4317).
-					AddPortMapping("http-metrics", 8888, 30088, 8888).
-					AddPortMapping("http-web", 80, 30090, 9090)
-
-			otlpPushURL               = fmt.Sprintf("grpc://localhost:%d", portRegistry.HostPort("grpc-otlp"))
-			metricsURL                = fmt.Sprintf("http://localhost:%d/metrics", portRegistry.HostPort("http-metrics"))
-			mockBackendTraceExportURL = fmt.Sprintf("http://localhost:%d/%s", portRegistry.HostPort("http-web"), telemetryDataFilename)
-		)
-
 		BeforeAll(func() {
-			k8sObjects := makeTracingTestK8sObjects(portRegistry)
+			k8sObjects := makeTracingTestK8sObjects(portRegistry, "trace-mocks-single-pipeline")
 
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
@@ -110,10 +112,171 @@ var _ = Describe("Tracing", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 	})
+
+	Context("When reaching the pipeline limit", func() {
+		It("Should have 3 running pipelines", func() {
+			pipeline1Objects := makeBrokenTracePipeline("pipeline-1")
+			pipeline2Objects := makeBrokenTracePipeline("pipeline-2")
+			pipeline3Objects := makeBrokenTracePipeline("pipeline-3")
+			pipeline4Objects := makeBrokenTracePipeline("pipeline-4")
+
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline2Objects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline3Objects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline4Objects...)).Should(Succeed())
+			})
+
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline1Objects...)).Should(Succeed())
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-1"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline2Objects...)).Should(Succeed())
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-2"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline3Objects...)).Should(Succeed())
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-3"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, pipeline4Objects...)).Should(Succeed())
+			time.Sleep(10 * time.Second) // wait for reconciliation
+			var pipeline telemetryv1alpha1.TracePipeline
+			key := types.NamespacedName{Name: "pipeline-4"}
+			Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+			// We allow only 3 piplines, pipeline-4 should not be running
+			Expect(!pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning))
+
+			Expect(kitk8s.DeleteObjects(ctx, k8sClient, pipeline1Objects...)).Should(Succeed())
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-4"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				// pipeline-4 should become running after pipeline-1 is deleted
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When a broken tracepipeline exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeTracingTestK8sObjects(portRegistry, "trace-mocks-broken-pipeline")
+			secondPipeline := makeBrokenTracePipeline("pipeline-2")
+
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, secondPipeline...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, secondPipeline...)).Should(Succeed())
+		})
+
+		It("Should have running pipelines", func() {
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "test"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-2"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should verify end-to-end trace delivery for the remaining pipeline", func() {
+			traceID := kittraces.NewTraceID()
+			var spanIDs []pcommon.SpanID
+			for i := 0; i < 100; i++ {
+				spanIDs = append(spanIDs, kittraces.NewSpanID())
+			}
+			attrs := pcommon.NewMap()
+			attrs.PutStr("attrA", "chocolate")
+			attrs.PutStr("attrB", "raspberry")
+			attrs.PutStr("attrC", "vanilla")
+
+			traces := kittraces.MakeTraces(traceID, spanIDs, attrs)
+
+			sendTraces(ctx, traces, otlpPushURL)
+
+			Eventually(func(g Gomega) {
+				resp, err := http.Get(mockBackendTraceExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(SatisfyAll(
+					ConsistOfSpansWithIDs(spanIDs),
+					ConsistOfSpansWithTraceID(traceID),
+					ConsistOfSpansWithAttributes(attrs))))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Context("When multiple tracepipelines exist", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeMultiPipelineTracingTestK8sObjects(portRegistry, "trace-mocks-multi-pipeline")
+
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+		})
+
+		It("Should have running pipelines", func() {
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-1"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func(g Gomega) bool {
+				var pipeline telemetryv1alpha1.TracePipeline
+				key := types.NamespacedName{Name: "pipeline-2"}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				return pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should verify end-to-end trace delivery", func() {
+			traceID := kittraces.NewTraceID()
+			var spanIDs []pcommon.SpanID
+			for i := 0; i < 100; i++ {
+				spanIDs = append(spanIDs, kittraces.NewSpanID())
+			}
+
+			attrs := pcommon.NewMap()
+			traces := kittraces.MakeTraces(traceID, spanIDs, attrs)
+
+			sendTraces(context.Background(), traces, otlpPushURL)
+
+			// Spans should arrive in the backend twice
+			Eventually(func(g Gomega) {
+				resp, err := http.Get(mockBackendTraceExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(SatisfyAll(
+					ConsistOfNumberOfSpans(2 * len(spanIDs)))))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
 })
 
 // makeTracingTestK8sObjects returns the list of mandatory E2E test suite k8s objects.
-func makeTracingTestK8sObjects(portRegistry testkit.PortRegistry) []client.Object {
+func makeTracingTestK8sObjects(portRegistry testkit.PortRegistry, namespace string) []client.Object {
 	var (
 		grpcOTLPPort        = portRegistry.ServicePort("grpc-otlp")
 		grpcOTLPNodePort    = portRegistry.NodePort("grpc-otlp")
@@ -125,7 +288,7 @@ func makeTracingTestK8sObjects(portRegistry testkit.PortRegistry) []client.Objec
 	)
 
 	//// Mocks namespace objects.
-	mocksNamespace := kitk8s.NewNamespace("trace-mocks")
+	mocksNamespace := kitk8s.NewNamespace(namespace)
 	mockBackend := mocks.NewBackend("trace-receiver", mocksNamespace.Name(), "/traces/"+telemetryDataFilename, mocks.SignalTypeTraces)
 	mockBackendConfigMap := mockBackend.ConfigMap("trace-receiver-config")
 	mockBackendDeployment := mockBackend.Deployment(mockBackendConfigMap.Name())
@@ -155,12 +318,70 @@ func makeTracingTestK8sObjects(portRegistry testkit.PortRegistry) []client.Objec
 	}
 }
 
+// makeMultiPipelineTracingTestK8sObjects returns the list of mandatory E2E test suite k8s objects including two tracepipelines.
+func makeMultiPipelineTracingTestK8sObjects(portRegistry testkit.PortRegistry, namespace string) []client.Object {
+	var (
+		grpcOTLPPort        = portRegistry.ServicePort("grpc-otlp")
+		grpcOTLPNodePort    = portRegistry.NodePort("grpc-otlp")
+		httpMetricsPort     = portRegistry.ServicePort("http-metrics")
+		httpMetricsNodePort = portRegistry.NodePort("http-metrics")
+		httpOTLPPort        = portRegistry.ServicePort("http-otlp")
+		httpWebPort         = portRegistry.ServicePort("http-web")
+		httpWebNodePort     = portRegistry.NodePort("http-web")
+	)
+
+	//// Mocks namespace objects.
+	mocksNamespace := kitk8s.NewNamespace(namespace)
+	mockBackend := mocks.NewBackend("trace-receiver", mocksNamespace.Name(), "/traces/"+telemetryDataFilename, mocks.SignalTypeTraces)
+	mockBackendConfigMap := mockBackend.ConfigMap("trace-receiver-config")
+	mockBackendDeployment := mockBackend.Deployment(mockBackendConfigMap.Name())
+	mockBackendExternalService := mockBackend.ExternalService().
+		WithPort("grpc-otlp", grpcOTLPPort).
+		WithPort("http-otlp", httpOTLPPort).
+		WithPortMapping("http-web", httpWebPort, httpWebNodePort)
+
+	// Default namespace objects.
+	otlpEndpointURL := mockBackendExternalService.OTLPEndpointURL(grpcOTLPPort)
+	hostSecret1 := kitk8s.NewOpaqueSecret("trace-rcv-hostname-1", defaultNamespaceName, kitk8s.WithStringData("trace-host", otlpEndpointURL))
+	tracePipeline1 := kittrace.NewPipeline("pipeline-1", hostSecret1.SecretKeyRef("trace-host"))
+
+	hostSecret2 := kitk8s.NewOpaqueSecret("trace-rcv-hostname-2", defaultNamespaceName, kitk8s.WithStringData("trace-host", otlpEndpointURL))
+	tracePipeline2 := kittrace.NewPipeline("pipeline-2", hostSecret2.SecretKeyRef("trace-host"))
+
+	// Kyma-system namespace objects.
+	traceGatewayExternalService := kitk8s.NewService("telemetry-otlp-traces-external", kymaSystemNamespaceName).
+		WithPortMapping("grpc-otlp", grpcOTLPPort, grpcOTLPNodePort).
+		WithPortMapping("http-metrics", httpMetricsPort, httpMetricsNodePort)
+
+	return []client.Object{
+		mocksNamespace.K8sObject(),
+		mockBackendConfigMap.K8sObject(),
+		mockBackendDeployment.K8sObject(kitk8s.WithLabel("app", mockBackend.Name())),
+		mockBackendExternalService.K8sObject(kitk8s.WithLabel("app", mockBackend.Name())),
+		hostSecret1.K8sObject(),
+		tracePipeline1.K8sObject(),
+		hostSecret2.K8sObject(),
+		tracePipeline2.K8sObject(),
+		traceGatewayExternalService.K8sObject(kitk8s.WithLabel("app.kubernetes.io/name", traceCollectorBaseName)),
+	}
+}
+
+func makeBrokenTracePipeline(name string) []client.Object {
+	hostSecret := kitk8s.NewOpaqueSecret("trace-rcv-hostname-"+name, defaultNamespaceName, kitk8s.WithStringData("trace-host", "http://unreachable:4317"))
+	tracePipeline := kittrace.NewPipeline(name, hostSecret.SecretKeyRef("trace-host"))
+
+	return []client.Object{
+		hostSecret.K8sObject(),
+		tracePipeline.K8sObject(),
+	}
+}
+
 func sendTraces(ctx context.Context, traces ptrace.Traces, otlpPushURL string) {
 	Eventually(func(g Gomega) {
 		sender, err := kittraces.NewDataSender(otlpPushURL)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sender.Start()).Should(Succeed())
-		Expect(sender.ConsumeTraces(ctx, traces)).Should(Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(sender.Start()).Should(Succeed())
+		g.Expect(sender.ConsumeTraces(ctx, traces)).Should(Succeed())
 		sender.Flush()
 	}, timeout, interval).Should(Succeed())
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Add end-to-end tests for support of multiple TracePipelines and MetricPipeliens. The added tests validate that the pipeline limit is enforced and reflected in the pending / running state, traces and metrics reach the backend from all pipelines, and a broken pipeline does not affect another one.

Changes proposed in this pull request:

- Add E2E tests for multi-pipeline support

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17234