### PR TITLE
Limit Fluent Bit to 300 retries

### DIFF
--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -102,7 +102,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
     name                     stdout
     match                    log-pipeline.*
     alias                    log-pipeline-stdout
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G`
 
 	var expectedSecret = make(map[string][]byte)

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -113,7 +113,7 @@ func TestMergeSectionsConfig(t *testing.T) {
     format                   json
     host                     localhost
     port                     443
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on
@@ -184,7 +184,7 @@ func TestMergeSectionsConfigCustomOutput(t *testing.T) {
     name                     stdout
     match                    foo.*
     alias                    foo-stdout
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G
 
 `

--- a/internal/fluentbit/config/builder/output_test.go
+++ b/internal/fluentbit/config/builder/output_test.go
@@ -13,7 +13,7 @@ func TestCreateOutputSectionWithCustomOutput(t *testing.T) {
     name                     null
     match                    foo.*
     alias                    foo-null
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G
 
 `
@@ -44,7 +44,7 @@ func TestCreateOutputSectionWithHTTPOutput(t *testing.T) {
     http_passwd              password
     http_user                user
     port                     1234
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on
@@ -85,7 +85,7 @@ func TestCreateOutputSectionWithHTTPOutputWithSecretReference(t *testing.T) {
     http_passwd              ${FOO_MY_NAMESPACE_SECRET_KEY}
     http_user                user
     port                     443
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on

--- a/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
+++ b/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
@@ -44,7 +44,7 @@
     format                   json
     host                     127.0.0.1
     port                     443
-    retry_limit              no_limits
+    retry_limit              300
     storage.total_limit_size 1G
     tls                      on
     tls.verify               on


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

In rare situation, Fluent Bit kept retrying malformed logs forever and thus block capacity of the file system buffer. To drop these records after a sufficient time, the retry count is limit to 300 by this PR.

Changes proposed in this pull request:

- Limit Fluent Bit to 300 retries

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/17662