### PR TITLE
Make excluded Fluent Bit container more specific

### DIFF
--- a/internal/resources/fluentbit/resources.go
+++ b/internal/resources/fluentbit/resources.go
@@ -316,7 +316,7 @@ func MakeConfigMap(name types.NamespacedName) *corev1.ConfigMap {
     Name tail
     Alias tele-tail
     Path /var/log/containers/*.log
-    Exclude_Path /var/log/containers/*-fluent-bit-*.log
+    Exclude_Path /var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log
     multiline.parser docker, cri, go, python, java
     Tag tele.*
     Mem_Buf_Limit 5MB


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Exclude only telemetry-fluent-bit DaemonSet from kyma-system namespace

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17611