### PR TITLE
Skip pending pipelines from collector config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -130,5 +130,9 @@ issues:
       path: test/e2e/metrics_test.go
     - linters: [ dupl ]
       path: test/e2e/tracing_test
+    - linters: [ dupl ]
+      path: internal/reconciler/tracepipeline/reconciler_test.go
+    - linters: [ dupl ]
+      path: internal/reconciler/metricpipeline/reconciler_test.go
     - linters: [ errcheck ]
       path: test/e2e/testkit/otlp/traces/traces.go

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -123,7 +123,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	}
 	deployablePipelines, err := getDeployableMetricPipelines(ctx, metricPipelineList.Items, r, lock)
 	if err != nil {
-		return fmt.Errorf("failed to fetch active metric pipelines: %w", err)
+		return fmt.Errorf("failed to fetch deployable metric pipelines: %w", err)
 	}
 	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, deployablePipelines)
 	if err != nil {
@@ -184,6 +184,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	return nil
 }
 
+// getDeployableTracePipelines returns the list of metric pipelines that are ready to be rendered into the otel collector configuration. A pipeline is deployable if it is not being deleted, all secret references exist, and is not above the pipeline limit.
 func getDeployableMetricPipelines(ctx context.Context, allPipelines []telemetryv1alpha1.MetricPipeline, client client.Client, lock *kubernetes.ResourceCountLock) ([]telemetryv1alpha1.MetricPipeline, error) {
 	var deployablePipelines []telemetryv1alpha1.MetricPipeline
 	for i := range allPipelines {

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -120,11 +120,11 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	if err = r.List(ctx, &metricPipelineList); err != nil {
 		return fmt.Errorf("failed to list metric pipelines: %w", err)
 	}
-	activePipelines, err := r.getActiveMetricPipelines(ctx, metricPipelineList.Items, lock)
+	deployablePipelines, err := r.getDeployableMetricPipelines(ctx, metricPipelineList.Items, lock)
 	if err != nil {
 		return fmt.Errorf("failed to fetch active metric pipelines: %w", err)
 	}
-	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, activePipelines)
+	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, deployablePipelines)
 	if err != nil {
 		return fmt.Errorf("failed to make otel collector config: %v", err)
 	}
@@ -183,16 +183,21 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	return nil
 }
 
-func (r *Reconciler) getActiveMetricPipelines(ctx context.Context, allPipelines []telemetryv1alpha1.MetricPipeline, lock *kubernetes.ResourceCountLock) ([]telemetryv1alpha1.MetricPipeline, error) {
-	var activePipelines []telemetryv1alpha1.MetricPipeline
+func (r *Reconciler) getDeployableMetricPipelines(ctx context.Context, allPipelines []telemetryv1alpha1.MetricPipeline, lock *kubernetes.ResourceCountLock) ([]telemetryv1alpha1.MetricPipeline, error) {
+	var deployablePipelines []telemetryv1alpha1.MetricPipeline
 	for i := range allPipelines {
-		active, err := lock.IsLockHolder(ctx, &allPipelines[i])
+		if !allPipelines[i].GetDeletionTimestamp().IsZero() {
+			continue
+		}
+
+		hasLock, err := lock.IsLockHolder(ctx, &allPipelines[i])
 		if err != nil {
 			return nil, err
 		}
-		if active {
-			activePipelines = append(activePipelines, allPipelines[i])
+
+		if hasLock {
+			deployablePipelines = append(deployablePipelines, allPipelines[i])
 		}
 	}
-	return activePipelines, nil
+	return deployablePipelines, nil
 }

--- a/internal/reconciler/metricpipeline/reconciler_test.go
+++ b/internal/reconciler/metricpipeline/reconciler_test.go
@@ -1,0 +1,164 @@
+package metricpipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/kubernetes"
+)
+
+var (
+	lockName = types.NamespacedName{
+		Name:      "lock",
+		Namespace: "default",
+	}
+
+	pipeline1 = telemetryv1alpha1.MetricPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-1",
+		},
+		Spec: telemetryv1alpha1.MetricPipelineSpec{
+			Output: telemetryv1alpha1.MetricPipelineOutput{
+				Otlp: &telemetryv1alpha1.OtlpOutput{
+					Endpoint: telemetryv1alpha1.ValueType{
+						Value: "http://localhost:4317",
+					},
+				},
+			},
+		},
+	}
+
+	pipeline2 = telemetryv1alpha1.MetricPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-2",
+		},
+		Spec: telemetryv1alpha1.MetricPipelineSpec{
+			Output: telemetryv1alpha1.MetricPipelineOutput{
+				Otlp: &telemetryv1alpha1.OtlpOutput{
+					Endpoint: telemetryv1alpha1.ValueType{
+						Value: "http://localhost:4317",
+					},
+				},
+			},
+		},
+	}
+
+	pipelineWithSecretRef = telemetryv1alpha1.MetricPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipelineWithSecretRef",
+		},
+		Spec: telemetryv1alpha1.MetricPipelineSpec{
+			Output: telemetryv1alpha1.MetricPipelineOutput{
+				Otlp: &telemetryv1alpha1.OtlpOutput{
+					Endpoint: telemetryv1alpha1.ValueType{
+						ValueFrom: &telemetryv1alpha1.ValueFromSource{
+							SecretKeyRef: &telemetryv1alpha1.SecretKeyRef{
+								Key:       "key",
+								Name:      "secret",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestGetDeployableMetricPipelines(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipeline1)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1}
+	deployablePipelines, err := getDeployableMetricPipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.Contains(t, deployablePipelines, pipeline1)
+}
+
+func TestMultipleGetDeployableMetricPipelines(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipeline1)
+	require.NoError(t, err)
+
+	err = l.TryAcquireLock(ctx, &pipeline2)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2}
+	deployablePipelines, err := getDeployableMetricPipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.Contains(t, deployablePipelines, pipeline1)
+	require.Contains(t, deployablePipelines, pipeline2)
+}
+
+func TestMultipleGetDeployableMetricPipelinesWithoutLock(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipeline1)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2}
+	deployablePipelines, err := getDeployableMetricPipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.Contains(t, deployablePipelines, pipeline1)
+	require.NotContains(t, deployablePipelines, pipeline2)
+}
+
+func TestGetDeployableMetricPipelinesWithMissingSecretReference(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipelineWithSecretRef)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.MetricPipeline{pipelineWithSecretRef}
+	deployablePipelines, err := getDeployableMetricPipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.NotContains(t, deployablePipelines, pipelineWithSecretRef)
+}
+
+func TestGetDeployableMetricPipelinesWithoutLock(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipelineWithSecretRef)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1}
+	deployablePipelines, err := getDeployableMetricPipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.NotContains(t, deployablePipelines, pipeline1)
+}

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -139,7 +139,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	}
 	deployablePipelines, err := getDeployableTracePipelines(ctx, tracePipelineList.Items, r, lock)
 	if err != nil {
-		return fmt.Errorf("failed to fetch active trace pipelines: %w", err)
+		return fmt.Errorf("failed to fetch deployable trace pipelines: %w", err)
 	}
 	collectorConfig, envVars, err := makeOtelCollectorConfig(ctx, r, deployablePipelines)
 	if err != nil {
@@ -208,6 +208,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	return nil
 }
 
+// getDeployableTracePipelines returns the list of trace pipelines that are ready to be rendered into the otel collector configuration. A pipeline is deployable if it is not being deleted, all secret references exist, and is not above the pipeline limit.
 func getDeployableTracePipelines(ctx context.Context, allPipelines []telemetryv1alpha1.TracePipeline, client client.Client, lock *kubernetes.ResourceCountLock) ([]telemetryv1alpha1.TracePipeline, error) {
 	var deployablePipelines []telemetryv1alpha1.TracePipeline
 	for i := range allPipelines {

--- a/internal/reconciler/tracepipeline/reconciler_test.go
+++ b/internal/reconciler/tracepipeline/reconciler_test.go
@@ -1,0 +1,164 @@
+package tracepipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/kubernetes"
+)
+
+var (
+	lockName = types.NamespacedName{
+		Name:      "lock",
+		Namespace: "default",
+	}
+
+	pipeline1 = telemetryv1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-1",
+		},
+		Spec: telemetryv1alpha1.TracePipelineSpec{
+			Output: telemetryv1alpha1.TracePipelineOutput{
+				Otlp: &telemetryv1alpha1.OtlpOutput{
+					Endpoint: telemetryv1alpha1.ValueType{
+						Value: "http://localhost:4317",
+					},
+				},
+			},
+		},
+	}
+
+	pipeline2 = telemetryv1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-2",
+		},
+		Spec: telemetryv1alpha1.TracePipelineSpec{
+			Output: telemetryv1alpha1.TracePipelineOutput{
+				Otlp: &telemetryv1alpha1.OtlpOutput{
+					Endpoint: telemetryv1alpha1.ValueType{
+						Value: "http://localhost:4317",
+					},
+				},
+			},
+		},
+	}
+
+	pipelineWithSecretRef = telemetryv1alpha1.TracePipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipelineWithSecretRef",
+		},
+		Spec: telemetryv1alpha1.TracePipelineSpec{
+			Output: telemetryv1alpha1.TracePipelineOutput{
+				Otlp: &telemetryv1alpha1.OtlpOutput{
+					Endpoint: telemetryv1alpha1.ValueType{
+						ValueFrom: &telemetryv1alpha1.ValueFromSource{
+							SecretKeyRef: &telemetryv1alpha1.SecretKeyRef{
+								Key:       "key",
+								Name:      "secret",
+								Namespace: "default",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestGetDeployableTracePipelines(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipeline1)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.TracePipeline{pipeline1}
+	deployablePipelines, err := getDeployableTracePipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.Contains(t, deployablePipelines, pipeline1)
+}
+
+func TestMultipleGetDeployableTracePipelines(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipeline1)
+	require.NoError(t, err)
+
+	err = l.TryAcquireLock(ctx, &pipeline2)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.TracePipeline{pipeline1, pipeline2}
+	deployablePipelines, err := getDeployableTracePipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.Contains(t, deployablePipelines, pipeline1)
+	require.Contains(t, deployablePipelines, pipeline2)
+}
+
+func TestMultipleGetDeployableTracePipelinesWithoutLock(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipeline1)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.TracePipeline{pipeline1, pipeline2}
+	deployablePipelines, err := getDeployableTracePipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.Contains(t, deployablePipelines, pipeline1)
+	require.NotContains(t, deployablePipelines, pipeline2)
+}
+
+func TestGetDeployableTracePipelinesWithMissingSecretReference(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipelineWithSecretRef)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.TracePipeline{pipelineWithSecretRef}
+	deployablePipelines, err := getDeployableTracePipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.NotContains(t, deployablePipelines, pipelineWithSecretRef)
+}
+
+func TestGetDeployableTracePipelinesWithoutLock(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = telemetryv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	l := kubernetes.NewResourceCountLock(fakeClient, lockName, 2)
+
+	err := l.TryAcquireLock(ctx, &pipelineWithSecretRef)
+	require.NoError(t, err)
+
+	pipelines := []telemetryv1alpha1.TracePipeline{pipeline1}
+	deployablePipelines, err := getDeployableTracePipelines(ctx, pipelines, fakeClient, l)
+	require.NoError(t, err)
+	require.NotContains(t, deployablePipelines, pipeline1)
+}

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -355,7 +355,7 @@ func metricPipelineShouldNotBeDeployed(pipelineName string) {
 		configString := collectorConfig.Data["relay.conf"]
 		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
 		return !strings.Contains(configString, pipelineAlias)
-	}, tracePipelineReconciliationTimeout, interval).Should(BeTrue())
+	}, metricPipelineReconciliationTimeout, interval).Should(BeTrue())
 }
 
 // makeMetricsTestK8sObjects returns the list of mandatory E2E test suite k8s objects.

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -154,6 +155,7 @@ var _ = Describe("Metrics", func() {
 		It("Should have only running pipelines", func() {
 			for pipelineName := range allPipelines {
 				metricPipelineShouldBeRunning(pipelineName)
+				metricPipelineShouldBeDeployed(pipelineName)
 			}
 		})
 
@@ -165,6 +167,7 @@ var _ = Describe("Metrics", func() {
 
 				Expect(kitk8s.CreateObjects(ctx, k8sClient, newPipeline...)).Should(Succeed())
 				metricPipelineShouldStayPending(newPipelineName)
+				metricPipelineShouldNotBeDeployed(newPipelineName)
 			})
 		})
 
@@ -331,6 +334,28 @@ func metricPipelineShouldStayPending(pipelineName string) {
 		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 		g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.MetricPipelineRunning)).To(BeFalse())
 	}, metricPipelineReconciliationTimeout, interval).Should(Succeed())
+}
+
+func metricPipelineShouldBeDeployed(pipelineName string) {
+	Eventually(func(g Gomega) bool {
+		var collectorConfig corev1.ConfigMap
+		key := types.NamespacedName{Name: "telemetry-metric-gateway", Namespace: "kyma-system"}
+		g.Expect(k8sClient.Get(ctx, key, &collectorConfig)).To(Succeed())
+		configString := collectorConfig.Data["relay.conf"]
+		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
+		return strings.Contains(configString, pipelineAlias)
+	}, timeout, interval).Should(BeTrue())
+}
+
+func metricPipelineShouldNotBeDeployed(pipelineName string) {
+	Consistently(func(g Gomega) bool {
+		var collectorConfig corev1.ConfigMap
+		key := types.NamespacedName{Name: "telemetry-metric-gateway", Namespace: "kyma-system"}
+		g.Expect(k8sClient.Get(ctx, key, &collectorConfig)).To(Succeed())
+		configString := collectorConfig.Data["relay.conf"]
+		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
+		return !strings.Contains(configString, pipelineAlias)
+	}, tracePipelineReconciliationTimeout, interval).Should(BeTrue())
 }
 
 // makeMetricsTestK8sObjects returns the list of mandatory E2E test suite k8s objects.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

TracePipelines and MetricPipelines that stay in Pending state because of the limited allowed number of pipelines may still be applied to the Otel Collector configuration as the reconciliation logic lists all pipelines. This PR excludes above the limit from the configuration by utilizing the lock mechanism.

Changes proposed in this pull request:

- Skip pending pipelines from collector config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/telemetry-manager/issues/239