### PR TITLE
fix: Make insecure flag in tls config optional

### DIFF
--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -50,7 +50,7 @@ type Header struct {
 
 type OtlpTLS struct {
 	// Defines whether to send requests using plaintext instead of TLS.
-	Insecure bool `json:"insecure"`
+	Insecure bool `json:"insecure,omitempty"`
 	// Defines whether to skip server certificate verification when using TLS.
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 	// Defines an optional CA certificate for server certificate verification when using TLS. The certificate needs to be provided in PEM format.

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -263,8 +263,6 @@ spec:
                                     type: object
                                 type: object
                             type: object
-                        required:
-                        - insecure
                         type: object
                     required:
                     - endpoint

--- a/config/development/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/development/telemetry.kyma-project.io_metricpipelines.yaml
@@ -298,8 +298,6 @@ spec:
                                     type: object
                                 type: object
                             type: object
-                        required:
-                        - insecure
                         type: object
                     required:
                     - endpoint

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -96,7 +96,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;cert.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string |  |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;cert.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string |  |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;cert.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string |  |
-| **output.&#x200b;otlp.&#x200b;tls.&#x200b;insecure** (required) | boolean | Defines whether to send requests using plaintext instead of TLS. |
+| **output.&#x200b;otlp.&#x200b;tls.&#x200b;insecure**  | boolean | Defines whether to send requests using plaintext instead of TLS. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;insecureSkipVerify**  | boolean | Defines whether to skip server certificate verification when using TLS. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;key**  | object | Defines the client key to use when using TLS. The key needs to be provided in PEM format. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;key.&#x200b;value**  | string | Value that can contain references to Secret values. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -107,7 +107,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;cert.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string |  |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;cert.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string |  |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;cert.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string |  |
-| **output.&#x200b;otlp.&#x200b;tls.&#x200b;insecure** (required) | boolean | Defines whether to send requests using plaintext instead of TLS. |
+| **output.&#x200b;otlp.&#x200b;tls.&#x200b;insecure**  | boolean | Defines whether to send requests using plaintext instead of TLS. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;insecureSkipVerify**  | boolean | Defines whether to skip server certificate verification when using TLS. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;key**  | object | Defines the client key to use when using TLS. The key needs to be provided in PEM format. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;key.&#x200b;value**  | string | Value that can contain references to Secret values. |


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

https://github.com/kyma-project/telemetry-manager/pull/347 added mTLS support for TracePipelines. The added TLS sub-resource of the CRD make the `insecure` flag mandatory. This PR makes the flag optional and defaults to `false`.

Changes proposed in this pull request:

- Make insecure flag in OTLP TLS settings optional

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues: https://github.com/kyma-project/kyma/issues/17995

## Traceability

- [x] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [ ] No, because unit tests are not needed.
- [x] No, because only the CRD is changed, not visible in Go code

The feature is e2e-tested:

- [ ] Yes.
- [ ] No, because e2e-tests are not needed.
- [x] No, because only the CRD is changed, not visible in Go code

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [x] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
