### PR TITLE
Add a simple Prometheus endpoint scraping e2e test scenario

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: k3d-kyma-registry:5000/telemetry-manager
-  newTag: latest
+  newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
+  newTag: v20230622-dd7e6d85

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: v20230622-dd7e6d85
+  newName: k3d-kyma-registry:5000/telemetry-manager
+  newTag: latest

--- a/test/e2e/metrics_prometheus_test.go
+++ b/test/e2e/metrics_prometheus_test.go
@@ -1,1 +1,0 @@
-package e2e

--- a/test/e2e/metrics_prometheus_test.go
+++ b/test/e2e/metrics_prometheus_test.go
@@ -1,0 +1,1 @@
+package e2e

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -14,10 +14,9 @@ import (
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 
+	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 )
 
 var (

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	"fmt"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -123,8 +122,8 @@ func makeMetricsRuntmeInputTestK8sObjects(mocksNamespaceName string, mockDeploym
 
 	// Default namespace objects.
 	otlpEndpointURL := mockBackendExternalService.OTLPEndpointURL(grpcOTLPPort)
-	hostSecret := kitk8s.NewOpaqueSecret("metric-rcv-hostname", defaultNamespaceName, kitk8s.WithStringData("metric-host", otlpEndpointURL)).Persistent(isOperational())
-	metricPipeline := kitmetric.NewPipeline(fmt.Sprintf("%s-%s", mockDeploymentName, "pipeline"), hostSecret.SecretKeyRef("metric-host")).RuntimeInput(true)
+	hostSecret := kitk8s.NewOpaqueSecret("metric-rcv-hostname", defaultNamespaceName, kitk8s.WithStringData("metric-host", otlpEndpointURL))
+	metricPipeline := kitmetric.NewPipeline("pipeline-with-runtime-input-enabled", hostSecret.SecretKeyRef("metric-host")).RuntimeInput(true)
 	pipelines.Append(metricPipeline.Name())
 
 	objs = append(objs, []client.Object{

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -5,8 +5,6 @@ package e2e
 import (
 	"net/http"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,8 +12,11 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/k8s/verifiers"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma"
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
-	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
+
+	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var (

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -5,6 +5,8 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -12,11 +14,8 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/k8s/verifiers"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma"
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
-	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
-
 	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 )
 
 var (

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -27,7 +27,7 @@ var (
 	kubeletMetricNames      = []string{"container.cpu.time", "container.cpu.utilization", "container.filesystem.available", "container.filesystem.capacity", "container.filesystem.usage", "container.memory.available", "container.memory.major_page_faults", "container.memory.page_faults", "container.memory.rss", "container.memory.usage", "container.memory.working_set", "k8s.pod.cpu.time", "k8s.pod.cpu.utilization", "k8s.pod.filesystem.available", "k8s.pod.filesystem.capacity", "k8s.pod.filesystem.usage", "k8s.pod.memory.available", "k8s.pod.memory.major_page_faults", "k8s.pod.memory.page_faults", "k8s.pod.memory.rss", "k8s.pod.memory.usage", "k8s.pod.memory.working_set", "k8s.pod.network.errors", "k8s.pod.network.io"}
 )
 
-var _ = Describe("Metrics Kubeletstats", Label("metrics"), func() {
+var _ = Describe("Metrics Runtime Input", Label("metrics"), func() {
 	Context("When a metricpipeline exists", Ordered, func() {
 		var (
 			pipelines          *kyma.PipelineList

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -14,9 +14,10 @@ import (
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 
-	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 )
 
 var (

--- a/test/e2e/metrics_workloads_input_test.go
+++ b/test/e2e/metrics_workloads_input_test.go
@@ -5,6 +5,8 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -12,11 +14,8 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/k8s/verifiers"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma"
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
-	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
-
 	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 )
 
 var _ = Describe("Metrics Workloads Input", Label("metrics"), func() {

--- a/test/e2e/metrics_workloads_input_test.go
+++ b/test/e2e/metrics_workloads_input_test.go
@@ -19,27 +19,19 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 )
 
-var (
-	metricAgentGatewayBaseName = "telemetry-metric-gateway"
-	metricAgentBaseName        = "telemetry-metric-agent"
-
-	kubeletMetricAttributes = []string{"k8s.cluster.name", "k8s.container.name", "k8s.daemonset.name", "k8s.deployment.name", "k8s.namespace.name", "k8s.node.name", "k8s.pod.name", "k8s.pod.uid", "kyma.source"}
-	kubeletMetricNames      = []string{"container.cpu.time", "container.cpu.utilization", "container.filesystem.available", "container.filesystem.capacity", "container.filesystem.usage", "container.memory.available", "container.memory.major_page_faults", "container.memory.page_faults", "container.memory.rss", "container.memory.usage", "container.memory.working_set", "k8s.pod.cpu.time", "k8s.pod.cpu.utilization", "k8s.pod.filesystem.available", "k8s.pod.filesystem.capacity", "k8s.pod.filesystem.usage", "k8s.pod.memory.available", "k8s.pod.memory.major_page_faults", "k8s.pod.memory.page_faults", "k8s.pod.memory.rss", "k8s.pod.memory.usage", "k8s.pod.memory.working_set", "k8s.pod.network.errors", "k8s.pod.network.io"}
-)
-
-var _ = Describe("Metrics Runtime Input", Label("metrics"), func() {
+var _ = Describe("Metrics Workloads Input", Label("metrics"), func() {
 	Context("When a metricpipeline exists", Ordered, func() {
 		var (
 			pipelines          *kyma.PipelineList
 			urls               *mocks.URLProvider
 			mockDeploymentName = "metric-agent-receiver"
-			mocksNs            = "metric-runtime-input-mocks"
+			mocksNs            = "metric-workloads-input"
 			metricGatewayName  = types.NamespacedName{Name: metricAgentGatewayBaseName, Namespace: kymaSystemNamespaceName}
 			metricAgentName    = types.NamespacedName{Name: metricAgentBaseName, Namespace: kymaSystemNamespaceName}
 		)
 
 		BeforeAll(func() {
-			k8sObjects, urlProvider, pipelinesProvider := makeMetricsRuntmeInputTestK8sObjects(mocksNs, mockDeploymentName)
+			k8sObjects, urlProvider, pipelinesProvider := makeMetricsPrometheusInputTestK8sObjects(mocksNs, mockDeploymentName)
 			pipelines = pipelinesProvider
 			urls = urlProvider
 
@@ -101,7 +93,7 @@ var _ = Describe("Metrics Runtime Input", Label("metrics"), func() {
 	})
 })
 
-func makeMetricsRuntmeInputTestK8sObjects(mocksNamespaceName string, mockDeploymentName string) ([]client.Object, *mocks.URLProvider, *kyma.PipelineList) {
+func makeMetricsPrometheusInputTestK8sObjects(mocksNamespaceName string, mockDeploymentName string) ([]client.Object, *mocks.URLProvider, *kyma.PipelineList) {
 	var (
 		objs         []client.Object
 		pipelines    = kyma.NewPipelineList()

--- a/test/e2e/metrics_workloads_input_test.go
+++ b/test/e2e/metrics_workloads_input_test.go
@@ -14,9 +14,10 @@ import (
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 
-	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 )
 
 var _ = Describe("Metrics Workloads Input", Label("metrics"), func() {

--- a/test/e2e/metrics_workloads_input_test.go
+++ b/test/e2e/metrics_workloads_input_test.go
@@ -5,8 +5,6 @@ package e2e
 import (
 	"net/http"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,8 +12,11 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/k8s/verifiers"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma"
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
-	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
+
+	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Metrics Workloads Input", Label("metrics"), func() {

--- a/test/e2e/metrics_workloads_input_test.go
+++ b/test/e2e/metrics_workloads_input_test.go
@@ -14,10 +14,9 @@ import (
 	kitmetric "github.com/kyma-project/telemetry-manager/test/e2e/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/e2e/testkit/mocks"
 
+	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/e2e/testkit/matchers"
 )
 
 var _ = Describe("Metrics Workloads Input", Label("metrics"), func() {

--- a/test/e2e/metrics_workloads_input_test.go
+++ b/test/e2e/metrics_workloads_input_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Metrics Workloads Input", Label("metrics"), func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(SatisfyAll(
-					HaveMetricNames(mocks.MetricProviderMetricNames...))))
+					HaveMetricNames(mocks.CustomMetricNames...))))
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -111,7 +111,7 @@ func makeMetricsPrometheusInputTestK8sObjects(mocksNamespaceName string, mockDep
 	mockBackendExternalService := mockBackend.ExternalService().
 		WithPort("grpc-otlp", grpcOTLPPort).
 		WithPort("http-web", httpWebPort)
-	mockMetricProvider := mocks.NewMetricProvider(mocksNamespaceName)
+	mockMetricProvider := mocks.NewCustomMetricProvider(mocksNamespaceName)
 
 	// Default namespace objects.
 	otlpEndpointURL := mockBackendExternalService.OTLPEndpointURL(grpcOTLPPort)

--- a/test/e2e/testkit/kyma/telemetry/metric/pipeline.go
+++ b/test/e2e/testkit/kyma/telemetry/metric/pipeline.go
@@ -20,6 +20,7 @@ type Pipeline struct {
 	persistent   bool
 	id           string
 	runtime      bool
+	workloads    bool
 }
 
 func NewPipeline(name string, secretKeyRef *telemetry.SecretKeyRef) *Pipeline {
@@ -45,24 +46,22 @@ func (p *Pipeline) K8sObject() *telemetry.MetricPipeline {
 	}
 	labels.Version(version)
 
-	var input telemetry.MetricPipelineInput
-	if p.runtime {
-		input = telemetry.MetricPipelineInput{
-			Application: telemetry.MetricPipelineApplicationInput{
-				Runtime: telemetry.MetricPipelineContainerRuntimeInput{
-					Enabled: true,
-				},
-			},
-		}
-	}
-
 	return &telemetry.MetricPipeline{
 		ObjectMeta: k8smeta.ObjectMeta{
 			Name:   p.Name(),
 			Labels: labels,
 		},
 		Spec: telemetry.MetricPipelineSpec{
-			Input: input,
+			Input: telemetry.MetricPipelineInput{
+				Application: telemetry.MetricPipelineApplicationInput{
+					Runtime: telemetry.MetricPipelineContainerRuntimeInput{
+						Enabled: p.runtime,
+					},
+					Workloads: telemetry.MetricPipelineWorkloadsInput{
+						Enabled: p.workloads,
+					},
+				},
+			},
 			Output: telemetry.MetricPipelineOutput{
 				Otlp: &telemetry.OtlpOutput{
 					Endpoint: telemetry.ValueType{
@@ -84,6 +83,12 @@ func (p *Pipeline) Persistent(persistent bool) *Pipeline {
 
 func (p *Pipeline) RuntimeInput(enableRuntime bool) *Pipeline {
 	p.runtime = enableRuntime
+
+	return p
+}
+
+func (p *Pipeline) WorkloadsInput(enableWorkloads bool) *Pipeline {
+	p.workloads = enableWorkloads
 
 	return p
 }

--- a/test/e2e/testkit/mocks/custom_metric_provider.go
+++ b/test/e2e/testkit/mocks/custom_metric_provider.go
@@ -19,7 +19,7 @@ func NewCustomMetricProvider(namespace string) *CustomMetricProvider {
 	}
 }
 
-func (mp *CustomMetricProvider) K8sObject() *corev1.Pod {:w
+func (mp *CustomMetricProvider) K8sObject() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sample-metrics",

--- a/test/e2e/testkit/mocks/custom_metric_provider.go
+++ b/test/e2e/testkit/mocks/custom_metric_provider.go
@@ -1,0 +1,56 @@
+package mocks
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var MetricProviderMetricNames = []string{"cpu_temperature_celsius", "hd_errors_total"}
+
+type MetricProvider struct {
+	namespace string
+}
+
+func NewMetricProvider(namespace string) *MetricProvider {
+	return &MetricProvider{
+		namespace: namespace,
+	}
+}
+
+func (mp *MetricProvider) K8sObject() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sample-metrics",
+			Namespace: mp.namespace,
+			Annotations: map[string]string{
+				"prometheus.io/path":   "/metrics",
+				"prometheus.io/port":   "8080",
+				"prometheus.io/scrape": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "sample-metrics",
+					Image: "eu.gcr.io/kyma-project/develop/monitoring-custom-metrics:e56d9645",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 8080,
+							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("32Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/testkit/mocks/custom_metric_provider.go
+++ b/test/e2e/testkit/mocks/custom_metric_provider.go
@@ -6,19 +6,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var MetricProviderMetricNames = []string{"cpu_temperature_celsius", "hd_errors_total"}
+var CustomMetricNames = []string{"cpu_temperature_celsius", "hd_errors_total"}
 
-type MetricProvider struct {
+// CustomMetricProvider represents a workload that exposes dummy metrics in the Prometheus exposition format
+type CustomMetricProvider struct {
 	namespace string
 }
 
-func NewMetricProvider(namespace string) *MetricProvider {
-	return &MetricProvider{
+func NewCustomMetricProvider(namespace string) *CustomMetricProvider {
+	return &CustomMetricProvider{
 		namespace: namespace,
 	}
 }
 
-func (mp *MetricProvider) K8sObject() *corev1.Pod {
+func (mp *CustomMetricProvider) K8sObject() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sample-metrics",

--- a/test/e2e/testkit/mocks/custom_metric_provider.go
+++ b/test/e2e/testkit/mocks/custom_metric_provider.go
@@ -19,7 +19,7 @@ func NewCustomMetricProvider(namespace string) *CustomMetricProvider {
 	}
 }
 
-func (mp *CustomMetricProvider) K8sObject() *corev1.Pod {
+func (mp *CustomMetricProvider) K8sObject() *corev1.Pod {:w
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sample-metrics",


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- Add a simple e2e test that deploys a Pod that exposes some dummy metrics (taken from [this example](https://github.com/kyma-project/examples/tree/main/prometheus/monitoring-custom-metrics)). The Pod is annotated and is getting scraped by the metric agent. The test verifies that dummy metrics are present, but the kubelet metrics are not
- Simplify the kubelet metric test

## Related Issues and Documents

https://github.com/kyma-project/kyma/issues/17828

## Traceability

- [x] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

It's an e2e test itself

## Codebase

- [ ] My code follows the style guidelines of this project.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [ ] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
