### PR TITLE
Fix installation guide typo

### DIFF
--- a/docs/contributor/installation.md
+++ b/docs/contributor/installation.md
@@ -33,17 +33,18 @@ kubectl apply -f https://github.com/kyma-project/telemetry-manager/releases/late
 
 ## Install Telemetry Manager in your cluster from latest release using the Lifecycle manager
 
-1. Install the Lifecycle manager:
+1. Ensure that you have the [Kyma CLI](https://kyma-project.io/docs/kyma/latest/04-operation-guides/operations/01-install-kyma-CLI/) installed.
+
+2. Install the Lifecycle manager:
 
 ```shell
-make kyma
 kyma alpha deploy
 ```
 
-2. Install the ModuleTemplate and activate the component:
+3. Install the ModuleTemplate and activate the component:
 ```shell
 kubectl apply -f https://github.com/kyma-project/telemetry-manager/releases/latest/download/template.yaml
 kyma alpha enable module telemetry --channel fast
 ```
 
-3. Verify that a `telemetry-operator` Pod starts up in the `kyma-system` Namespace.
+4. Verify that a `telemetry-operator` Pod starts up in the `kyma-system` Namespace.

--- a/docs/contributor/installation.md
+++ b/docs/contributor/installation.md
@@ -42,7 +42,7 @@ kyma alpha deploy
 
 2. Install the ModuleTemplate and activate the component:
 ```shell
-kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/template.yaml
+kubectl apply -f https://github.com/kyma-project/telemetry-manager/releases/latest/download/template.yaml
 kyma alpha enable module telemetry
 ```
 

--- a/docs/contributor/installation.md
+++ b/docs/contributor/installation.md
@@ -43,7 +43,7 @@ kyma alpha deploy
 2. Install the ModuleTemplate and activate the component:
 ```shell
 kubectl apply -f https://github.com/kyma-project/telemetry-manager/releases/latest/download/template.yaml
-kyma alpha enable module telemetry
+kyma alpha enable module telemetry --channel fast
 ```
 
 3. Verify that a `telemetry-operator` Pod starts up in the `kyma-system` Namespace.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

For the `Install Telemetry Manager in your cluster from latest release using the Lifecycle manager` section in the docs:
  - Fix the typo of referencing the latest module template from the btp-manager repo
  - Add the missing channel flag in the enable module command
  - Reference the Kyma CLI installation link instead of using the kyma make target

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
