### PR TITLE
Introduce make targets to run e2e tests per signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,6 @@ e2e-test: ginkgo k3d test-matchers ## Provision k3d cluster and run end-to-end t
 	$(GINKGO) run --tags e2e -v --junit-report=junit.xml ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
-	$(K3D) cluster delete kyma
-	$(K3D) registry delete k3d-kyma-registry
 
 .PHONY: e2e-test-logging
 e2e-test-logging: ginkgo k3d test-matchers-logging ## Provision k3d cluster and run end-to-end tests.
@@ -122,8 +120,6 @@ e2e-test-logging: ginkgo k3d test-matchers-logging ## Provision k3d cluster and 
 	$(GINKGO) run --tags e2e -v --junit-report=junit.xml --label-filter="logging" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
-	$(K3D) cluster delete kyma
-	$(K3D) registry delete k3d-kyma-registry
 
 .PHONY: e2e-test-tracing
 e2e-test-tracing: ginkgo k3d test-matchers-tracing ## Provision k3d cluster and run end-to-end tests.
@@ -131,8 +127,6 @@ e2e-test-tracing: ginkgo k3d test-matchers-tracing ## Provision k3d cluster and 
 	$(GINKGO) run --tags e2e -v --junit-report=junit.xml --label-filter="tracing" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
-	$(K3D) cluster delete kyma
-	$(K3D) registry delete k3d-kyma-registry
 
 .PHONY: e2e-test-metrics
 e2e-test-metrics: ginkgo k3d test-matchers-metrics ## Provision k3d cluster and run end-to-end tests.
@@ -140,14 +134,10 @@ e2e-test-metrics: ginkgo k3d test-matchers-metrics ## Provision k3d cluster and 
 	$(GINKGO) run --tags e2e -v --junit-report=junit.xml --label-filter="metrics" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
-	$(K3D) cluster delete kyma
-	$(K3D) registry delete k3d-kyma-registry
 
 .PHONY: upgrade-test
 upgrade-test: ginkgo k3d test-matchers ## Provision k3d cluster and run upgrade tests.
 	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/upgrade-test.sh
-	$(K3D) cluster delete kyma
-	$(K3D) registry delete k3d-kyma-registry
 
 .PHONY: e2e-deploy-module
 e2e-deploy-module: kyma kustomize ## Provision a k3d cluster and deploy module with the lifecycle manager. Manager image and module image are pushed to local k3d registry

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,46 @@ test: manifests generate fmt vet tidy envtest ## Run tests.
 test-matchers: ginkgo
 	$(GINKGO) run --tags e2e -v ./test/e2e/testkit/matchers
 
+test-matchers-logging: ginkgo
+	$(GINKGO) run --tags e2e -v --label-filter="logging" ./test/e2e/testkit/matchers
+
+test-matchers-tracing: ginkgo
+	$(GINKGO) run --tags e2e -v --label-filter="tracing" ./test/e2e/testkit/matchers
+
+test-matchers-metrics: ginkgo
+	$(GINKGO) run --tags e2e -v --label-filter="metrics" ./test/e2e/testkit/matchers
+
 .PHONY: e2e-test
 e2e-test: ginkgo k3d test-matchers ## Provision k3d cluster and run end-to-end tests.
 	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/provision-test-env.sh
 	$(GINKGO) run --tags e2e -v --junit-report=junit.xml ./test/e2e
+	mkdir -p ${ARTIFACTS}
+	mv junit.xml ${ARTIFACTS}
+	$(K3D) cluster delete kyma
+	$(K3D) registry delete k3d-kyma-registry
+
+.PHONY: e2e-test-logging
+e2e-test-logging: ginkgo k3d test-matchers-logging ## Provision k3d cluster and run end-to-end tests.
+	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/provision-test-env.sh
+	$(GINKGO) run --tags e2e -v --junit-report=junit.xml --label-filter="logging" ./test/e2e
+	mkdir -p ${ARTIFACTS}
+	mv junit.xml ${ARTIFACTS}
+	$(K3D) cluster delete kyma
+	$(K3D) registry delete k3d-kyma-registry
+
+.PHONY: e2e-test-tracing
+e2e-test-tracing: ginkgo k3d test-matchers-tracing ## Provision k3d cluster and run end-to-end tests.
+	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/provision-test-env.sh
+	$(GINKGO) run --tags e2e -v --junit-report=junit.xml --label-filter="tracing" ./test/e2e
+	mkdir -p ${ARTIFACTS}
+	mv junit.xml ${ARTIFACTS}
+	$(K3D) cluster delete kyma
+	$(K3D) registry delete k3d-kyma-registry
+
+.PHONY: e2e-test-metrics
+e2e-test-metrics: ginkgo k3d test-matchers-metrics ## Provision k3d cluster and run end-to-end tests.
+	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/provision-test-env.sh
+	$(GINKGO) run --tags e2e -v --junit-report=junit.xml --label-filter="metrics" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 	$(K3D) cluster delete kyma

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: k3d-kyma-registry:5000/telemetry-manager
-  newTag: latest
+  newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
+  newTag: v20230622-dd7e6d85

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: v20230622-dd7e6d85
+  newName: k3d-kyma-registry:5000/telemetry-manager
+  newTag: latest

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -32,7 +32,7 @@ var (
 	telemetryFluentbitMetricServiceName = "telemetry-fluent-bit-metrics"
 )
 
-var _ = Describe("Logging", func() {
+var _ = Describe("Logging", Label("logging"), func() {
 	Context("When a logpipeline exists", Ordered, func() {
 		var (
 			urls               *mocks.URLProvider

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Telemetry-manager", func() {
+var _ = Describe("Telemetry-manager", Label("logging", "tracing", "metrics"), func() {
 	Context("After deploying manifest", func() {
 		It("Should have kyma-system namespace", func() {
 			var namespace corev1.Namespace

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -34,7 +34,7 @@ var (
 	metricPipelineReconciliationTimeout = 10 * time.Second
 )
 
-var _ = Describe("Metrics", func() {
+var _ = Describe("Metrics", Label("metrics"), func() {
 	Context("When a metricpipeline exists", Ordered, func() {
 		var (
 			pipelines          *kyma.PipelineList

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -25,7 +25,7 @@ var (
 	}
 )
 
-var _ = Describe("Telemetry-module", Ordered, func() {
+var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ordered, func() {
 	Context("After creating Telemetry resources", Ordered, func() {
 		It("Should have ValidatingWebhookConfiguration", func() {
 			Eventually(func(g Gomega) {

--- a/test/e2e/testkit/matchers/log_matchers_test.go
+++ b/test/e2e/testkit/matchers/log_matchers_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ConsistOfNumberOfLogs", func() {
+var _ = Describe("ConsistOfNumberOfLogs", Label("logging"), func() {
 	var fileBytes []byte
 
 	Context("with nil input", func() {
@@ -54,7 +54,7 @@ var _ = Describe("ConsistOfNumberOfLogs", func() {
 
 })
 
-var _ = Describe("ContainLogs", func() {
+var _ = Describe("ContainLogs", Label("logging"), func() {
 	var fileBytes []byte
 
 	Context("with nil input", func() {
@@ -98,7 +98,7 @@ var _ = Describe("ContainLogs", func() {
 	})
 })
 
-var _ = Describe("ContainsLogsWith", func() {
+var _ = Describe("ContainsLogsWith", Label("logging"), func() {
 	var fileBytes []byte
 
 	Context("with nil input", func() {

--- a/test/e2e/testkit/matchers/metric_matchers_test.go
+++ b/test/e2e/testkit/matchers/metric_matchers_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("HaveGauges", func() {
+var _ = Describe("HaveGauges", Label("metrics"), func() {
 	var fileBytes []byte
 	var expectedMetrics []pmetric.Metric
 
@@ -110,7 +110,7 @@ var _ = Describe("HaveGauges", func() {
 	})
 })
 
-var _ = Describe("HaveNumberOfMetrics", func() {
+var _ = Describe("HaveNumberOfMetrics", Label("metrics"), func() {
 	Context("with nil input", func() {
 		It("should match 0", func() {
 			success, err := HaveNumberOfMetrics(0).Match(nil)

--- a/test/e2e/testkit/matchers/prometheus_matcher_test.go
+++ b/test/e2e/testkit/matchers/prometheus_matcher_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("HasValidPrometheusMetric", func() {
+var _ = Describe("HasValidPrometheusMetric", Label("metrics"), func() {
 	var fileBytes []byte
 
 	Context("with nil input", func() {

--- a/test/e2e/testkit/matchers/trace_matchers_test.go
+++ b/test/e2e/testkit/matchers/trace_matchers_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ConsistOfSpansWithIDs", func() {
+var _ = Describe("ConsistOfSpansWithIDs", Label("tracing"), func() {
 	var fileBytes []byte
 	var expectedSpansWithIDs []pcommon.SpanID
 
@@ -90,7 +90,7 @@ var _ = Describe("ConsistOfSpansWithIDs", func() {
 	})
 })
 
-var _ = Describe("ConsistOfSpansWithTraceID", func() {
+var _ = Describe("ConsistOfSpansWithTraceID", Label("tracing"), func() {
 	var fileBytes []byte
 	var expectedTraceID pcommon.TraceID
 
@@ -171,7 +171,7 @@ var _ = Describe("ConsistOfSpansWithTraceID", func() {
 	})
 })
 
-var _ = Describe("ConsistOfSpansWithAttributes", func() {
+var _ = Describe("ConsistOfSpansWithAttributes", Label("tracing"), func() {
 	var fileBytes []byte
 	var expectedAttrs pcommon.Map
 
@@ -255,7 +255,7 @@ var _ = Describe("ConsistOfSpansWithAttributes", func() {
 	})
 })
 
-var _ = Describe("ConsistOfNumberOfSpans", func() {
+var _ = Describe("ConsistOfNumberOfSpans", Label("tracing"), func() {
 	var fileBytes []byte
 
 	Context("with nil input", func() {

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -37,7 +37,7 @@ var (
 	tracePipelineReconciliationTimeout = 10 * time.Second
 )
 
-var _ = Describe("Tracing", func() {
+var _ = Describe("Tracing", Label("tracing"), func() {
 	Context("When a tracepipeline exists", Ordered, func() {
 		var (
 			pipelines          *kyma.PipelineList


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Adding more test-cases to the e2e-test suite make the test runs to take more time and also increased flakiness. This PR adds make targets to run the tests for a specific signal with the goal to improve the development workflow and have separate pipelines in future.

Changes proposed in this pull request:

- Introduce make targets to run e2e tests per signal

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
