### PR TITLE
fix: Fix noisy span filter rule for healthz endpoint

### DIFF
--- a/internal/otelcollector/config/trace/gateway/processors.go
+++ b/internal/otelcollector/config/trace/gateway/processors.go
@@ -103,7 +103,7 @@ var (
 	toFromTelemetryMetricGateway = joinWithAnd(componentIsProxy, namespacesIsKymaSystem, istioCanonicalNameEquals("telemetry-metric-gateway"))
 	toFromTelemetryMetricAgent   = joinWithAnd(componentIsProxy, namespacesIsKymaSystem, istioCanonicalNameEquals("telemetry-metric-agent"))
 
-	toIstioGatewayWitHealthz = joinWithAnd(componentIsProxy, namespacesIsIstioSystem, methodIsGet, operationIsEgress, istioCanonicalNameEquals("istio-ingressgateway"), urlIsIstioHealthz)
+	toIstioGatewayWithHealthz = joinWithAnd(componentIsProxy, namespacesIsIstioSystem, methodIsGet, operationIsEgress, istioCanonicalNameEquals("istio-ingressgateway"), urlIsIstioHealthz)
 
 	toTelemetryTraceService         = joinWithAnd(componentIsProxy, methodIsPost, operationIsEgress, urlIsTelemetryTraceService)
 	toTelemetryTraceInternalService = joinWithAnd(componentIsProxy, methodIsPost, operationIsEgress, urlIsTelemetryTraceInternalService)
@@ -123,7 +123,7 @@ func makeSpanFilterConfig() []string {
 		toFromTelemetryTraceGateway,
 		toFromTelemetryMetricGateway,
 		toFromTelemetryMetricAgent,
-		toIstioGatewayWitHealthz,
+		toIstioGatewayWithHealthz,
 		toTelemetryTraceService,
 		toTelemetryTraceInternalService,
 		toTelemetryMetricService,

--- a/internal/otelcollector/config/trace/gateway/processors_test.go
+++ b/internal/otelcollector/config/trace/gateway/processors_test.go
@@ -81,7 +81,7 @@ func TestProcessors(t *testing.T) {
 		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toFromTelemetryTraceGateway, "toFromTelemetryTraceGateway span filter is missing")
 		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toFromTelemetryMetricGateway, "toFromTelemetryMetricGateway span filter is missing")
 		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toFromTelemetryMetricAgent, "toFromTelemetryMetricAgent span filter is missing")
-		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toIstioGatewayWitHealthz, "toIstioGatewayWitHealthz span filter is missing")
+		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toIstioGatewayWithHealthz, "toIstioGatewayWitHealthz span filter is missing")
 		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toTelemetryTraceService, "toTelemetryTraceService span filter is missing")
 		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toTelemetryTraceInternalService, "toTelemetryTraceInternalService span filter is missing")
 		require.Contains(t, collectorConfig.Processors.SpanFilter.Traces.Span, toTelemetryMetricService, "toTelemetryTraceInternalService span filter is missing")

--- a/test/testkit/otlp/traces/helpers.go
+++ b/test/testkit/otlp/traces/helpers.go
@@ -86,7 +86,7 @@ func MakeAndSendIstioHealthzEndpointTraces(proxyClient *apiserver.ProxyClient, o
 	attrs.PutStr("http.method", "GET")
 	attrs.PutStr("component", "proxy")
 	attrs.PutStr("istio.canonical_service", "istio-ingressgateway")
-	attrs.PutStr("OperationName", "Ingress")
+	attrs.PutStr("OperationName", "Egress")
 	attrs.PutStr("http.url", "https://healthz.some-url/healthz/ready")
 
 	resAttrs := pcommon.NewMap()


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

The trace filter rule changed in https://github.com/kyma-project/telemetry-manager/pull/468 about the /healthz endpoint was wrong. The test was adjusted right to use the "Egress" operation but the filter rule was still filtering for "Ingress"

All spans created by the istio-ingressgateway are of type "egress", there is no point in filtering for "ingress"
I adjusted the rule.

Still not clear how the change could have been merged in first place. Most probably there is a flakyness on receiving spans which at the merge was kicking-in so that the span was wrongly assumed to be filtered out. Currently the tests on main are failing.
<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- Adjusted the rule to be correct as demanded by the test

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues:

## Traceability

- [ ] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [ ] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [ ] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [ ] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
