### PR TITLE
chore: Introduce test targets not requiring k3d

### DIFF
--- a/.github/workflows/pull-governance.yml
+++ b/.github/workflows/pull-governance.yml
@@ -1,7 +1,6 @@
 name: Governance
 run-name: ${{github.event.pull_request.title}}
 on:
-  pull_request:
   pull_request_target:
     types:
       - opened

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ run-e2e-test-tracing: ginkgo test-matchers ## run end-to-end tracing tests using
 
 .PHONY: run-e2e-test-metrics
 run-e2e-test-metrics: ginkgo test-matchers ## run end-to-end metrics tests using an existing cluster
-	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="icke" ./test/e2e
+	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="metrics" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 

--- a/Makefile
+++ b/Makefile
@@ -103,44 +103,56 @@ provision-test-env:
 	K8S_VERSION=$(ENVTEST_K8S_VERSION) hack/provision-test-env.sh
 
 .PHONY: e2e-test
-e2e-test: ginkgo k3d  | test-matchers provision-test-env ## Provision k3d cluster and run end-to-end tests.
+e2e-test: k3d provision-test-env ## Provision k3d cluster and run end-to-end tests.
 	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+	make run-e2e-test
+
+.PHONY: e2e-test-logging
+e2e-test-logging: k3d provision-test-env ## Provision k3d cluster, deploy development variant and run end-to-end logging tests.
+	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+	make run-e2e-test-logging
+
+.PHONY: e2e-test-tracing
+e2e-test-tracing: k3d provision-test-env ## Provision k3d cluster, deploy development variant and run end-to-end tracing tests.
+	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+	make run-e2e-test-tracing
+
+.PHONY: e2e-test-metrics
+e2e-test-metrics: k3d provision-test-env ## Provision k3d cluster, deploy development variant and run end-to-end metrics tests.
+	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+	make run-e2e-test-metrics
+
+.PHONY: e2e-test-logging-release
+e2e-test-logging-release: k3d provision-test-env ## Provision k3d cluster, deploy release (default) variant and run end-to-end logging tests.
+	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy
+	make run-e2e-test-logging
+
+.PHONY: e2e-test-tracing-release
+e2e-test-tracing-release: k3d provision-test-env ## Provision k3d cluster, deploy release (default) variant and run end-to-end tracing tests.
+	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy
+	make run-e2e-test-tracing
+
+.PHONY: run-e2e-test
+run-e2e-test: ginkgo test-matchers ## run all end-to-end tests using an existing cluster
 	$(GINKGO) run --tags e2e --junit-report=junit.xml ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 
-.PHONY: e2e-test-logging
-e2e-test-logging: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy development variant and run end-to-end logging tests.
-	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+.PHONY: run-e2e-test-logging
+run-e2e-test-logging: ginkgo test-matchers ## run end-to-end metrics tests using an existing cluster
 	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="logging" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 
-.PHONY: e2e-test-tracing
-e2e-test-tracing: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy development variant and run end-to-end tracing tests.
-	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+.PHONY: run-e2e-test-tracing
+run-e2e-test-tracing: ginkgo test-matchers ## run end-to-end tracing tests using an existing cluster
 	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="tracing" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 
-.PHONY: e2e-test-metrics
- e2e-test-metrics: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy development variant and run end-to-end metrics tests.
-	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
-	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="metrics" ./test/e2e
-	mkdir -p ${ARTIFACTS}
-	mv junit.xml ${ARTIFACTS}
-
-.PHONY: e2e-test-logging-release
-e2e-test-logging-release: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy release (default) variant and run end-to-end logging tests.
-	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy
-	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="logging" ./test/e2e
-	mkdir -p ${ARTIFACTS}
-	mv junit.xml ${ARTIFACTS}
-
-.PHONY: e2e-test-tracing-release
-e2e-test-tracing-release: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy release (default) variant and run end-to-end tracing tests.
-	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy
-	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="tracing" ./test/e2e
+.PHONY: run-e2e-test-metrics
+run-e2e-test-metrics: ginkgo test-matchers ## run end-to-end metrics tests using an existing cluster
+	$(GINKGO) run --tags e2e --junit-report=junit.xml --label-filter="icke" ./test/e2e
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 
@@ -161,8 +173,12 @@ e2e-coverage: ginkgo
 
 .PHONY: integration-test-istio
 integration-test-istio: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy development variant and run integration tests with istio.
-	ISTIO_VERSION=$(ISTIO_VERSION) hack/deploy-istio.sh
 	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev
+	make run-integration-test-istio
+
+.PHONY: run-integration-test-istio
+run-integration-test-istio: ginkgo test-matchers ## run integration tests with istio on an existing cluster
+	ISTIO_VERSION=$(ISTIO_VERSION) hack/deploy-istio.sh
 	$(GINKGO) run --tags istio --flake-attempts=5 --junit-report=junit.xml ./test/integration/istio
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
@@ -328,23 +344,18 @@ GARDENER_K8S_VERSION?=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloud
 endif
 
 # log tests are excluded for now as they are too flaky
-.PHONY: run-tests
-run-tests: ginkgo ## Run e2e tests on existing cluster using image related to git commit sha
+.PHONY: run-tests-with-git-image
+run-tests-with-git-image: ## Run e2e tests on existing cluster using image related to git commit sha
 	kubectl create namespace kyma-system
 	IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} make deploy-dev
-	mkdir -p ${ARTIFACTS}
-	$(GINKGO) run --tags e2e --junit-report=traces-junit.xml --label-filter="tracing" ./test/e2e
-	mv traces-junit.xml ${ARTIFACTS}
-	$(GINKGO) run --tags e2e --junit-report=metrics-junit.xml --label-filter="metrics" ./test/e2e
-	mv metrics-junit.xml ${ARTIFACTS}
-	ISTIO_VERSION=$(ISTIO_VERSION) hack/deploy-istio.sh
-	$(GINKGO) run --tags istio --flake-attempts=5 --junit-report=istio-junit.xml ./test/integration/istio
-	mv istio-junit.xml ${ARTIFACTS}
+	make run-e2e-test-tracing
+	make run-e2e-test-metrics
+	make run-integration-test-istio
 
 .PHONY: gardener-integration-test
 gardener-integration-test: ## Provision gardener cluster and run integration test on it.
 	make provision-gardener \
-		run-tests \
+		run-tests-with-git-image \
 		deprovision-gardener || \
 		(make deprovision-gardener && false)
 


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

There is no make target available to run e2e tests local on an existing cluster. This is very inconvenient when running tests against an existing installation. This PR splits up the existing targets to be independent on the cluster and manager installation while keeping the k3d based targets. 

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- split up the test targets to have a version based on k3d and a version not based on any cluster
- Adjust gardener integration test to use the cluster-less targets
- Adjusted governance github action to not get triggered twice

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues:

## Traceability

- [ ] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [ ] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [ ] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [ ] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
