### PR TITLE
Fix otel-collector crash due to missing secret ref

### DIFF
--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -112,6 +112,9 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	if err != nil {
 		return fmt.Errorf("failed to fetch deployable metric pipelines: %w", err)
 	}
+	if len(deployablePipelines) == 0 {
+		return fmt.Errorf("no trace metric ready for deployment")
+	}
 
 	if err = r.reconcileMetricGateway(ctx, pipeline, deployablePipelines); err != nil {
 		return fmt.Errorf("failed to reconcile metric gateway: %w", err)

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -113,7 +113,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 		return fmt.Errorf("failed to fetch deployable metric pipelines: %w", err)
 	}
 	if len(deployablePipelines) == 0 {
-		return fmt.Errorf("no trace metric ready for deployment")
+		return fmt.Errorf("no metric pipeline ready for deployment")
 	}
 
 	if err = r.reconcileMetricGateway(ctx, pipeline, deployablePipelines); err != nil {

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -125,6 +125,9 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	if err != nil {
 		return fmt.Errorf("failed to fetch deployable trace pipelines: %w", err)
 	}
+	if len(deployablePipelines) == 0 {
+		return fmt.Errorf("no trace pipeline ready for deployment")
+	}
 
 	if err = r.reconcileTraceGateway(ctx, pipeline, deployablePipelines); err != nil {
 		return fmt.Errorf("failed to reconcile trace gateway: %w", err)

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -134,6 +134,39 @@ var _ = Describe("Metrics", Label("metrics"), func() {
 
 	})
 
+	Context("When metricpipeline with missing secret reference exists", Ordered, func() {
+		hostSecret := kitk8s.NewOpaqueSecret("metric-rcv-hostname", defaultNamespaceName, kitk8s.WithStringData("metric-host", "http://localhost:4317"))
+		metricPipeline := kitmetric.NewPipeline("without-secret", hostSecret.SecretKeyRef("metric-host"))
+
+		BeforeAll(func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipeline.K8sObject())).Should(Succeed())
+
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, metricPipeline.K8sObject(), hostSecret.K8sObject())).Should(Succeed())
+			})
+		})
+
+		It("Should have pending metricpipeline", func() {
+			metricPipelineShouldStayPending(metricPipeline.Name())
+		})
+
+		It("Should not have metric-gateway deployment", func() {
+			Consistently(func(g Gomega) {
+				var deployment appsv1.Deployment
+				key := types.NamespacedName{Name: "telemetry-metric-gateway", Namespace: "kyma-system"}
+				g.Expect(k8sClient.Get(ctx, key, &deployment)).To(Succeed())
+			}, metricPipelineReconciliationTimeout, interval).ShouldNot(Succeed())
+		})
+
+		It("Should have running metricpipeline", func() {
+			By("Creating missing secret", func() {
+				Expect(kitk8s.CreateObjects(ctx, k8sClient, hostSecret.K8sObject())).Should(Succeed())
+			})
+
+			metricPipelineShouldBeRunning(metricPipeline.Name())
+		})
+	})
+
 	Context("When reaching the pipeline limit", Ordered, func() {
 		pipelinesObjects := make(map[string][]client.Object, 0)
 		pipelines := kyma.NewPipelineList()


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

The telemetry-operator created an OpenTelemetry Collector deployment if only one TracePipeline or MetricPipeline existed that had a missing secret reference. This caused to a crashing Collector since no exporter was configured. This PR changes the TracePipeline and MetricPipeline controller to reconcile the related Kubernetes objects online if at least one pipeline is ready for deployment.

Changes proposed in this pull request:

- Reconcile Kubernetes objects only if at least one pipeline is ready for deployment

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes: https://github.com/kyma-project/telemetry-manager/issues/272

Related issues:

## Traceability

- [x] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [ ] No, because unit tests are not needed.
- [x] No, because it is more sufficient to cover by e2e-tests since K8s object creation should be under test

The feature is e2e-tested:

- [x] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [x] My code follows the style guidelines of this project.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [x] This PR adds value and shows no feature creep.
- [x] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
