### PR TITLE
Refine otlpexporter package API

### DIFF
--- a/internal/otelcollector/config/builder/common/config_base_exporters.go
+++ b/internal/otelcollector/config/builder/common/config_base_exporters.go
@@ -1,10 +1,5 @@
 package common
 
-type BaseGatewayExporterConfig struct {
-	*OTLPExporterConfig    `yaml:",inline,omitempty"`
-	*LoggingExporterConfig `yaml:",inline,omitempty"`
-}
-
 type OTLPExporterConfig struct {
 	Endpoint       string               `yaml:"endpoint,omitempty"`
 	Headers        map[string]string    `yaml:"headers,omitempty"`

--- a/internal/otelcollector/config/builder/common/config_base_exporters.go
+++ b/internal/otelcollector/config/builder/common/config_base_exporters.go
@@ -27,3 +27,7 @@ type RetryOnFailureConfig struct {
 type LoggingExporterConfig struct {
 	Verbosity string `yaml:"verbosity"`
 }
+
+func DefaultLoggingExporterConfig() *LoggingExporterConfig {
+	return &LoggingExporterConfig{Verbosity: "basic"}
+}

--- a/internal/otelcollector/config/builder/common/otlpexporter/config_builder.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/config_builder.go
@@ -1,12 +1,12 @@
 package otlpexporter
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"context"
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/common"
 )

--- a/internal/otelcollector/config/builder/common/otlpexporter/config_builder.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/config_builder.go
@@ -1,4 +1,4 @@
-package otlpoutput
+package otlpexporter
 
 import (
 	"context"

--- a/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 )
 
-func TestGetOutputTypeHttp(t *testing.T) {
+func TestExporterIDHTTP(t *testing.T) {
 	output := &v1alpha1.OtlpOutput{
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 		Protocol: "http",
@@ -19,7 +19,7 @@ func TestGetOutputTypeHttp(t *testing.T) {
 	require.Equal(t, "otlphttp/test", ExporterID(output, "test"))
 }
 
-func TestGetOutputTypeOtlp(t *testing.T) {
+func TestExporterIDGRPC(t *testing.T) {
 	output := &v1alpha1.OtlpOutput{
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 		Protocol: "grpc",
@@ -28,7 +28,7 @@ func TestGetOutputTypeOtlp(t *testing.T) {
 	require.Equal(t, "otlp/test", ExporterID(output, "test"))
 }
 
-func TestGetOutputTypeDefault(t *testing.T) {
+func TestExorterIDDefault(t *testing.T) {
 	output := &v1alpha1.OtlpOutput{
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
@@ -36,7 +36,7 @@ func TestGetOutputTypeDefault(t *testing.T) {
 	require.Equal(t, "otlp/test", ExporterID(output, "test"))
 }
 
-func TestMakeExporterConfig(t *testing.T) {
+func TestMakeConfig(t *testing.T) {
 	output := &v1alpha1.OtlpOutput{
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}

--- a/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
@@ -41,16 +41,13 @@ func TestMakeExporterConfig(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	exporterConfig, envVars, err := MakeExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
-	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
 
 	require.NotNil(t, envVars["OTLP_ENDPOINT_TEST"])
 	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte("otlp-endpoint"))
-
-	require.Contains(t, exporterConfig, "otlp/test")
-	otlpExporterConfig := exporterConfig["otlp/test"]
 
 	require.Equal(t, "${OTLP_ENDPOINT_TEST}", otlpExporterConfig.Endpoint)
 	require.True(t, otlpExporterConfig.SendingQueue.Enabled)
@@ -60,11 +57,6 @@ func TestMakeExporterConfig(t *testing.T) {
 	require.Equal(t, "5s", otlpExporterConfig.RetryOnFailure.InitialInterval)
 	require.Equal(t, "30s", otlpExporterConfig.RetryOnFailure.MaxInterval)
 	require.Equal(t, "300s", otlpExporterConfig.RetryOnFailure.MaxElapsedTime)
-
-	require.Contains(t, exporterConfig, "logging/test")
-	loggingExporterConfig := exporterConfig["logging/test"]
-
-	require.Equal(t, "basic", loggingExporterConfig.Verbosity)
 }
 
 func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
@@ -81,13 +73,11 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 		Headers:  headers,
 	}
 
-	exporterConfig, envVars, err := MakeExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
-	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
 
-	require.Contains(t, exporterConfig, "otlp/test")
-	otlpExporterConfig := exporterConfig["otlp/test"]
 	require.Equal(t, 1, len(otlpExporterConfig.Headers))
 	require.Equal(t, "${HEADER_TEST_AUTHORIZATION}", otlpExporterConfig.Headers["Authorization"])
 }

--- a/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
@@ -1,4 +1,4 @@
-package otlpoutput
+package otlpexporter
 
 import (
 	"context"

--- a/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/config_builder_test.go
@@ -16,7 +16,7 @@ func TestGetOutputTypeHttp(t *testing.T) {
 		Protocol: "http",
 	}
 
-	require.Equal(t, "otlphttp/test", getOTLPOutputAlias(output, "test"))
+	require.Equal(t, "otlphttp/test", ExporterID(output, "test"))
 }
 
 func TestGetOutputTypeOtlp(t *testing.T) {
@@ -25,7 +25,7 @@ func TestGetOutputTypeOtlp(t *testing.T) {
 		Protocol: "grpc",
 	}
 
-	require.Equal(t, "otlp/test", getOTLPOutputAlias(output, "test"))
+	require.Equal(t, "otlp/test", ExporterID(output, "test"))
 }
 
 func TestGetOutputTypeDefault(t *testing.T) {
@@ -33,7 +33,7 @@ func TestGetOutputTypeDefault(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	require.Equal(t, "otlp/test", getOTLPOutputAlias(output, "test"))
+	require.Equal(t, "otlp/test", ExporterID(output, "test"))
 }
 
 func TestMakeExporterConfig(t *testing.T) {
@@ -41,7 +41,7 @@ func TestMakeExporterConfig(t *testing.T) {
 		Endpoint: v1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	exporterConfig, envVars, err := MakeExportersConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test", 512)
+	exporterConfig, envVars, err := MakeExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test", 512)
 	require.NoError(t, err)
 	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)
@@ -81,7 +81,7 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 		Headers:  headers,
 	}
 
-	exporterConfig, envVars, err := MakeExportersConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test", 512)
+	exporterConfig, envVars, err := MakeExporterConfig(context.Background(), fake.NewClientBuilder().Build(), output, "test", 512)
 	require.NoError(t, err)
 	require.NotNil(t, exporterConfig)
 	require.NotNil(t, envVars)

--- a/internal/otelcollector/config/builder/common/otlpexporter/env_vars.go
+++ b/internal/otelcollector/config/builder/common/otlpexporter/env_vars.go
@@ -1,4 +1,4 @@
-package otlpoutput
+package otlpexporter
 
 import (
 	"context"

--- a/internal/otelcollector/config/builder/metric/gateway/config.go
+++ b/internal/otelcollector/config/builder/metric/gateway/config.go
@@ -34,5 +34,6 @@ type FilterProcessorMetricConfig struct {
 type ExportersConfig map[string]ExporterConfig
 
 type ExporterConfig struct {
-	common.BaseGatewayExporterConfig `yaml:",inline"`
+	OTLP    *common.OTLPExporterConfig    `yaml:",inline,omitempty"`
+	Logging *common.LoggingExporterConfig `yaml:",inline,omitempty"`
 }

--- a/internal/otelcollector/config/builder/metric/gateway/config_builder.go
+++ b/internal/otelcollector/config/builder/metric/gateway/config_builder.go
@@ -10,7 +10,6 @@ import (
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/common"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/otlpoutput"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 )
 
@@ -21,11 +20,11 @@ type otlpOutputConfigBuilder struct {
 	queueSize int
 }
 
-func (b *otlpOutputConfigBuilder) build() (map[string]common.BaseGatewayExporterConfig, otlpoutput.EnvVars, error) {
-	return otlpoutput.MakeExportersConfig(b.ctx, b.c, b.pipeline.Spec.Output.Otlp, b.pipeline.Name, b.queueSize)
+func (b *otlpOutputConfigBuilder) build() (map[string]common.BaseGatewayExporterConfig, otlpexporter.EnvVars, error) {
+	return otlpexporter.MakeExportersConfig(b.ctx, b.c, b.pipeline.Spec.Output.Otlp, b.pipeline.Name, b.queueSize)
 }
 
-func MakeConfig(ctx context.Context, c client.Reader, pipelines []telemetryv1alpha1.MetricPipeline) (*Config, otlpoutput.EnvVars, error) {
+func MakeConfig(ctx context.Context, c client.Reader, pipelines []telemetryv1alpha1.MetricPipeline) (*Config, otlpexporter.EnvVars, error) {
 	config := &Config{
 		BaseConfig: common.BaseConfig{
 			Service:    makeServiceConfig(),
@@ -36,7 +35,7 @@ func MakeConfig(ctx context.Context, c client.Reader, pipelines []telemetryv1alp
 		Exporters:  make(ExportersConfig),
 	}
 
-	envVars := make(otlpoutput.EnvVars)
+	envVars := make(otlpexporter.EnvVars)
 	queueSize := 256 / len(pipelines)
 
 	for i := range pipelines {
@@ -100,7 +99,7 @@ func makeServiceConfig() common.ServiceConfig {
 }
 
 // addComponentsForMetricPipeline enriches a Config (exporters, processors, etc.) with components for a given MetricPipeline.
-func addComponentsForMetricPipeline(otlpOutputBuilder otlpOutputConfigBuilder, pipeline *telemetryv1alpha1.MetricPipeline, config *Config, envVars otlpoutput.EnvVars) error {
+func addComponentsForMetricPipeline(otlpOutputBuilder otlpOutputConfigBuilder, pipeline *telemetryv1alpha1.MetricPipeline, config *Config, envVars otlpexporter.EnvVars) error {
 	if enableDropIfInputSourceRuntime(pipeline) {
 		config.Processors.DropIfInputSourceRuntime = makeDropIfInputSourceRuntimeConfig()
 	}

--- a/internal/otelcollector/config/builder/metric/gateway/config_builder.go
+++ b/internal/otelcollector/config/builder/metric/gateway/config_builder.go
@@ -105,7 +105,7 @@ func addComponentsForMetricPipeline(ctx context.Context, otlpExporterBuilder *ot
 	config.Exporters[otlpExporterID] = ExporterConfig{OTLP: otlpExporterConfig}
 
 	loggingExporterID := fmt.Sprintf("logging/%s", pipeline.Name)
-	config.Exporters[loggingExporterID] = ExporterConfig{Logging: &common.LoggingExporterConfig{Verbosity: "basic"}}
+	config.Exporters[loggingExporterID] = ExporterConfig{Logging: common.DefaultLoggingExporterConfig()}
 
 	pipelineID := fmt.Sprintf("metrics/%s", pipeline.Name)
 	config.Service.Pipelines[pipelineID] = makePipelineConfig(pipeline, otlpExporterID, loggingExporterID)

--- a/internal/otelcollector/config/builder/metric/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/builder/metric/gateway/config_builder_test.go
@@ -24,7 +24,7 @@ func TestMakeConfig(t *testing.T) {
 		require.Contains(t, collectorConfig.Exporters, "otlp/test")
 
 		actualExporterConfig := collectorConfig.Exporters["otlp/test"]
-		require.Equal(t, expectedEndpoint, actualExporterConfig.Endpoint)
+		require.Equal(t, expectedEndpoint, actualExporterConfig.OTLP.Endpoint)
 	})
 
 	t.Run("secure", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestMakeConfig(t *testing.T) {
 
 		require.Contains(t, collectorConfig.Exporters, "otlp/test")
 		actualExporterConfig := collectorConfig.Exporters["otlp/test"]
-		require.False(t, actualExporterConfig.TLS.Insecure)
+		require.False(t, actualExporterConfig.OTLP.TLS.Insecure)
 	})
 
 	t.Run("insecure", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestMakeConfig(t *testing.T) {
 
 		require.Contains(t, collectorConfig.Exporters, "otlp/test-insecure")
 		actualExporterConfig := collectorConfig.Exporters["otlp/test-insecure"]
-		require.True(t, actualExporterConfig.TLS.Insecure)
+		require.True(t, actualExporterConfig.OTLP.TLS.Insecure)
 	})
 
 	t.Run("basic auth", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestMakeConfig(t *testing.T) {
 
 		require.Contains(t, collectorConfig.Exporters, "otlp/test-basic-auth")
 		actualExporterConfig := collectorConfig.Exporters["otlp/test-basic-auth"]
-		headers := actualExporterConfig.Headers
+		headers := actualExporterConfig.OTLP.Headers
 
 		authHeader, existing := headers["Authorization"]
 		require.True(t, existing)
@@ -83,7 +83,7 @@ func TestMakeConfig(t *testing.T) {
 	t.Run("single pipeline queue size", func(t *testing.T) {
 		collectorConfig, _, err := MakeConfig(ctx, fakeClient, []v1alpha1.MetricPipeline{testutils.NewMetricPipelineBuilder().WithName("test").Build()})
 		require.NoError(t, err)
-		require.Equal(t, 256, collectorConfig.Exporters["otlp/test"].SendingQueue.QueueSize, "Pipeline should have the full queue size")
+		require.Equal(t, 256, collectorConfig.Exporters["otlp/test"].OTLP.SendingQueue.QueueSize, "Pipeline should have the full queue size")
 	})
 
 	t.Run("multi pipeline queue size", func(t *testing.T) {
@@ -93,9 +93,9 @@ func TestMakeConfig(t *testing.T) {
 			testutils.NewMetricPipelineBuilder().WithName("test-3").Build()},
 		)
 		require.NoError(t, err)
-		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-1"].SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
-		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-2"].SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
-		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-3"].SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
+		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-1"].OTLP.SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
+		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-2"].OTLP.SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
+		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-3"].OTLP.SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
 	})
 
 	t.Run("single pipeline topology", func(t *testing.T) {

--- a/internal/otelcollector/config/builder/trace/gateway/config.go
+++ b/internal/otelcollector/config/builder/trace/gateway/config.go
@@ -34,5 +34,6 @@ type TraceConfig struct {
 type ExportersConfig map[string]ExporterConfig
 
 type ExporterConfig struct {
-	common.BaseGatewayExporterConfig `yaml:",inline"`
+	OTLP    *common.OTLPExporterConfig    `yaml:",inline,omitempty"`
+	Logging *common.LoggingExporterConfig `yaml:",inline,omitempty"`
 }

--- a/internal/otelcollector/config/builder/trace/gateway/config_builder.go
+++ b/internal/otelcollector/config/builder/trace/gateway/config_builder.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/common"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/otlpoutput"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 )
 
-func MakeConfig(ctx context.Context, c client.Reader, pipelines []v1alpha1.TracePipeline) (*Config, otlpoutput.EnvVars, error) {
-	allVars := make(otlpoutput.EnvVars)
+func MakeConfig(ctx context.Context, c client.Reader, pipelines []v1alpha1.TracePipeline) (*Config, otlpexporter.EnvVars, error) {
+	allVars := make(otlpexporter.EnvVars)
 	exportersConfig := make(ExportersConfig)
 	pipelinesConfig := make(common.PipelinesConfig)
 
@@ -25,7 +24,7 @@ func MakeConfig(ctx context.Context, c client.Reader, pipelines []v1alpha1.Trace
 
 		output := pipeline.Spec.Output
 		queueSize := 256 / len(pipelines)
-		exporterConfig, envVars, err := otlpoutput.MakeExportersConfig(ctx, c, output.Otlp, pipeline.Name, queueSize)
+		exporterConfig, envVars, err := otlpexporter.MakeExportersConfig(ctx, c, output.Otlp, pipeline.Name, queueSize)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to make exporter config: %v", err)
 		}

--- a/internal/otelcollector/config/builder/trace/gateway/config_builder.go
+++ b/internal/otelcollector/config/builder/trace/gateway/config_builder.go
@@ -99,7 +99,7 @@ func addComponentsForTracePipeline(ctx context.Context, otlpExporterBuilder *otl
 	config.Exporters[otlpExporterID] = ExporterConfig{OTLP: otlpExporterConfig}
 
 	loggingExporterID := fmt.Sprintf("logging/%s", pipeline.Name)
-	config.Exporters[loggingExporterID] = ExporterConfig{Logging: &common.LoggingExporterConfig{Verbosity: "basic"}}
+	config.Exporters[loggingExporterID] = ExporterConfig{Logging: common.DefaultLoggingExporterConfig()}
 
 	pipelineID := fmt.Sprintf("traces/%s", pipeline.Name)
 	config.Service.Pipelines[pipelineID] = makePipelineConfig(pipeline, otlpExporterID, loggingExporterID)

--- a/internal/otelcollector/config/builder/trace/gateway/config_builder.go
+++ b/internal/otelcollector/config/builder/trace/gateway/config_builder.go
@@ -3,14 +3,15 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"sort"
+
+	"golang.org/x/exp/maps"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/common"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/builder/common/otlpexporter"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
-	"golang.org/x/exp/maps"
-	"sort"
 )
 
 func MakeConfig(ctx context.Context, c client.Reader, pipelines []telemetryv1alpha1.TracePipeline) (*Config, otlpexporter.EnvVars, error) {
@@ -102,12 +103,12 @@ func addComponentsForTracePipeline(ctx context.Context, otlpExporterBuilder *otl
 	config.Exporters[loggingExporterID] = ExporterConfig{Logging: common.DefaultLoggingExporterConfig()}
 
 	pipelineID := fmt.Sprintf("traces/%s", pipeline.Name)
-	config.Service.Pipelines[pipelineID] = makePipelineConfig(pipeline, otlpExporterID, loggingExporterID)
+	config.Service.Pipelines[pipelineID] = makePipelineConfig(otlpExporterID, loggingExporterID)
 
 	return nil
 }
 
-func makePipelineConfig(pipeline *telemetryv1alpha1.TracePipeline, exporterIDs ...string) common.PipelineConfig {
+func makePipelineConfig(exporterIDs ...string) common.PipelineConfig {
 	sort.Strings(exporterIDs)
 
 	return common.PipelineConfig{

--- a/internal/otelcollector/config/builder/trace/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/builder/trace/gateway/config_builder_test.go
@@ -23,7 +23,7 @@ func TestMakeConfig(t *testing.T) {
 		expectedEndpoint := fmt.Sprintf("${%s}", "OTLP_ENDPOINT_TEST")
 		require.Contains(t, collectorConfig.Exporters, "otlp/test")
 		otlpExporterConfig := collectorConfig.Exporters["otlp/test"]
-		require.Equal(t, expectedEndpoint, otlpExporterConfig.Endpoint)
+		require.Equal(t, expectedEndpoint, otlpExporterConfig.OTLP.Endpoint)
 	})
 
 	t.Run("secure", func(t *testing.T) {
@@ -31,7 +31,7 @@ func TestMakeConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, collectorConfig.Exporters, "otlp/test")
 		otlpExporterConfig := collectorConfig.Exporters["otlp/test"]
-		require.False(t, otlpExporterConfig.TLS.Insecure)
+		require.False(t, otlpExporterConfig.OTLP.TLS.Insecure)
 	})
 
 	t.Run("insecure", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestMakeConfig(t *testing.T) {
 
 		require.Contains(t, collectorConfig.Exporters, "otlp/test-insecure")
 		actualExporterConfig := collectorConfig.Exporters["otlp/test-insecure"]
-		require.True(t, actualExporterConfig.TLS.Insecure)
+		require.True(t, actualExporterConfig.OTLP.TLS.Insecure)
 	})
 
 	t.Run("basic auth", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestMakeConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, collectorConfig.Exporters, "otlp/test-basic-auth")
 		otlpExporterConfig := collectorConfig.Exporters["otlp/test-basic-auth"]
-		headers := otlpExporterConfig.Headers
+		headers := otlpExporterConfig.OTLP.Headers
 
 		authHeader, existing := headers["Authorization"]
 		require.True(t, existing)
@@ -80,7 +80,7 @@ func TestMakeConfig(t *testing.T) {
 	t.Run("single pipeline queue size", func(t *testing.T) {
 		collectorConfig, _, err := MakeConfig(ctx, fakeClient, []v1alpha1.TracePipeline{testutils.NewTracePipelineBuilder().WithName("test").Build()})
 		require.NoError(t, err)
-		require.Equal(t, 256, collectorConfig.Exporters["otlp/test"].SendingQueue.QueueSize, "Pipeline should have the full queue size")
+		require.Equal(t, 256, collectorConfig.Exporters["otlp/test"].OTLP.SendingQueue.QueueSize, "Pipeline should have the full queue size")
 	})
 
 	t.Run("multi pipeline queue size", func(t *testing.T) {
@@ -90,9 +90,9 @@ func TestMakeConfig(t *testing.T) {
 			testutils.NewTracePipelineBuilder().WithName("test-3").Build()},
 		)
 		require.NoError(t, err)
-		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-1"].SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
-		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-2"].SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
-		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-3"].SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
+		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-1"].OTLP.SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
+		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-2"].OTLP.SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
+		require.Equal(t, 85, collectorConfig.Exporters["otlp/test-3"].OTLP.SendingQueue.QueueSize, "Queue size should be divided by the number of pipelines")
 	})
 
 	t.Run("single pipeline topology", func(t *testing.T) {


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

The `otlpoutput` package was used to create configs for both `otlp` and `logging` exporters. This resulted in a strange API - it returned a map of exporters that had to be merged into the final map of exporters by the metric and trace gateway reconcilers. This PR splits it up so that the renamed `common/otlpexporter` package only takes care of creating the `otlp` exporter configuration. This has several advantages:

* Simplifies package API.
* The package adheres to the single responsibility principle - it only does what you expect it to do (`otlpexporter` build an `otlp` exporter config).

## Traceability

Not relevant since it's not a new feature. It's just an improvement of the existing code.

## Testability

The feature is unit-tested:

- [x] Yes.
- [ ] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [x] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the style guidelines of this project.
- [x] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [x] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
