### PR TITLE
Downgrade Golang version to 1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY webhook/ webhook/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go mod tidy && go build -a -o manager main.go
 
 # Use the fluent-bit image because we need the fluent-bit binary
-FROM europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-52bb9772
+FROM europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-fef25e9c
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.5 as builder
+FROM golang:1.20.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/config/samples/http-mockserver.yaml
+++ b/config/samples/http-mockserver.yaml
@@ -37,7 +37,7 @@ spec:
             - -i http
             - -o stdout
             - -q
-          image: europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-52bb9772
+          image: europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-fef25e9c
           livenessProbe:
             tcpSocket:
               port: serviceport

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ var (
 const (
 	otelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.79.0-0065b2a5"
 	overrideConfigMapName  = "telemetry-override-config"
-	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-52bb9772"
+	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-fef25e9c"
 	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20230503-c10c571f"
 
 	fluentBitDaemonSet = "telemetry-fluent-bit"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,7 @@ module-name: telemetry-manager
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20230428-c64807e3
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.79.0-0065b2a5
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-52bb9772
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.4-fef25e9c
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20230308-ff6cf204
 whitesource:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Downgrade Golang version to 1.20.4 for telemetry-manager
- Use fluent-bit image with Golang version 1.20.4


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#220 