### PR TITLE
Improve fluent bit config reconciliation

### DIFF
--- a/config/samples/telemetry_v1alpha1_logpipeline.yaml
+++ b/config/samples/telemetry_v1alpha1_logpipeline.yaml
@@ -3,16 +3,6 @@ kind: LogPipeline
 metadata:
   name: logpipeline-sample
 spec:
-  filters:
-    - custom: |
-        Name    grep
-        Regex   $kubernetes['labels']['app'] my-deployment
-    - custom: |
-        Name    grep
-        Exclude $kubernetes['namespace_name'] kyma-system|kube-system|istio-system
-    - custom: |
-        Name    record_modifier
-        Record  cluster_identifier ${KUBERNETES_SERVICE_HOST}
   output:
     custom: |
       Name               stdout

--- a/controllers/telemetry/logparser_controller.go
+++ b/controllers/telemetry/logparser_controller.go
@@ -19,8 +19,11 @@ limitations under the License.
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/logparser"
@@ -49,5 +52,10 @@ func (r *LogParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *LogParserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1alpha1.LogParser{}).
+		Watches(
+			&source.Kind{Type: &corev1.ConfigMap{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &telemetryv1alpha1.LogParser{},
+				IsController: false}).
 		Complete(r)
 }

--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -27,6 +27,8 @@ import (
 var (
 	testLogPipelineConfig = logpipelinereconciler.Config{
 		DaemonSet:         types.NamespacedName{Name: "test-telemetry-fluent-bit", Namespace: "default"},
+		ParsersConfigMap:  types.NamespacedName{Name: "test-telemetry-fluent-bit-parsers", Namespace: "default"},
+		LuaConfigMap:      types.NamespacedName{Name: "test-telemetry-fluent-bit-luascripts", Namespace: "default"},
 		SectionsConfigMap: types.NamespacedName{Name: "test-telemetry-fluent-bit-sections", Namespace: "default"},
 		FilesConfigMap:    types.NamespacedName{Name: "test-telemetry-fluent-bit-files", Namespace: "default"},
 		EnvSecret:         types.NamespacedName{Name: "test-telemetry-fluent-bit-env", Namespace: "default"},
@@ -189,7 +191,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
 					}
 				}
 				return false
-			}, timeout, interval).Should(Equal(true))
+			}, timeout, interval).Should(BeTrue())
 		})
 		It("Should have the telemetry_all_logpipelines metric set to 1", func() {
 			// All log pipeline gauge should be updated

--- a/internal/reconciler/logparser/sync.go
+++ b/internal/reconciler/logparser/sync.go
@@ -46,8 +46,8 @@ func (s *syncer) syncFluentBitConfig(ctx context.Context) error {
 		}
 	}
 
-	for _, parser := range logParsers.Items {
-		if err := controllerutil.SetOwnerReference(&parser, &cm, s.Scheme()); err != nil {
+	for i := range logParsers.Items {
+		if err := controllerutil.SetOwnerReference(&logParsers.Items[i], &cm, s.Scheme()); err != nil {
 			return fmt.Errorf("unable to set owner reference for parsers configmap: %w", err)
 		}
 	}

--- a/internal/reconciler/logparser/sync_test.go
+++ b/internal/reconciler/logparser/sync_test.go
@@ -61,4 +61,5 @@ Format regex`},
 	expectedCMData := "[PARSER]\n    Name foo\n    Format regex\n\n"
 	require.Contains(t, cm.Data[parsersConfigMapKey], expectedCMData)
 	require.Len(t, cm.OwnerReferences, 1)
+	require.Equal(t, lp.Name, cm.OwnerReferences[0].Name)
 }

--- a/internal/reconciler/logparser/sync_test.go
+++ b/internal/reconciler/logparser/sync_test.go
@@ -44,7 +44,7 @@ func TestSuccessfulParserConfigMap(t *testing.T) {
 	require.NoError(t, err)
 
 	lp := &telemetryv1alpha1.LogParser{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "fooNs"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 		Spec: telemetryv1alpha1.LogParserSpec{Parser: `
 Format regex`},
 	}
@@ -60,4 +60,5 @@ Format regex`},
 	require.NoError(t, err)
 	expectedCMData := "[PARSER]\n    Name foo\n    Format regex\n\n"
 	require.Contains(t, cm.Data[parsersConfigMapKey], expectedCMData)
+	require.Len(t, cm.OwnerReferences, 1)
 }

--- a/internal/reconciler/logpipeline/sync_test.go
+++ b/internal/reconciler/logpipeline/sync_test.go
@@ -80,6 +80,7 @@ alias foo`,
 		require.Contains(t, sectionsCm.Data, "noop.conf")
 		require.Contains(t, sectionsCm.Data["noop.conf"], "foo")
 		require.Len(t, sectionsCm.OwnerReferences, 1)
+		require.Equal(t, pipeline.Name, sectionsCm.OwnerReferences[0].Name)
 	})
 
 	t.Run("should update section during subsequent sync", func(t *testing.T) {
@@ -201,6 +202,7 @@ alias foo`,
 		require.Contains(t, filesCm.Data, "js-script")
 		require.Contains(t, filesCm.Data["js-script"], "here comes some js code")
 		require.Len(t, filesCm.OwnerReferences, 1)
+		require.Equal(t, pipeline.Name, filesCm.OwnerReferences[0].Name)
 	})
 
 	t.Run("should update files during subsequent sync", func(t *testing.T) {
@@ -330,6 +332,7 @@ func TestSyncReferencedSecrets(t *testing.T) {
 		require.Contains(t, envSecret.Data, "HTTP_DEFAULT_CREDS_PASSWORD")
 		require.Equal(t, []byte("qwerty"), envSecret.Data["HTTP_DEFAULT_CREDS_PASSWORD"])
 		require.Len(t, envSecret.OwnerReferences, 1)
+		require.Equal(t, allPipelines.Items[0].Name, envSecret.OwnerReferences[0].Name)
 	})
 
 	t.Run("should update value in env secret during subsequent sync", func(t *testing.T) {

--- a/internal/reconciler/logpipeline/sync_test.go
+++ b/internal/reconciler/logpipeline/sync_test.go
@@ -54,6 +54,7 @@ func TestSyncSectionsConfigMap(t *testing.T) {
 				Namespace: sectionsCmName.Namespace,
 			},
 		}).Build()
+	require.NoError(t, telemetryv1alpha1.AddToScheme(fakeClient.Scheme()))
 
 	t.Run("should add section during first sync", func(t *testing.T) {
 		sut := syncer{fakeClient, Config{SectionsConfigMap: sectionsCmName}}
@@ -78,10 +79,12 @@ alias foo`,
 		require.NoError(t, err)
 		require.Contains(t, sectionsCm.Data, "noop.conf")
 		require.Contains(t, sectionsCm.Data["noop.conf"], "foo")
+		require.Len(t, sectionsCm.OwnerReferences, 1)
 	})
 
 	t.Run("should update section during subsequent sync", func(t *testing.T) {
 		sut := syncer{fakeClient, Config{SectionsConfigMap: sectionsCmName}}
+		require.NoError(t, telemetryv1alpha1.AddToScheme(fakeClient.Scheme()))
 
 		pipeline := &telemetryv1alpha1.LogPipeline{
 			ObjectMeta: metav1.ObjectMeta{
@@ -115,6 +118,7 @@ alias bar`
 
 	t.Run("should remove section if marked for deletion", func(t *testing.T) {
 		sut := syncer{fakeClient, Config{SectionsConfigMap: sectionsCmName}}
+		require.NoError(t, telemetryv1alpha1.AddToScheme(fakeClient.Scheme()))
 
 		pipeline := &telemetryv1alpha1.LogPipeline{
 			ObjectMeta: metav1.ObjectMeta{
@@ -196,6 +200,7 @@ alias foo`,
 		require.Contains(t, filesCm.Data["lua-script"], "here comes some lua code")
 		require.Contains(t, filesCm.Data, "js-script")
 		require.Contains(t, filesCm.Data["js-script"], "here comes some js code")
+		require.Len(t, filesCm.OwnerReferences, 1)
 	})
 
 	t.Run("should update files during subsequent sync", func(t *testing.T) {
@@ -324,6 +329,7 @@ func TestSyncReferencedSecrets(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, envSecret.Data, "HTTP_DEFAULT_CREDS_PASSWORD")
 		require.Equal(t, []byte("qwerty"), envSecret.Data["HTTP_DEFAULT_CREDS_PASSWORD"])
+		require.Len(t, envSecret.OwnerReferences, 1)
 	})
 
 	t.Run("should update value in env secret during subsequent sync", func(t *testing.T) {

--- a/internal/resources/fluentbit/resources.go
+++ b/internal/resources/fluentbit/resources.go
@@ -367,10 +367,10 @@ func MakeConfigMap(name types.NamespacedName) *corev1.ConfigMap {
 	}
 }
 
-func MakeDynamicParserConfigmap(name types.NamespacedName) *corev1.ConfigMap {
+func MakeParserConfigmap(name types.NamespacedName) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-parsers", name.Name),
+			Name:      name.Name,
 			Namespace: name.Namespace,
 			Labels:    labels(),
 		},
@@ -413,7 +413,7 @@ end
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-luascripts", name.Name),
+			Name:      name.Name,
 			Namespace: name.Namespace,
 			Labels:    labels(),
 		},

--- a/internal/resources/fluentbit/resources_test.go
+++ b/internal/resources/fluentbit/resources_test.go
@@ -125,12 +125,11 @@ func TestMakeConfigMap(t *testing.T) {
 }
 
 func TestMakeLuaConfigMap(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
+	name := types.NamespacedName{Name: "telemetry-fluent-bit-luascripts", Namespace: "telemetry-system"}
 	cm := MakeLuaConfigMap(name)
 
 	require.NotNil(t, cm)
-	require.NotEqual(t, cm.Name, name.Name)
-	require.Equal(t, cm.Name, name.Name+"-luascripts")
+	require.Equal(t, cm.Name, name.Name)
 	require.Equal(t, cm.Namespace, name.Namespace)
 	require.NotEmpty(t, cm.Data["filter-script.lua"])
 }

--- a/main.go
+++ b/main.go
@@ -419,6 +419,8 @@ func createLogPipelineReconciler(client client.Client) *telemetrycontrollers.Log
 	config := logpipelinereconciler.Config{
 		SectionsConfigMap: types.NamespacedName{Name: "telemetry-fluent-bit-sections", Namespace: telemetryNamespace},
 		FilesConfigMap:    types.NamespacedName{Name: "telemetry-fluent-bit-files", Namespace: telemetryNamespace},
+		LuaConfigMap:      types.NamespacedName{Name: "telemetry-fluent-bit-luascripts", Namespace: telemetryNamespace},
+		ParsersConfigMap:  types.NamespacedName{Name: "telemetry-fluent-bit-parsers", Namespace: telemetryNamespace},
 		EnvSecret:         types.NamespacedName{Name: "telemetry-fluent-bit-env", Namespace: telemetryNamespace},
 		DaemonSet:         types.NamespacedName{Name: fluentBitDaemonSet, Namespace: telemetryNamespace},
 		OverrideConfigMap: types.NamespacedName{Name: overrideConfigMapName, Namespace: telemetryNamespace},


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Include static Fluent Bit configuration into checksum calculation
- Add owner references to all created resources
- Remove unnecessary checks for changed resources
- Add missing watch to LogParser controller

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Preparations to fix https://github.com/kyma-project/kyma/issues/17611