### PR TITLE
test: Unify timeouts for Consistently usage

### DIFF
--- a/test/e2e/consts.go
+++ b/test/e2e/consts.go
@@ -7,8 +7,10 @@ import (
 )
 
 const (
-	timeout  = time.Second * 60
-	interval = time.Millisecond * 250
+	timeout                  = time.Second * 60
+	reconciliationTimeout    = time.Second * 10
+	telemetryDeliveryTimeout = time.Second * 20
+	interval                 = time.Millisecond * 250
 
 	// The filename for the OpenTelemetry collector's file exporter.
 	telemetryDataFilename = "otlp-data.jsonl"

--- a/test/e2e/logging_annotation_test.go
+++ b/test/e2e/logging_annotation_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Logging", Label("logging"), func() {
 					ContainLogs(WithKubernetesAnnotations()),
 					Not(ContainLogs(WithKubernetesLabels())),
 				)))
-			}, timeout, interval).Should(Succeed())
+			}, telemetryDeliveryTimeout, interval).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/logging_exclude_container_test.go
+++ b/test/e2e/logging_exclude_container_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"net/http"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,7 +72,7 @@ var _ = Describe("Logging", Label("logging"), func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(SatisfyAll(
 					Not(ContainLogs(WithContainer("log-spammer"))))))
-			}, 20*time.Second, interval).Should(Succeed())
+			}, telemetryDeliveryTimeout, interval).Should(Succeed())
 		})
 
 	})

--- a/test/e2e/logging_label_test.go
+++ b/test/e2e/logging_label_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Logging", Label("logging"), func() {
 					ContainLogs(WithKubernetesLabels()),
 					Not(ContainLogs(WithKubernetesAnnotations())),
 				)))
-			}, timeout, interval).Should(Succeed())
+			}, telemetryDeliveryTimeout, interval).Should(Succeed())
 		})
 
 	})

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,9 +28,8 @@ import (
 )
 
 var (
-	metricGatewayBaseName               = "telemetry-metric-gateway"
-	maxNumberOfMetricPipelines          = 3
-	metricPipelineReconciliationTimeout = 10 * time.Second
+	metricGatewayBaseName      = "telemetry-metric-gateway"
+	maxNumberOfMetricPipelines = 3
 )
 
 var _ = Describe("Metrics", Label("metrics"), func() {
@@ -222,7 +220,7 @@ var _ = Describe("Metrics", Label("metrics"), func() {
 				var deployment appsv1.Deployment
 				key := types.NamespacedName{Name: "telemetry-metric-gateway", Namespace: "kyma-system"}
 				g.Expect(k8sClient.Get(ctx, key, &deployment)).To(Succeed())
-			}, metricPipelineReconciliationTimeout, interval).ShouldNot(Succeed())
+			}, reconciliationTimeout, interval).ShouldNot(Succeed())
 		})
 
 		It("Should have running metricpipeline", func() {
@@ -441,7 +439,7 @@ func metricPipelineShouldStayPending(pipelineName string) {
 		key := types.NamespacedName{Name: pipelineName}
 		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 		g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.MetricPipelineRunning)).To(BeFalse())
-	}, metricPipelineReconciliationTimeout, interval).Should(Succeed())
+	}, reconciliationTimeout, interval).Should(Succeed())
 }
 
 func addCumulativeToDeltaConversion(metricPipeline telemetryv1alpha1.MetricPipeline) {
@@ -467,7 +465,7 @@ func metricPipelineShouldNotBeDeployed(pipelineName string) {
 		configString := collectorConfig.Data["relay.conf"]
 		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
 		return !strings.Contains(configString, pipelineAlias)
-	}, metricPipelineReconciliationTimeout, interval).Should(BeTrue())
+	}, reconciliationTimeout, interval).Should(BeTrue())
 }
 
 // makeMetricsTestK8sObjects returns the list of mandatory E2E test suite k8s objects.

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -31,9 +30,8 @@ import (
 )
 
 var (
-	traceGatewayBaseName               = "telemetry-trace-collector"
-	maxNumberOfTracePipelines          = 3
-	tracePipelineReconciliationTimeout = 10 * time.Second
+	traceGatewayBaseName      = "telemetry-trace-collector"
+	maxNumberOfTracePipelines = 3
 )
 
 var _ = Describe("Tracing", Label("tracing"), func() {
@@ -163,7 +161,7 @@ var _ = Describe("Tracing", Label("tracing"), func() {
 				var deployment appsv1.Deployment
 				key := types.NamespacedName{Name: "telemetry-trace-collector", Namespace: "kyma-system"}
 				g.Expect(k8sClient.Get(ctx, key, &deployment)).To(Succeed())
-			}, tracePipelineReconciliationTimeout, interval).ShouldNot(Succeed())
+			}, reconciliationTimeout, interval).ShouldNot(Succeed())
 		})
 
 		It("Should have running tracepipeline", func() {
@@ -379,7 +377,7 @@ func tracePipelineShouldStayPending(pipelineName string) {
 		key := types.NamespacedName{Name: pipelineName}
 		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 		g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning)).To(BeFalse())
-	}, tracePipelineReconciliationTimeout, interval).Should(Succeed())
+	}, reconciliationTimeout, interval).Should(Succeed())
 }
 
 func tracePipelineShouldBeDeployed(pipelineName string) {
@@ -401,7 +399,7 @@ func tracePipelineShouldNotBeDeployed(pipelineName string) {
 		configString := collectorConfig.Data["relay.conf"]
 		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
 		return !strings.Contains(configString, pipelineAlias)
-	}, tracePipelineReconciliationTimeout, interval).Should(BeTrue())
+	}, reconciliationTimeout, interval).Should(BeTrue())
 }
 
 // makeTracingTestK8sObjects returns the list of mandatory E2E test suite k8s objects.


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

Ginkgo's `Consistently` calls were used with different timeouts for similar purposes. This PR introduces two different timeouts, one for tests that wait for reconciliation, one for timeouts that wait for telemetry data delivery.

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- Unify timeouts for Consistently usage

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues:

## Traceability

- [ ] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [x] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [x] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [x] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [x] The code was planned and designed following the defined architecture and the separation of concerns.
- [x] The code has sufficient comments, particularly for all hard-to-understand areas.
- [x] This PR adds value and shows no feature creep.
- [x] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
