### PR TITLE
fix: Reconcile webhook while waiting for module deletion

### DIFF
--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -144,7 +144,7 @@ func (r *Reconciler) reconcileWebhook(ctx context.Context, telemetry *operatorv1
 		return nil
 	}
 
-	if !telemetry.DeletionTimestamp.IsZero() {
+	if !telemetry.DeletionTimestamp.IsZero() && !r.dependentCRsFound(ctx) {
 		return nil
 	}
 

--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -144,6 +144,7 @@ func (r *Reconciler) reconcileWebhook(ctx context.Context, telemetry *operatorv1
 		return nil
 	}
 
+	// We skip webhook reconciliation only if no pipelines are remaining. This avoids the risk of certificate expiration while waiting for deletion.
 	if !telemetry.DeletionTimestamp.IsZero() && !r.dependentCRsFound(ctx) {
 		return nil
 	}

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -181,8 +181,8 @@ func testWebhookReconciliation() {
 		Expect(k8sClient.Delete(ctx, &validatingWebhookConfiguration)).Should(Succeed())
 	})
 
-	var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
 	Eventually(func(g Gomega) {
+		var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
 		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
 		g.Expect(validatingWebhookConfiguration.UID).ShouldNot(Equal(oldUID))
 	}, timeout, interval).Should(Succeed())

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -73,19 +73,7 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 		})
 
 		It("Should reconcile ValidatingWebhookConfiguration", func() {
-			var oldUID types.UID
-			By("Deleting ValidatingWebhookConfiguration", func() {
-				var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
-				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
-				oldUID = validatingWebhookConfiguration.UID
-				Expect(k8sClient.Delete(ctx, &validatingWebhookConfiguration)).Should(Succeed())
-			})
-
-			var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
-				g.Expect(validatingWebhookConfiguration.UID).ShouldNot(Equal(oldUID))
-			}, timeout, interval).Should(Succeed())
+			testWebhookReconciliation()
 		})
 
 		It("Should reconcile CA bundle secret", func() {
@@ -155,6 +143,10 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 			}, timeout, interval).Should(Succeed())
 		})
 
+		It("Should reconcile ValidatingWebhookConfiguration if LogPipeline exists", func() {
+			testWebhookReconciliation()
+		})
+
 		It("Should delete Telemetry", func() {
 			By("Deleting Telemetry and other resources", func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sLogPipelineObject...)).Should(Succeed())
@@ -179,6 +171,22 @@ var _ = Describe("Telemetry-module", Label("logging", "tracing", "metrics"), Ord
 		})
 	})
 })
+
+func testWebhookReconciliation() {
+	var oldUID types.UID
+	By("Deleting ValidatingWebhookConfiguration", func() {
+		var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
+		oldUID = validatingWebhookConfiguration.UID
+		Expect(k8sClient.Delete(ctx, &validatingWebhookConfiguration)).Should(Succeed())
+	})
+
+	var validatingWebhookConfiguration admissionv1.ValidatingWebhookConfiguration
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: webhookName}, &validatingWebhookConfiguration)).Should(Succeed())
+		g.Expect(validatingWebhookConfiguration.UID).ShouldNot(Equal(oldUID))
+	}, timeout, interval).Should(Succeed())
+}
 
 func makeTestPipelineK8sObjects() []client.Object {
 	logPipeline := kitlog.NewPipeline(telemetryTestK8SObjectName)


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

The Telemetry CRD controller reconciles the ValidatingWebhookConfiguration for the LogPipeline and LogParser CRDs. The reconciliation of the webhook was stopped after the Telemetry CR had a deletion timestamp. This could lead an expiring certificate while waiting for remaining pipelines. The PR changes the behaviour to reconcile the webhook until all pipelines are deleted.

Changes proposed in this pull request:

- Reconcile webhook while waiting for module deletion

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues:

## Traceability

- [ ] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [x] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [x] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [x] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [x] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [x] This PR adds value and shows no feature creep.
- [x] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
