### PR TITLE
chore: Integrate ConventionalCommits specification support to the SDLC

### DIFF
--- a/.commitlint.js
+++ b/.commitlint.js
@@ -11,7 +11,7 @@ module.exports = {
         "scope-case": [2, "always", "lower-case"],
 
         // The subject-case clause can be of any case to allow mentioning abbreviations and K8s resources.
-        // "subject-case": [2, "always", ["sentence-case", "start-case", "pascal-case", "upper-case"]],
+        "subject-case": [0, "always"],
 
         // The subject-case clause mustn't be empty and mustn't end with a full stop.
         "subject-empty": [2, "never"],
@@ -22,7 +22,7 @@ module.exports = {
         "subject-min-length": [2, "always", "5"],
 
         // The type must always be in lowercase and be one of the predefined values.
-        "type-enum": [2, "always", ["feat", "fix", "docs", "refactor", "test"]],
+        "type-enum": [2, "always", ["deps", "chore", "docs", "feat", "fix", "test"]],
         "type-case": [2, "always", "lower-case"],
     }
 }

--- a/.commitlint.js
+++ b/.commitlint.js
@@ -1,0 +1,28 @@
+// commitlint rules documentation: https://commitlint.js.org/#/reference-rules
+//
+// Each PR encompasses these sections:
+//     type(scope?): subject
+//     body?
+//     footer?
+
+module.exports = {
+    rules: {
+        // The scope clause must always be in lowercase.
+        "scope-case": [2, "always", "lower-case"],
+
+        // The subject-case clause can be of any case to allow mentioning abbreviations and K8s resources.
+        // "subject-case": [2, "always", ["sentence-case", "start-case", "pascal-case", "upper-case"]],
+
+        // The subject-case clause mustn't be empty and mustn't end with a full stop.
+        "subject-empty": [2, "never"],
+        "subject-full-stop": [2, "never", "."],
+
+        // The subject-case clause's length must be between 5 and 120 characters.
+        "subject-max-length": [2, "always", "120"],
+        "subject-min-length": [2, "always", "5"],
+
+        // The type must always be in lowercase and be one of the predefined values.
+        "type-enum": [2, "always", ["feat", "fix", "docs", "refactor", "test"]],
+        "type-case": [2, "always", "lower-case"],
+    }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,11 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "deps"
-      include: "scope"
-
+      prefix: "chore(dependabot)"
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: "chore(dependabot)"

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -1,0 +1,23 @@
+name: PR Title Check
+run-name: ${{github.event.pull_request.title}}
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitlintRulesPath: ".commitlint.js"
+          # If the PR contains a single commit, fail if the commit message and the PR title do not match.
+          commitTitleMatch: "false"
+          # Disable linting commits messages due to the "Squash Merging" PR workflow.
+          ignoreCommits: "true"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,18 +6,21 @@ changelog:
     - title: Bug fixes
       regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
       order: 1
+    - title: Dependencies
+      regexp: '^.*?deps(\([[:word:]]+\))??!?:.+$'
+      order: 2
     - title: Documentation
       regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
-      order: 2
+      order: 3
     - title: Test suites
       regexp: '^.*?test(\([[:word:]]+\))??!?:.+$'
-      order: 3
+      order: 4
     - title: Features
       order: 0
   filters:
     exclude:
-        - '^.*?refactor(\([[:word:]]+\))??!?:.+$'
-        - '^.*?deps(\([[:word:]]+\))??!?:.+$'
+        - '^.*?chore(\([[:word:]]+\))??!?:.+$'
+        - '^(B|b)ump'
 release:
   extra_files:
     - glob: template.yaml

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,19 +4,20 @@ changelog:
   sort: asc
   groups:
     - title: Bug fixes
-      regexp: '^[(\[]?(B|b)ug'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
       order: 1
     - title: Documentation
-      regexp: '^(.*?(D|d)ocs.*?)|(.*?(D|d)ocument.*?)$'
+      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
       order: 2
     - title: Test suites
-      regexp: '^((T|t)est)|(.*?[\s-_](T|t)est)'
+      regexp: '^.*?test(\([[:word:]]+\))??!?:.+$'
       order: 3
     - title: Features
       order: 0
   filters:
     exclude:
-        - '^(B|b)ump'
+        - '^.*?refactor(\([[:word:]]+\))??!?:.+$'
+        - '^.*?deps(\([[:word:]]+\))??!?:.+$'
 release:
   extra_files:
     - glob: template.yaml

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -43,7 +43,7 @@ This release process covers the steps to release new major and minor versions fo
 
 9. Verify the [Prow Status](https://status.build.kyma-project.io/) of the postsubmit job (`post-telemetry-manager-release-module`).
    - Once the postsubmit job succeeds, the new Github release is available under [releases](https://github.com/kyma-project/telemetry-manager/releases).
-   - If the postsubmit job failed, retrigger it by removing the tag from upstream and pushing it again:
+   - If the postsubmit job fails, retrigger it by removing the tag from upstream and pushing it again:
      ```bash
      git push --delete upstream {RELEASE_VERSION}
      git push upstream {RELEASE_VERSION}
@@ -66,11 +66,11 @@ Due to the Squash merge Github Workflow, each PR results in a single commit afte
 * **docs**. Changes regarding the documentation.
 * **test**. The test suite alternations.
 * **deps**. The changes in the external dependencies.
-* **chore**. Anything not covered by the above categories (e.g. refactoring or artefacts building alternations).
+* **chore**. Anything not covered by the above categories (e.g., refactoring or artefacts building alternations).
 
 Beware that PRs of type `chore` do not appear in the Changelog for the release. Therefore, exclude maintenance changes that are not interesting to consumers of the project by marking them with chore type:
 
-* Dotfile changes (.gitignore, .github and so forth).
+* Dotfile changes (.gitignore, .github, and so forth).
 * Changes to development-only dependencies.
 * Minor code style changes.
 * Formatting changes in documentation.
@@ -81,4 +81,4 @@ The subject must describe the change and follow the recommendations:
 
 * Describe a change using the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood).  It must start with a present-tense verb, for example (but not limited to) Add, Document, Fix, Deprecate.
 * Start with an uppercase.
-* Kyma [capitalization](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#capitalization) and [termonology](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#terminology) guides.
+* Kyma [capitalization](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#capitalization) and [terminology](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#terminology) guides.

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -1,14 +1,16 @@
-# Release Process
+# Releasing
+
+## Release Process
 
 This release process covers the steps to release new major and minor versions for the Kyma Telemetry module.
 
 1. Verify that all issues in the [Github milestone](https://github.com/kyma-project/telemetry-manager/milestones) related to the version are closed.
 
-1. Close the milestone.
+2. Close the milestone.
 
-1. Create a new [Github milestone](https://github.com/kyma-project/telemetry-manager/milestones) for the next version.
+3. Create a new [Github milestone](https://github.com/kyma-project/telemetry-manager/milestones) for the next version.
 
-1. Bump the `telemetry-manager/main` branch with the new versions for the dependent images.
+4. Bump the `telemetry-manager/main` branch with the new versions for the dependent images.
    Create a PR to `telemetry-manager/main` with the following changes:
    - `Makefile`:
       - Ensure the `IMG` variable reflects the latest `telemetry-manager` version.
@@ -18,9 +20,9 @@ This release process covers the steps to release new major and minor versions fo
    - `sec-scanners-config.yaml`:
       - Ensure that all images listed in the `protecode` field have the same versions as those used in the `main.go` file.
 
-1. Merge the PR.
+5. Merge the PR.
 
-1. In the `telemetry-manager` repository, create a release branch.
+6. In the `telemetry-manager` repository, create a release branch.
    The name of this branch must follow the `release-x.y` pattern, such as `release-1.0`.
    ```bash
    git fetch upstream
@@ -28,21 +30,55 @@ This release process covers the steps to release new major and minor versions fo
    git push upstream {RELEASE_BRANCH}
    ```
 
-1. In the `telemetry-manager/{RELEASE_BRANCH}` branch, create a release tag for the head commit.
+7. In the `telemetry-manager/{RELEASE_BRANCH}` branch, create a release tag for the head commit.
    ```bash
    git tag -a {RELEASE_VERSION} -m "Release {RELEASE_VERSION}"
    ```
    Replace {RELEASE_VERSION} with the new module release version, for example, `1.0.0`. The release tag points to the HEAD commit in `telemetry-manager/main` and `telemetry-manager/{RELEASE_BRANCH}` branches.
 
-1. Push the tag to trigger a postsubmit job (`post-telemetry-manager-release-module`) that creates the GitHub release.
+8. Push the tag to trigger a postsubmit job (`post-telemetry-manager-release-module`) that creates the GitHub release.
    ```bash
    git push upstream {RELEASE_VERSION}
    ```
 
-1. Verify the [Prow Status](https://status.build.kyma-project.io/) of the postsubmit job (`post-telemetry-manager-release-module`).
+9. Verify the [Prow Status](https://status.build.kyma-project.io/) of the postsubmit job (`post-telemetry-manager-release-module`).
    - Once the postsubmit job succeeds, the new Github release is available under [releases](https://github.com/kyma-project/telemetry-manager/releases).
    - If the postsubmit job failed, retrigger it by removing the tag from upstream and pushing it again:
      ```bash
      git push --delete upstream {RELEASE_VERSION}
      git push upstream {RELEASE_VERSION}
      ```
+
+## Changelog
+
+Every PR's title must adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for an automatic changelog generation. It is enforced by a [Conventional Pull Request](https://github.com/marketplace/actions/conventional-pull-request) GitHub Action and a [Commitlint](https://commitlint.js.org/#/reference-rules).
+
+### Pull Request Title
+
+Due to the Squash merge Github Workflow, each PR results in a single commit after merging into the main development branch. The PR's title becomes the commit message and must adhere to the template:
+
+`type(scope?): subject`
+
+#### Type
+
+* **feat**. A new feature or functionality change.
+* **fix**. A bug or regression fix.
+* **docs**. Changes regarding the documentation.
+* **test**. The test suite alternations.
+* **deps**. The changes in the external dependencies.
+* **chore**. Anything not covered by the above categories (e.g. refactoring or artefacts building alternations).
+
+Beware that PRs of type `chore` do not appear in the Changelog for the release. Therefore, exclude maintenance changes that are not interesting to consumers of the project by marking them with chore type:
+
+* Dotfile changes (.gitignore, .github and so forth).
+* Changes to development-only dependencies.
+* Minor code style changes.
+* Formatting changes in documentation.
+
+#### Subject
+
+The subject must describe the change and follow the recommendations:
+
+* Describe a change using the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood).  It must start with a present-tense verb, for example (but not limited to) Add, Document, Fix, Deprecate.
+* Start with an uppercase.
+* Kyma [capitalization](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#capitalization) and [termonology](https://github.com/kyma-project/community/blob/main/docs/guidelines/content-guidelines/02-style-and-terminology.md#terminology) guides.


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- Add a GitHub action to support PR title validation using the ConventionalCommits specification.
- Augment the goreleaser to adhere to the ConventionalCommits messages.
- Alter the Dependabot commit messages to fit into the ConventionalCommits expectations.

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

None

## Traceability

Irrelevant

## Testability

Irrelevant 

## Codebase

Irrelevant
