### PR TITLE
fix: Consider LogPipeline undeployable only if grafana-loki output is defined with non-empty url

### DIFF
--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -291,7 +291,7 @@ func getDeployableLogPipelines(ctx context.Context, allPipelines []telemetryv1al
 		if secretref.ReferencesNonExistentSecret(ctx, client, &allPipelines[i]) {
 			continue
 		}
-		if allPipelines[i].Spec.Output.Loki != nil {
+		if allPipelines[i].Spec.Output.IsLokiDefined() {
 			continue
 		}
 		deployablePipelines = append(deployablePipelines, allPipelines[i])

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -59,7 +59,7 @@ func (r *Reconciler) updateStatusConditions(ctx context.Context, pipelineName st
 
 	log := logf.FromContext(ctx)
 
-	if pipeline.Spec.Output.Loki != nil {
+	if pipeline.Spec.Output.IsLokiDefined() {
 		pending := telemetryv1alpha1.NewLogPipelineCondition(conditions.ReasonUnsupportedLokiOutput, telemetryv1alpha1.LogPipelinePending)
 
 		if pipeline.Status.HasCondition(telemetryv1alpha1.LogPipelineRunning) {


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- If LogPipeline is defined with `grafana-loki` output, it should stay in `Pending` State and considered undeployable only if it has a non-empty url.

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:
#461
Related issues:

## Traceability

- [x] The PR is linked to a GitHub Issue.
- [x] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [ ] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [ ] Yes.
- [ ] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [x] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [x] The code was planned and designed following the defined architecture and the separation of concerns.
- [x] The code has sufficient comments, particularly for all hard-to-understand areas.
- [x] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
