### PR TITLE
feat: Update to otel-collector 0.87.0 and fluentbit 2.1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY webhook/ webhook/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go mod tidy && go build -a -o manager main.go
 
 # Use the fluent-bit image because we need the fluent-bit binary
-FROM europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.9-6130ed2c
+FROM europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-35ea5d89
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/config/samples/http-mockserver.yaml
+++ b/config/samples/http-mockserver.yaml
@@ -37,7 +37,7 @@ spec:
             - -i http
             - -o stdout
             - -q
-          image: europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.9-6130ed2c
+          image: europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-35ea5d89
           livenessProbe:
             tcpSocket:
               port: serviceport

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -45,6 +45,7 @@ func makeKubeletStatsConfig() *KubeletStatsReceiver {
 	return &KubeletStatsReceiver{
 		CollectionInterval: collectionInterval,
 		AuthType:           "serviceAccount",
+		InsecureSkipVerify: true,
 		Endpoint:           fmt.Sprintf("https://${env:%s}:%d", config.EnvVarCurrentNodeName, portKubelet),
 		MetricGroups:       []MetricGroupType{MetricGroupTypeContainer, MetricGroupTypePod},
 	}

--- a/internal/otelcollector/config/metric/agent/receivers_test.go
+++ b/internal/otelcollector/config/metric/agent/receivers_test.go
@@ -29,6 +29,7 @@ func TestReceivers(t *testing.T) {
 
 		require.NotNil(t, collectorConfig.Receivers.KubeletStats)
 		require.Equal(t, "serviceAccount", collectorConfig.Receivers.KubeletStats.AuthType)
+		require.Equal(t, true, collectorConfig.Receivers.KubeletStats.InsecureSkipVerify)
 		require.Equal(t, "https://${env:MY_NODE_NAME}:10250", collectorConfig.Receivers.KubeletStats.Endpoint)
 		require.Equal(t, false, collectorConfig.Receivers.KubeletStats.InsecureSkipVerify)
 

--- a/internal/otelcollector/config/metric/agent/receivers_test.go
+++ b/internal/otelcollector/config/metric/agent/receivers_test.go
@@ -31,7 +31,6 @@ func TestReceivers(t *testing.T) {
 		require.Equal(t, "serviceAccount", collectorConfig.Receivers.KubeletStats.AuthType)
 		require.Equal(t, true, collectorConfig.Receivers.KubeletStats.InsecureSkipVerify)
 		require.Equal(t, "https://${env:MY_NODE_NAME}:10250", collectorConfig.Receivers.KubeletStats.Endpoint)
-		require.Equal(t, false, collectorConfig.Receivers.KubeletStats.InsecureSkipVerify)
 
 		require.Nil(t, collectorConfig.Receivers.PrometheusSelf)
 		require.Nil(t, collectorConfig.Receivers.PrometheusAppPods)

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_active.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_active.yaml
@@ -48,7 +48,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${env:MY_NODE_NAME}:10250
-        insecure_skip_verify: false
+        insecure_skip_verify: true
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_active.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_active.yaml
@@ -48,7 +48,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${env:MY_NODE_NAME}:10250
-        insecure_skip_verify: false
+        insecure_skip_verify: true
         metric_groups:
             - container
             - pod

--- a/main.go
+++ b/main.go
@@ -134,10 +134,10 @@ var (
 )
 
 const (
-	otelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.86.0-6f994b09"
+	otelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.87.0-35ea5d89"
 	overridesConfigMapName = "telemetry-override-config"
-	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.9-6130ed2c"
-	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20230911-5d49c958"
+	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-35ea5d89"
+	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231011-c6f25b5b"
 
 	fluentBitDaemonSet = "telemetry-fluent-bit"
 	webhookServiceName = "telemetry-operator-webhook"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,9 +1,9 @@
 module-name: telemetry
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231005-7938fb33
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.86.0-6f994b09
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.9-6130ed2c
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20230911-5d49c958
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.87.0-35ea5d89
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-35ea5d89
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231011-c6f25b5b
 whitesource:
   language: golang-mod
   subprojects: false

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -20,8 +20,38 @@ import (
 )
 
 var (
-	kubeletMetricNames      = []string{"container.cpu.time", "container.cpu.utilization", "container.filesystem.available", "container.filesystem.capacity", "container.filesystem.usage", "container.memory.available", "container.memory.major_page_faults", "container.memory.page_faults", "container.memory.rss", "container.memory.usage", "container.memory.working_set", "k8s.pod.cpu.time", "k8s.pod.cpu.utilization", "k8s.pod.filesystem.available", "k8s.pod.filesystem.capacity", "k8s.pod.filesystem.usage", "k8s.pod.memory.available", "k8s.pod.memory.major_page_faults", "k8s.pod.memory.page_faults", "k8s.pod.memory.rss", "k8s.pod.memory.usage", "k8s.pod.memory.working_set", "k8s.pod.network.errors", "k8s.pod.network.io"}
-	kubeletMetricAttributes = []string{"k8s.cluster.name", "k8s.container.name", "k8s.namespace.name", "k8s.node.name", "k8s.pod.name", "k8s.pod.uid"}
+	kubeletMetricNames = []string{
+		"container.cpu.time",
+		"container.cpu.utilization",
+		"container.filesystem.available",
+		"container.filesystem.capacity",
+		"container.filesystem.usage",
+		"container.memory.available",
+		"container.memory.major_page_faults",
+		"container.memory.page_faults",
+		"container.memory.rss",
+		"container.memory.usage",
+		"container.memory.working_set",
+		"k8s.pod.cpu.time",
+		"k8s.pod.cpu.utilization",
+		"k8s.pod.filesystem.available",
+		"k8s.pod.filesystem.capacity",
+		"k8s.pod.filesystem.usage",
+		"k8s.pod.memory.available",
+		"k8s.pod.memory.major_page_faults",
+		"k8s.pod.memory.page_faults",
+		"k8s.pod.memory.rss",
+		"k8s.pod.memory.usage",
+		"k8s.pod.memory.working_set",
+		"k8s.pod.network.errors",
+		"k8s.pod.network.io"}
+	kubeletMetricResourceAttributes = []string{
+		"k8s.cluster.name",
+		"k8s.container.name",
+		"k8s.namespace.name",
+		"k8s.node.name",
+		"k8s.pod.name",
+		"k8s.pod.uid"}
 )
 
 var _ = Describe("Metrics Runtime Input", Label("metrics"), func() {
@@ -90,7 +120,7 @@ var _ = Describe("Metrics Runtime Input", Label("metrics"), func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should verify kubelet metric attributes", func() {
+		It("Should verify kubelet metric resource attributes", func() {
 			Eventually(func(g Gomega) {
 				resp, err := proxyClient.Get(telemetryExportURL)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Metrics Runtime Input", Label("metrics"), func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(
-					ConsistOfMds(ContainResourceAttrs(HaveKey(BeElementOf(kubeletMetricAttributes)))),
+					ConsistOfMds(ContainResourceAttrs(HaveKey(BeElementOf(kubeletMetricResourceAttributes)))),
 				))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})

--- a/test/testkit/mocks/backend/deployment.go
+++ b/test/testkit/mocks/backend/deployment.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	replicas           = 1
-	otelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.86.0-6f994b09"
+	otelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.87.0-35ea5d89"
 	nginxImage         = "europe-docker.pkg.dev/kyma-project/prod/external/nginx:1.23.3"
 	fluentDImage       = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluentd:v1.16-debian-1"
 )


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- update to otel-collector 0.87.0
- update to fluentbit 2.1.10
- update to latest directory-size-exporter
- The otel-collector update introduced a breaking change to the kubeletstatsreceiver, see [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.87.0). The insecure_skip_verify flag was ignored. Not it gets honored and as the default value is false, it broke the setup. I switched it to true for now as on Gardener it seems to be not able to verify the used certificate. A follow-up needs to be done on how we could disable it.
- The new metrics exported by the kubeletstatsreceiver are all optional and need to get enabled explicitly

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues:
https://github.com/kyma-project/third-party-images/pull/388
https://github.com/kyma-project/directory-size-exporter/pull/32


## Traceability

- [ ] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [x] Yes.
- [ ] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [x] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [ ] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
