### PR TITLE
Fix OTLP push URL for E2E tests

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -259,7 +259,6 @@ var _ = Describe("Metrics", func() {
 				builder.WithMetric(gauge)
 			}
 			Expect(sendMetrics(context.Background(), builder.Build(), urls.OTLPPush())).To(Succeed())
-			Expect(sendMetrics(context.Background(), builder.Build(), urls.OTLPPushAt(1))).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				resp, err := proxyClient.Get(urls.MockBackendExport())
@@ -338,9 +337,10 @@ func makeMetricsTestK8sObjects(namespace string, mockDeploymentNames ...string) 
 			metricPipeline.K8sObject(),
 		}...)
 
-		urls.SetOTLPPushAt(proxyClient.ProxyURLForService(mocksNamespace.Name(), mockBackend.Name(), "v1/metrics/", httpOTLPPort), i)
 		urls.SetMockBackendExportAt(proxyClient.ProxyURLForService(mocksNamespace.Name(), mockBackend.Name(), telemetryDataFilename, httpWebPort), i)
 	}
+
+	urls.SetOTLPPush(proxyClient.ProxyURLForService(kymaSystemNamespaceName, "telemetry-otlp-metrics", "v1/metrics/", httpOTLPPort))
 
 	// Kyma-system namespace objects.
 	metricGatewayExternalService := kitk8s.NewService("telemetry-otlp-metrics-external", kymaSystemNamespaceName).

--- a/test/e2e/testkit/mocks/urlprovider.go
+++ b/test/e2e/testkit/mocks/urlprovider.go
@@ -5,6 +5,7 @@ package mocks
 type URLProvider struct {
 	metrics   string
 	pipelines map[int]map[string]string
+	otlpPush  string
 }
 
 func NewURLProvider() *URLProvider {
@@ -23,25 +24,12 @@ func (p *URLProvider) Metrics() string {
 }
 
 func (p *URLProvider) SetOTLPPush(url string) *URLProvider {
-	return p.SetOTLPPushAt(url, 0)
-}
-
-func (p *URLProvider) OTLPPush() string {
-	return p.OTLPPushAt(0)
-}
-
-func (p *URLProvider) SetOTLPPushAt(url string, idx int) *URLProvider {
-	if p.pipelines[idx] == nil {
-		p.pipelines[idx] = map[string]string{}
-	}
-
-	p.pipelines[idx]["otlpPush"] = url
-
+	p.otlpPush = url
 	return p
 }
 
-func (p *URLProvider) OTLPPushAt(idx int) string {
-	return p.pipelines[idx]["otlpPush"]
+func (p *URLProvider) OTLPPush() string {
+	return p.otlpPush
 }
 
 func (p *URLProvider) SetMockBackendExport(url string) *URLProvider {

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -260,7 +260,6 @@ var _ = Describe("Tracing", func() {
 			traces := kittraces.MakeTraces(traceID, spanIDs, attrs)
 
 			Expect(sendTraces(context.Background(), traces, urls.OTLPPush())).To(Succeed())
-			Expect(sendTraces(context.Background(), traces, urls.OTLPPushAt(1))).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				resp, err := proxyClient.Get(urls.MockBackendExport())
@@ -343,9 +342,10 @@ func makeTracingTestK8sObjects(namespace string, mockDeploymentNames ...string) 
 			tracePipeline.K8sObject(),
 		}...)
 
-		urls.SetOTLPPushAt(proxyClient.ProxyURLForService(mocksNamespace.Name(), mockBackend.Name(), "v1/traces/", httpOTLPPort), i)
 		urls.SetMockBackendExportAt(proxyClient.ProxyURLForService(mocksNamespace.Name(), mockBackend.Name(), telemetryDataFilename, httpWebPort), i)
 	}
+
+	urls.SetOTLPPush(proxyClient.ProxyURLForService(kymaSystemNamespaceName, "telemetry-otlp-traces", "v1/traces/", httpOTLPPort))
 
 	// Kyma-system namespace objects.
 	traceGatewayExternalService := kitk8s.NewService("telemetry-otlp-traces-external", kymaSystemNamespaceName).


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Push metrics and traces to telemetry-otlp-* and not mock backend

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#85 