### PR TITLE
Reduce flakiness of e2e tests

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -56,22 +56,21 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
-				return ready
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should have a metrics backend running", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
-				return ready
-
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should be able to get metric gateway metrics endpoint", func() {
@@ -177,21 +176,20 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
-				return ready
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 		It("Should have a metrics backend running", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
-				g.Expect(err).To(BeNil())
-				return ready
-
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should verify end-to-end metric delivery", func() {
@@ -233,22 +231,21 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
-				g.Expect(err).To(BeNil())
-				return ready
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should have a metrics backend running", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
-				g.Expect(err).To(BeNil())
-				return ready
-
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should verify end-to-end metric delivery", func() {

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have a running metric gateway deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
 				return ready
 			}, timeout, interval).Should(BeTrue())
@@ -67,7 +67,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have a metrics backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
 				return ready
 
@@ -179,7 +179,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have a running metric gateway deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
 				return ready
 			}, timeout, interval).Should(BeTrue())
@@ -187,7 +187,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have a metrics backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
 				return ready
 
@@ -235,7 +235,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have a running metric gateway deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
 				return ready
 			}, timeout, interval).Should(BeTrue())
@@ -244,7 +244,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have a metrics backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).To(BeNil())
 				return ready
 

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/otlp/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,10 +33,10 @@ var (
 var _ = Describe("Metrics", func() {
 	var (
 		portRegistry = testkit.NewPortRegistry().
-			AddServicePort("http-otlp", 4318).
-			AddPortMapping("grpc-otlp", 4317, 30017, 4317).
-			AddPortMapping("http-metrics", 8888, 30088, 8888).
-			AddPortMapping("http-web", 80, 30090, 9090)
+				AddServicePort("http-otlp", 4318).
+				AddPortMapping("grpc-otlp", 4317, 30017, 4317).
+				AddPortMapping("http-metrics", 8888, 30088, 8888).
+				AddPortMapping("http-web", 80, 30090, 9090)
 
 		otlpPushURL                 = fmt.Sprintf("grpc://localhost:%d", portRegistry.HostPort("grpc-otlp"))
 		metricsURL                  = fmt.Sprintf("http://localhost:%d/metrics", portRegistry.HostPort("http-metrics"))
@@ -59,18 +58,18 @@ var _ = Describe("Metrics", func() {
 		It("Should have a running metric gateway deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
 				g.Expect(err).To(BeNil())
-				return res
+				return ready
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("Should have a metrics backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
 				g.Expect(err).To(BeNil())
-				return res
+				return ready
 
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -180,17 +179,17 @@ var _ = Describe("Metrics", func() {
 		It("Should have a running metric gateway deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
-				g.Expect(err).To(BeNil())
-				return res
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				g.Expect(err).NotTo(HaveOccurred())
+				return ready
 			}, timeout, interval).Should(BeTrue())
 		})
 		It("Should have a metrics backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
 				g.Expect(err).To(BeNil())
-				return res
+				return ready
 
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -236,18 +235,18 @@ var _ = Describe("Metrics", func() {
 		It("Should have a running metric gateway deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
 				g.Expect(err).To(BeNil())
-				return res
+				return ready
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("Should have a metrics backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
 				g.Expect(err).To(BeNil())
-				return res
+				return ready
 
 			}, timeout, interval).Should(BeTrue())
 		})

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Metrics", func() {
 			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: metricGatewayBaseName, Namespace: kymaSystemNamespaceName}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).ShouldNot(HaveOccurred())
 				g.Expect(ready).To(BeTrue())
 			}, timeout, interval).Should(Succeed())
 		})
@@ -68,7 +68,7 @@ var _ = Describe("Metrics", func() {
 			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
-				g.Expect(err).To(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(ready).To(BeTrue())
 			}, timeout, interval).Should(Succeed())
 		})

--- a/test/e2e/testkit/k8s/verifiers/deployment.go
+++ b/test/e2e/testkit/k8s/verifiers/deployment.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package verifiers
 
 import (

--- a/test/e2e/testkit/k8s/verifiers/deployment.go
+++ b/test/e2e/testkit/k8s/verifiers/deployment.go
@@ -1,0 +1,35 @@
+package verifiers
+
+import (
+	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsDeploymentReady(k8sClient client.Client, ctx context.Context, name types.NamespacedName) (bool, error) {
+	var deployment appsv1.Deployment
+	err := k8sClient.Get(ctx, name, &deployment)
+	if err != nil {
+		return false, err
+	}
+	listOptions := client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(deployment.Spec.Selector.MatchLabels),
+		Namespace:     name.Namespace,
+	}
+	var pods corev1.PodList
+	err = k8sClient.List(ctx, &pods, &listOptions)
+	if err != nil {
+		return false, err
+	}
+	for _, pod := range pods.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.State.Running == nil {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}

--- a/test/e2e/testkit/k8s/verifiers/deployment.go
+++ b/test/e2e/testkit/k8s/verifiers/deployment.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func IsDeploymentReady(k8sClient client.Client, ctx context.Context, name types.NamespacedName) (bool, error) {
+func IsDeploymentReady(ctx context.Context, k8sClient client.Client, name types.NamespacedName) (bool, error) {
 	var deployment appsv1.Deployment
 	err := k8sClient.Get(ctx, name, &deployment)
 	if err != nil {

--- a/test/e2e/testkit/mocks/backend_deployment.go
+++ b/test/e2e/testkit/mocks/backend_deployment.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	replicas           = 1
-	otelCollectorImage = "otel/opentelemetry-collector-contrib:0.77.0"
-	nginxImage         = "nginx:1.23.3"
+	otelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.77.0-8115210c"
+	nginxImage         = "europe-docker.pkg.dev/kyma-project/prod/external/nginx:1.23.3"
 )
 
 type BackendDeployment struct {

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -58,22 +58,21 @@ var _ = Describe("Tracing", func() {
 		})
 
 		It("Should have a running trace collector deployment", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: traceCollectorBaseName, Namespace: kymaSystemNamespaceName}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
-				return ready
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should have a trace backend running", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
-				return ready
-
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should be able to get trace collector metrics endpoint", func() {
@@ -187,13 +186,12 @@ var _ = Describe("Tracing", func() {
 		})
 
 		It("Should have a trace backend running", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
-				return ready
-
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should verify end-to-end trace delivery for the remaining pipeline", func() {
@@ -242,13 +240,12 @@ var _ = Describe("Tracing", func() {
 		})
 
 		It("Should have a trace backend running", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
 				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
-				return ready
-
-			}, timeout, interval).Should(BeTrue())
+				g.Expect(ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should verify end-to-end trace delivery", func() {

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Tracing", func() {
 
 		It("Should have a running trace collector deployment", func() {
 			Eventually(func(g Gomega) bool {
-				//var deployment appsv1.Deployment
 				key := types.NamespacedName{Name: traceCollectorBaseName, Namespace: kymaSystemNamespaceName}
 				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Tracing", func() {
 		It("Should have a running trace collector deployment", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: traceCollectorBaseName, Namespace: kymaSystemNamespaceName}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
 				return ready
 			}, timeout, interval).Should(BeTrue())
@@ -69,7 +69,7 @@ var _ = Describe("Tracing", func() {
 		It("Should have a trace backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
 				return ready
 
@@ -189,7 +189,7 @@ var _ = Describe("Tracing", func() {
 		It("Should have a trace backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
 				return ready
 
@@ -244,7 +244,7 @@ var _ = Describe("Tracing", func() {
 		It("Should have a trace backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				ready, err := verifiers.IsDeploymentReady(ctx, k8sClient, key)
 				g.Expect(err).NotTo(HaveOccurred())
 				return ready
 

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -61,18 +61,18 @@ var _ = Describe("Tracing", func() {
 			Eventually(func(g Gomega) bool {
 				//var deployment appsv1.Deployment
 				key := types.NamespacedName{Name: traceCollectorBaseName, Namespace: kymaSystemNamespaceName}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
-				g.Expect(err).To(BeNil())
-				return res
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				g.Expect(err).NotTo(HaveOccurred())
+				return ready
 			}, timeout, interval).Should(BeTrue())
 		})
 
 		It("Should have a trace backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
-				g.Expect(err).To(BeNil())
-				return res
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				g.Expect(err).NotTo(HaveOccurred())
+				return ready
 
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -190,9 +190,9 @@ var _ = Describe("Tracing", func() {
 		It("Should have a trace backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
-				g.Expect(err).To(BeNil())
-				return res
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				g.Expect(err).NotTo(HaveOccurred())
+				return ready
 
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -245,9 +245,9 @@ var _ = Describe("Tracing", func() {
 		It("Should have a trace backend running", func() {
 			Eventually(func(g Gomega) bool {
 				key := types.NamespacedName{Name: mockDeploymentName, Namespace: mockNs}
-				res, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
-				g.Expect(err).To(BeNil())
-				return res
+				ready, err := verifiers.IsDeploymentReady(k8sClient, ctx, key)
+				g.Expect(err).NotTo(HaveOccurred())
+				return ready
 
 			}, timeout, interval).Should(BeTrue())
 		})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- We are using otel and nginx images from docker. These images are pull in unauthenticated docker pull which has rate limiting. To mitigate use images from kyma's docker registry
- Make sure the trace/metric backend is running before testing for traces.
- Some refactoring

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
