### PR TITLE
Make Telemetry CRD namspace scoped

### DIFF
--- a/apis/operator/v1alpha1/telemetry_types.go
+++ b/apis/operator/v1alpha1/telemetry_types.go
@@ -95,7 +95,6 @@ func (s *TelemetryStatus) WithInstallConditionStatus(status metav1.ConditionStat
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="generation",type="integer",JSONPath=".metadata.generation"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="state",type="string",JSONPath=".status.state"

--- a/config/busola/telemetry_busola_extension_cm.yaml
+++ b/config/busola/telemetry_busola_extension_cm.yaml
@@ -26,7 +26,7 @@ data:
     name: Telemetry Module
     category: Observability
     urlPath: telemetries
-    scope: cluster
+    scope: namespace
     description: >-
       {{[Telemetry](https://github.com/kyma-project/telemetry-manager/blob/main/config/crd/bases/operator.kyma-project.io_telemetries.yaml)}}
       is a detailed description of the kind of data and the format used to define a

--- a/config/crd/bases/operator.kyma-project.io_telemetries.yaml
+++ b/config/crd/bases/operator.kyma-project.io_telemetries.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: TelemetryList
     plural: telemetries
     singular: telemetry
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.generation

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -90,6 +90,7 @@ rules:
   - validatingwebhookconfigurations
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -116,27 +117,9 @@ rules:
   resources:
   - telemetries
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - operator.kyma-project.io
-  resources:
-  - telemetries/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - operator.kyma-project.io
-  resources:
-  - telemetries/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -343,5 +326,31 @@ rules:
   verbs:
   - create
   - delete
+  - patch
+  - update
+- apiGroups:
+  - operator.kyma-project.io
+  resources:
+  - telemetries
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.kyma-project.io
+  resources:
+  - telemetries/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operator.kyma-project.io
+  resources:
+  - telemetries/status
+  verbs:
+  - get
   - patch
   - update

--- a/controllers/operator/telemetry_controller.go
+++ b/controllers/operator/telemetry_controller.go
@@ -86,7 +86,8 @@ func (r *TelemetryReconciler) mapWebhook(object client.Object) []reconcile.Reque
 	for _, t := range telemetries.Items {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: client.ObjectKey{
-				Name: t.Name,
+				Name:      t.Name,
+				Namespace: t.Namespace,
 			},
 		})
 	}

--- a/controllers/operator/telemetry_controller.go
+++ b/controllers/operator/telemetry_controller.go
@@ -19,7 +19,6 @@ package operator
 import (
 	"context"
 
-	"github.com/kyma-project/telemetry-manager/internal/setup"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,6 +30,7 @@ import (
 
 	operatorv1alpha1 "github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/telemetry"
+	"github.com/kyma-project/telemetry-manager/internal/setup"
 )
 
 type TelemetryReconciler struct {

--- a/controllers/operator/telemetry_controller.go
+++ b/controllers/operator/telemetry_controller.go
@@ -19,11 +19,14 @@ package operator
 import (
 	"context"
 
+	"github.com/kyma-project/telemetry-manager/internal/setup"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	operatorv1alpha1 "github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
@@ -56,8 +59,37 @@ func (r *TelemetryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				IsController: false}).
 		Watches(
 			&source.Kind{Type: &admissionv1.ValidatingWebhookConfiguration{}},
-			&handler.EnqueueRequestForOwner{
-				OwnerType:    &operatorv1alpha1.Telemetry{},
-				IsController: false}).
+			handler.EnqueueRequestsFromMapFunc(r.mapWebhook),
+			builder.WithPredicates(setup.DeleteOrUpdate())).
 		Complete(r)
+}
+
+func (r *TelemetryReconciler) mapWebhook(object client.Object) []reconcile.Request {
+	var telemetries operatorv1alpha1.TelemetryList
+	var requests []reconcile.Request
+
+	webhook, ok := object.(*admissionv1.ValidatingWebhookConfiguration)
+	if !ok {
+		ctrl.Log.Error(nil, "unable to cast object to ValidatingWebhookConfiguration")
+		return requests
+	}
+	if webhook.Name != r.reconciler.WebhookConfig.CertConfig.WebhookName.Name {
+		return requests
+	}
+
+	err := r.List(context.Background(), &telemetries)
+	if err != nil {
+		ctrl.Log.Error(err, "unable to list Telemetry CRs")
+		return requests
+	}
+
+	for _, t := range telemetries.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: client.ObjectKey{
+				Name: t.Name,
+			},
+		})
+	}
+
+	return requests
 }

--- a/controllers/operator/telemetry_controller_test.go
+++ b/controllers/operator/telemetry_controller_test.go
@@ -25,7 +25,8 @@ var _ = Describe("Deploying a Telemetry", func() {
 
 		telemetryTestObj := &operatorv1alpha1.Telemetry{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "telemetry",
+				Name:      "telemetry",
+				Namespace: "default",
 			},
 		}
 
@@ -34,7 +35,8 @@ var _ = Describe("Deploying a Telemetry", func() {
 
 			Eventually(func() error {
 				telemetryLookupKey := types.NamespacedName{
-					Name: "telemetry",
+					Name:      "telemetry",
+					Namespace: "default",
 				}
 				var telemetryTestInstance operatorv1alpha1.Telemetry
 				err := k8sClient.Get(ctx, telemetryLookupKey, &telemetryTestInstance)

--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -15,6 +15,7 @@ apiVersion: operator.kyma-project.io/v1alpha1
 kind: Telemetry
 metadata:
   name: default
+  namespace: kyma-system
 Status:
   Conditions:
     Last Transition Time:  2023-05-23T14:57:11Z

--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -108,6 +108,10 @@ func (r *Reconciler) reconcileWebhook(ctx context.Context, telemetry *operatorv1
 		return nil
 	}
 
+	if !telemetry.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	if err := webhookcert.EnsureCertificate(ctx, r.Client, r.WebhookConfig.CertConfig); err != nil {
 		return fmt.Errorf("failed to reconcile webhook: %w", err)
 	}

--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -7,6 +7,7 @@ import (
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,7 @@ type Reconciler struct {
 	*rest.Config
 	// EventRecorder for creating k8s events
 	record.EventRecorder
-	webhookConfig WebhookConfig
+	WebhookConfig WebhookConfig
 }
 
 func NewReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, webhookConfig WebhookConfig) *Reconciler {
@@ -48,7 +49,7 @@ func NewReconciler(client client.Client, scheme *runtime.Scheme, eventRecorder r
 		Client:        client,
 		Scheme:        scheme,
 		EventRecorder: eventRecorder,
-		webhookConfig: webhookConfig,
+		WebhookConfig: webhookConfig,
 	}
 }
 
@@ -103,16 +104,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Reconciler) reconcileWebhook(ctx context.Context, telemetry *operatorv1alpha1.Telemetry) error {
-	if !r.webhookConfig.Enabled {
+	if !r.WebhookConfig.Enabled {
 		return nil
 	}
 
-	if err := webhookcert.EnsureCertificate(ctx, r.Client, r.webhookConfig.CertConfig); err != nil {
+	if err := webhookcert.EnsureCertificate(ctx, r.Client, r.WebhookConfig.CertConfig); err != nil {
 		return fmt.Errorf("failed to reconcile webhook: %w", err)
 	}
 
 	var secret corev1.Secret
-	if err := r.Get(ctx, r.webhookConfig.CertConfig.CASecretName, &secret); err != nil {
+	if err := r.Get(ctx, r.WebhookConfig.CertConfig.CASecretName, &secret); err != nil {
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
 	if err := controllerutil.SetOwnerReference(telemetry, &secret, r.Scheme); err != nil {
@@ -123,17 +124,24 @@ func (r *Reconciler) reconcileWebhook(ctx context.Context, telemetry *operatorv1
 	}
 
 	var webhook admissionv1.ValidatingWebhookConfiguration
-	if err := r.Get(ctx, r.webhookConfig.CertConfig.WebhookName, &webhook); err != nil {
+	if err := r.Get(ctx, r.WebhookConfig.CertConfig.WebhookName, &webhook); err != nil {
 		return fmt.Errorf("failed to get webhook: %w", err)
-	}
-	if err := controllerutil.SetOwnerReference(telemetry, &webhook, r.Scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference for webhook: %w", err)
 	}
 	if err := kubernetes.CreateOrUpdateValidatingWebhookConfiguration(ctx, r.Client, &webhook); err != nil {
 		return fmt.Errorf("failed to update webhook: %w", err)
 	}
 
 	return nil
+}
+
+func (r *Reconciler) deleteWebhook(ctx context.Context) error {
+	webhook := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: r.WebhookConfig.CertConfig.WebhookName.Name,
+		},
+	}
+
+	return r.Delete(ctx, webhook)
 }
 
 // HandleReadyState checks for the consistency of reconciled resource, by verifying the underlying resources.
@@ -173,6 +181,11 @@ func (r *Reconciler) HandleProcessingState(ctx context.Context, objectInstance *
 
 func (r *Reconciler) HandleDeletingState(ctx context.Context, objectInstance *operatorv1alpha1.Telemetry) error {
 	r.Event(objectInstance, "Normal", "Deleting", "resource deleting")
+
+	err := r.deleteWebhook(ctx)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete webhook: %w", err)
+	}
 
 	// if resources are ready to be deleted, remove finalizer
 	if controllerutil.RemoveFinalizer(objectInstance, finalizer) {

--- a/main.go
+++ b/main.go
@@ -384,7 +384,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if enableWebhook {
+	if enableWebhook && !enableTelemetryManagerModule {
 		// Create own client since manager might not be started while using
 		clientOptions := client.Options{
 			Scheme: scheme,

--- a/main.go
+++ b/main.go
@@ -169,9 +169,10 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:groups=telemetry.kyma-project.io,resources=metricpipelines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=telemetry.kyma-project.io,resources=metricpipelines/finalizers,verbs=update
 
-//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=telemetries,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=telemetries/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=telemetries/finalizers,verbs=update
+//+kubebuilder:rbac:groups=operator.kyma-project.io,namespace=system,resources=telemetries,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=operator.kyma-project.io,namespace=system,resources=telemetries/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=operator.kyma-project.io,namespace=system,resources=telemetries/finalizers,verbs=update
+//+kubebuilder:rbac:groups=operator.kyma-project.io,resources=telemetries,verbs=get;list;watch
 
 //+kubebuilder:rbac:groups="",namespace=system,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",namespace=system,resources=services,verbs=get;list;watch;create;update;patch;delete
@@ -193,7 +194,7 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
 
-//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Telemetry-manager", func() {
 			}
 			err := k8sClient.Get(ctx, key, &crd)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(crd.Spec.Scope).To(Equal(apiextensionsv1.ClusterScoped))
 		})
 
 		It("Should have LogParsers CRD", Label("logging"), func() {
@@ -110,6 +111,7 @@ var _ = Describe("Telemetry-manager", func() {
 			}
 			err := k8sClient.Get(ctx, key, &crd)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(crd.Spec.Scope).To(Equal(apiextensionsv1.ClusterScoped))
 		})
 
 		It("Should have TracePipelines CRD", Label("tracing"), func() {
@@ -119,6 +121,7 @@ var _ = Describe("Telemetry-manager", func() {
 			}
 			err := k8sClient.Get(ctx, key, &crd)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(crd.Spec.Scope).To(Equal(apiextensionsv1.ClusterScoped))
 		})
 
 		It("Should have MetricPipelines CRD", Label("metrics"), func() {
@@ -128,6 +131,17 @@ var _ = Describe("Telemetry-manager", func() {
 			}
 			err := k8sClient.Get(ctx, key, &crd)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(crd.Spec.Scope).To(Equal(apiextensionsv1.ClusterScoped))
+		})
+
+		It("Should have Telemetry CRD", func() {
+			var crd apiextensionsv1.CustomResourceDefinition
+			key := types.NamespacedName{
+				Name: "telemetries.operator.kyma-project.io",
+			}
+			err := k8sClient.Get(ctx, key, &crd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(crd.Spec.Scope).To(Equal(apiextensionsv1.NamespaceScoped))
 		})
 
 		It("Should have a Fluent Bit dashboard", Label("logging"), func() {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	telemetryK8sObjects = []client.Object{kitk8s.NewTelemetry("default").Persistent(isOperational()).K8sObject()}
+	telemetryK8sObjects = []client.Object{kitk8s.NewTelemetry("default", "kyma-system").Persistent(isOperational()).K8sObject()}
 
 	Expect(kitk8s.CreateObjects(ctx, k8sClient, telemetryK8sObjects...)).To(Succeed())
 

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -32,10 +32,6 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 				var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
 
-				g.Expect(validatingWebhookConfiguration.OwnerReferences).Should(HaveLen(1))
-				g.Expect(validatingWebhookConfiguration.OwnerReferences[0].Name).Should(Equal("default"))
-				g.Expect(validatingWebhookConfiguration.OwnerReferences[0].Kind).Should(Equal("Telemetry"))
-
 				g.Expect(validatingWebhookConfiguration.Webhooks).Should(HaveLen(2))
 
 				logPipelineWebhook := validatingWebhookConfiguration.Webhooks[0]
@@ -88,7 +84,6 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 			var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
-				g.Expect(validatingWebhookConfiguration.OwnerReferences).Should(HaveLen(1))
 				g.Expect(validatingWebhookConfiguration.UID).ShouldNot(Equal(oldUID))
 			}, timeout, interval).Should(Succeed())
 		})
@@ -113,7 +108,8 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 
 	Context("Deleting Telemetry resources", Ordered, func() {
 		telemetryKey := types.NamespacedName{
-			Name: "default",
+			Name:      "default",
+			Namespace: "kyma-system",
 		}
 		k8sLogPipelineObject := makeTestPipelineK8sObjects()
 
@@ -126,7 +122,7 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 		AfterAll(func() {
 			// Re-create Telemetry to have ValidatingWebhookConfiguration for remaining tests
 			Eventually(func(g Gomega) {
-				newTelemetry := []client.Object{kitk8s.NewTelemetry("default").K8sObject()}
+				newTelemetry := []client.Object{kitk8s.NewTelemetry("default", "kyma-system").K8sObject()}
 				g.Expect(kitk8s.CreateObjects(ctx, k8sClient, newTelemetry...)).Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -165,6 +165,18 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 				g.Expect(k8sClient.Get(ctx, telemetryKey, &telemetry)).ShouldNot(Succeed())
 			}, timeout, interval).Should(Succeed())
 		})
+
+		It("Should not have Webhook and CA bundle", func() {
+			Eventually(func(g Gomega) {
+				var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
+			}, timeout, interval).ShouldNot(Succeed())
+
+			Eventually(func(g Gomega) {
+				var secret corev1.Secret
+				g.Expect(k8sClient.Get(ctx, webhookCertSecret, &secret)).Should(Succeed())
+			}, timeout, interval).ShouldNot(Succeed())
+		})
 	})
 })
 

--- a/test/e2e/testkit/k8s/telemetry.go
+++ b/test/e2e/testkit/k8s/telemetry.go
@@ -10,12 +10,14 @@ import (
 
 type Telemetry struct {
 	Name       string
+	Namespace  string
 	persistent bool
 }
 
-func NewTelemetry(name string) *Telemetry {
+func NewTelemetry(name, namespace string) *Telemetry {
 	return &Telemetry{
-		Name: name,
+		Name:      name,
+		Namespace: namespace,
 	}
 }
 
@@ -27,8 +29,9 @@ func (s *Telemetry) K8sObject() *operatorv1alpha1.Telemetry {
 
 	return &operatorv1alpha1.Telemetry{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   s.Name,
-			Labels: labels,
+			Name:      s.Name,
+			Namespace: s.Namespace,
+			Labels:    labels,
 		},
 	}
 }


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

The Telemetry module CRD should be namespace scoped to be aligned with other Kyma modules. This PR updates the scope and related ClusterRole. Since a cluster scoped resource cannot be owned by a namespace scoped resource, the reconciliation of the ValidatingWebhookConfiguration had to be updated.

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- Make Telemetry module CRD namespace scoped
- Update RBAC
- Change webhook reconciliation to not use owner references anymore

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes: https://github.com/kyma-project/telemetry-manager/issues/286

Related issues: https://github.com/kyma-project/busola/issues/2512

## Traceability

- [x] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [x] Yes (env test)
- [ ] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [x] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the style guidelines of this project.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [ ] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
