### PR TITLE
Update `control-plane` label

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: telemetry-
 labels:
 - includeSelectors: false
   pairs:
-    control-plane: operator
+    control-plane: telemetry-operator
     app.kubernetes.io/component: telemetry
     app.kubernetes.io/part-of: kyma
     app.kubernetes.io/name: telemetry-operator


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Change the value of `control-plane` label from `operator` to `telemetry-operator` which is the value currently used in the helm chart. This is needed to allow running the fast-integration test after a migration scenario from old Kyma to modular Kyma, since the test expects the label `control-plane=telemetry-operator` https://github.com/kyma-project/kyma/blob/main/tests/fast-integration/telemetry-test/suite.js#L121

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
