### PR TITLE
Create Kustomize development variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/development | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/development | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Release Module
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 - bases/telemetry.kyma-project.io_logpipelines.yaml
 - bases/telemetry.kyma-project.io_logparsers.yaml
 - bases/telemetry.kyma-project.io_tracepipelines.yaml
-- bases/telemetry.kyma-project.io_metricpipelines.yaml
 - bases/operator.kyma-project.io_telemetries.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 

--- a/config/development/crd/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/development/crd/telemetry.kyma-project.io_metricpipelines.yaml
@@ -1,0 +1,224 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: metricpipelines.telemetry.kyma-project.io
+spec:
+  group: telemetry.kyma-project.io
+  names:
+    kind: MetricPipeline
+    listKind: MetricPipelineList
+    plural: metricpipelines
+    singular: metricpipeline
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1].type
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MetricPipeline is the Schema for the metricpipelines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired characteristics of MetricPipeline.
+            properties:
+              input:
+                description: Configures different inputs to send additional metrics
+                  to the metric gateway.
+                properties:
+                  application:
+                    description: Configures application related scraping.
+                    properties:
+                      runtime:
+                        description: Configures runtime scraping (workload-related
+                          k8s ).
+                        properties:
+                          enabled:
+                            description: Indicates if runtime scraping is enabled.
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+              output:
+                description: Configures the metric gateway.
+                properties:
+                  otlp:
+                    description: Defines an output using the OpenTelemetry protocol.
+                    properties:
+                      authentication:
+                        description: Defines authentication options for the OTLP output
+                        properties:
+                          basic:
+                            description: Activates `Basic` authentication for the
+                              destination providing relevant Secrets.
+                            properties:
+                              password:
+                                description: Contains the basic auth password or a
+                                  Secret reference.
+                                properties:
+                                  value:
+                                    description: Value that can contain references
+                                      to Secret values.
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        description: Refers to a key in a Secret.
+                                          You must provide `name` and `namespace`
+                                          of the Secret, as well as the name of the
+                                          `key`.
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              user:
+                                description: Contains the basic auth username or a
+                                  Secret reference.
+                                properties:
+                                  value:
+                                    description: Value that can contain references
+                                      to Secret values.
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        description: Refers to a key in a Secret.
+                                          You must provide `name` and `namespace`
+                                          of the Secret, as well as the name of the
+                                          `key`.
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                            required:
+                            - password
+                            - user
+                            type: object
+                        type: object
+                      endpoint:
+                        description: Defines the host and port (<host>:<port>) of
+                          an OTLP endpoint.
+                        properties:
+                          value:
+                            description: Value that can contain references to Secret
+                              values.
+                            type: string
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                description: Refers to a key in a Secret. You must
+                                  provide `name` and `namespace` of the Secret, as
+                                  well as the name of the `key`.
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        description: Defines custom headers to be added to outgoing
+                          HTTP or GRPC requests.
+                        items:
+                          properties:
+                            name:
+                              description: Defines the header name.
+                              type: string
+                            value:
+                              description: Value that can contain references to Secret
+                                values.
+                              type: string
+                            valueFrom:
+                              properties:
+                                secretKeyRef:
+                                  description: Refers to a key in a Secret. You must
+                                    provide `name` and `namespace` of the Secret,
+                                    as well as the name of the `key`.
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      protocol:
+                        default: grpc
+                        description: Defines the OTLP protocol (http or grpc). Default
+                          is GRPC.
+                        enum:
+                        - grpc
+                        - http
+                        minLength: 1
+                        type: string
+                    required:
+                    - endpoint
+                    type: object
+                required:
+                - otlp
+                type: object
+            type: object
+          status:
+            description: Represents the current information/status of MetricPipeline.
+            properties:
+              conditions:
+                description: Defines the trail of MetricPipeline conditions.
+                items:
+                  description: Contains details for the current condition of this
+                    MetricPipeline.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    reason:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/development/kustomization.yaml
+++ b/config/development/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../default
+- crd/telemetry.kyma-project.io_metricpipelines.yaml
+patches:
+  - path: manager_deployment_patch.yaml

--- a/config/development/manager_deployment_patch.yaml
+++ b/config/development/manager_deployment_patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-operator
+  namespace: kyma-system
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --enable-metrics=true
+        - --cert-dir=/tmp
+        - --fluent-bit-cpu-request=100m
+        - --fluent-bit-memory-request=50Mi
+        - --fluent-bit-denied-filter-plugins=kubernetes,rewrite_tag,multiline
+        - --trace-collector-cpu-limit=1
+        - --trace-collector-memory-limit=1Gi
+        - --trace-collector-cpu-request=25m
+        - --trace-collector-memory-request=32Mi
+        - --validating-webhook-enabled=true
+        - --manager-namespace=$(MY_POD_NAMESPACE)
+        - --trace-collector-priority-class=telemetry-priority-class
+        - --fluent-bit-priority-class-name=telemetry-priority-class-high
+        - --metric-gateway-priority-class=telemetry-priority-class
+        name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
       - command:
         - /manager
         args:
+        - --enable-metrics=false
         - --cert-dir=/tmp
         - --fluent-bit-cpu-request=100m
         - --fluent-bit-memory-request=50Mi
@@ -43,7 +44,6 @@ spec:
         - --manager-namespace=$(MY_POD_NAMESPACE)
         - --trace-collector-priority-class=telemetry-priority-class
         - --fluent-bit-priority-class-name=telemetry-priority-class-high
-        - --metric-gateway-priority-class=telemetry-priority-class
         image: controller:latest
         name: manager
         securityContext:

--- a/hack/deploy-module.sh
+++ b/hack/deploy-module.sh
@@ -14,6 +14,7 @@ function build_and_push_manager_image() {
 function create_module() {
     export IMG=k3d-${REGISTRY_NAME}:${REGISTRY_PORT}/${MODULE_NAME}-manager
     cd config/manager && ${KUSTOMIZE} edit set image controller=${IMG} && cd ../..
+    # create module command uses Kustomization files defined in "config/default"
     ${KYMA} alpha create module --name kyma-project.io/module/${MODULE_NAME} --version ${MODULE_VERSION} --channel ${MODULE_CHANNEL} --default-cr ${MODULE_CR_PATH} --registry ${MODULE_REGISTRY} --insecure --ci
 }
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -5,6 +5,7 @@ readonly GCP_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
 
 function create_module() {
     cd config/manager && ${KUSTOMIZE} edit set image controller=${IMG} && cd ../..
+    # create module command uses Kustomization files defined in "config/default"
     ${KYMA} alpha create module --name kyma-project.io/module/${MODULE_NAME} --version ${MODULE_VERSION} --channel ${MODULE_CHANNEL} --default-cr ${MODULE_CR_PATH} --registry ${MODULE_REGISTRY} -c oauth2accesstoken:${GCP_ACCESS_TOKEN} --ci
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Create Kustomize development variant to allow excluding development features from releases. Default variant will be treated as a production variant since `create module` command from the Kyma cli uses the default variant for building manifests: https://github.com/kyma-project/cli/blob/main/pkg/module/kubebuilder/project.go#L22
- Currently, `Metricpipeline` CRD will only be included in the development variant and the metrics feature will be disabled in the default variant by setting the `enable-metrics` flag to false.
- `deploy` and `undeploy` targets will be using the development variant when building the manifests. Thus, e2e-test and upgrade-test will run against the development variant.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#259