### PR TITLE
update otel collector clusterrole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -272,14 +280,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - networking.k8s.io

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -155,7 +155,7 @@ func (r *Reconciler) reconcileFluentBit(ctx context.Context, pipeline *telemetry
 		return fmt.Errorf("failed to create fluent bit service account: %w", err)
 	}
 
-	clusterRole := commonresources.MakeClusterRole(r.config.DaemonSet)
+	clusterRole := resources.MakeClusterRole(r.config.DaemonSet)
 	if err := controllerutil.SetOwnerReference(pipeline, clusterRole, r.Scheme()); err != nil {
 		return err
 	}

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -101,7 +101,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	if err = kubernetes.CreateOrUpdateServiceAccount(ctx, r, serviceAccount); err != nil {
 		return fmt.Errorf("failed to create otel collector service account: %w", err)
 	}
-	clusterRole := commonresources.MakeClusterRole(namespacedBaseName)
+	clusterRole := collectorresources.MakeClusterRole(namespacedBaseName)
 	if err = controllerutil.SetOwnerReference(pipeline, clusterRole, r.Scheme()); err != nil {
 		return err
 	}

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -117,7 +117,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	if err = kubernetes.CreateOrUpdateServiceAccount(ctx, r, serviceAccount); err != nil {
 		return fmt.Errorf("failed to create otel collector service account: %w", err)
 	}
-	clusterRole := commonresources.MakeClusterRole(namespacedBaseName)
+	clusterRole := collectorresources.MakeClusterRole(namespacedBaseName)
 	if err = controllerutil.SetOwnerReference(pipeline, clusterRole, r.Scheme()); err != nil {
 		return err
 	}

--- a/internal/resources/common/resources.go
+++ b/internal/resources/common/resources.go
@@ -32,14 +32,3 @@ func MakeClusterRoleBinding(name types.NamespacedName) *v1.ClusterRoleBinding {
 	}
 	return &clusterRoleBinding
 }
-
-func MakeClusterRole(name types.NamespacedName) *v1.ClusterRole {
-	clusterRole := v1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-		},
-		Rules: []v1.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"namespaces", "pods"}}},
-	}
-	return &clusterRole
-}

--- a/internal/resources/common/resources_test.go
+++ b/internal/resources/common/resources_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -17,25 +16,14 @@ func TestMakeServiceAccount(t *testing.T) {
 	require.Equal(t, svcAcc.Namespace, name.Namespace)
 }
 
-func TestMakeClusterRole(t *testing.T) {
-	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
-	clusterRole := MakeClusterRole(name)
-	expectedRules := []v1.PolicyRule{{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"namespaces", "pods"}}}
-
-	require.NotNil(t, clusterRole)
-	require.Equal(t, clusterRole.Name, name.Name)
-	require.Equal(t, clusterRole.Rules, expectedRules)
-}
-
 func TestMakeClusterRoleBinding(t *testing.T) {
 	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
 	clusterRoleBinding := MakeClusterRoleBinding(name)
 	svcAcc := MakeServiceAccount(name)
-	clusterRole := MakeClusterRole(name)
 
 	require.NotNil(t, clusterRoleBinding)
 	require.Equal(t, clusterRoleBinding.Name, name.Name)
-	require.Equal(t, clusterRoleBinding.RoleRef.Name, clusterRole.Name)
+	require.Equal(t, clusterRoleBinding.RoleRef.Name, name.Name)
 	require.Equal(t, clusterRoleBinding.RoleRef.Kind, "ClusterRole")
 	require.Equal(t, clusterRoleBinding.Subjects[0].Name, svcAcc.Name)
 	require.Equal(t, clusterRoleBinding.Subjects[0].Kind, "ServiceAccount")

--- a/internal/resources/fluentbit/resources.go
+++ b/internal/resources/fluentbit/resources.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -230,6 +231,23 @@ func MakeDaemonSet(name types.NamespacedName, checksum string, dsConfig DaemonSe
 			},
 		},
 	}
+}
+
+func MakeClusterRole(name types.NamespacedName) *rbacv1.ClusterRole {
+	clusterRole := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+	return &clusterRole
 }
 
 func MakeMetricsService(name types.NamespacedName) *corev1.Service {

--- a/internal/resources/fluentbit/resources_test.go
+++ b/internal/resources/fluentbit/resources_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -71,6 +72,22 @@ func TestMakeDaemonSet(t *testing.T) {
 
 	volMounts := daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts
 	require.True(t, reflect.DeepEqual(volMounts, expectedVolMounts))
+}
+
+func TestMakeClusterRole(t *testing.T) {
+	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
+	clusterRole := MakeClusterRole(name)
+	expectedRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+
+	require.NotNil(t, clusterRole)
+	require.Equal(t, clusterRole.Name, name.Name)
+	require.Equal(t, clusterRole.Rules, expectedRules)
 }
 
 func TestMakeMetricsService(t *testing.T) {

--- a/internal/resources/otelcollector/resources.go
+++ b/internal/resources/otelcollector/resources.go
@@ -5,6 +5,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -77,6 +78,28 @@ func MakeConfigMap(config Config, collectorConfig collectorconfig.Config) *corev
 			configMapKey: confYAML,
 		},
 	}
+}
+
+func MakeClusterRole(name types.NamespacedName) *rbacv1.ClusterRole {
+	clusterRole := rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+	return &clusterRole
 }
 
 func makePodAffinity(labels map[string]string) corev1.Affinity {

--- a/internal/resources/otelcollector/resources_test.go
+++ b/internal/resources/otelcollector/resources_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -43,6 +45,27 @@ func TestMakeSecret(t *testing.T) {
 
 	require.Equal(t, "otlpEndpoint", string(secret.Data["OTLP_ENDPOINT"]), "Secret must contain Otlp endpoint")
 	require.Equal(t, "basicAuthHeader", string(secret.Data["BASIC_AUTH_HEADER"]), "Secret must contain basic auth header")
+}
+
+func TestMakeClusterRole(t *testing.T) {
+	name := types.NamespacedName{Name: "telemetry-metric-gateway", Namespace: "telemetry-system"}
+	clusterRole := MakeClusterRole(name)
+	expectedRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"replicasets"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+
+	require.NotNil(t, clusterRole)
+	require.Equal(t, clusterRole.Name, name.Name)
+	require.Equal(t, clusterRole.Rules, expectedRules)
 }
 
 func TestMakeDeployment(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,namespace=system,resources=replicasets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
 
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- metric gateway and trace collector are logging the following error recently: 
  ```
  Failed to watch *v1.ReplicaSet: failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User "system:serviceaccount:kyma-system:telemetry-trace-collector" cannot list resource "replicasets" in API group "apps" at the cluster scope
  ```
- This reason is  https://github.com/open-telemetry/opentelemetry-helm-charts/issues/800
- This PR fixes the issue

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/telemetry-manager/issues/230
