### PR TITLE
test: Fix E2E tests on Gardener

### DIFF
--- a/test/e2e/metrics_service_name_test.go
+++ b/test/e2e/metrics_service_name_test.go
@@ -125,7 +125,8 @@ var _ = Describe("Metrics Service Name", Label("metrics"), func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(
 					ContainMd(
-						ContainResourceAttrs(HaveKeyWithValue("service.name", "unknown_service")),
+						// on a Gardener cluster, API server proxy traffic is routed through vpn-shoot, so service.name is set respectively
+						ContainResourceAttrs(HaveKeyWithValue("service.name", BeElementOf("unknown_service", "vpn-shoot"))),
 					),
 				))
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())

--- a/test/e2e/traces_service_name_test.go
+++ b/test/e2e/traces_service_name_test.go
@@ -123,7 +123,8 @@ var _ = Describe("Traces Service Name", Label("tracing"), func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(
 					ContainTd(
-						ContainResourceAttrs(HaveKeyWithValue("service.name", "unknown_service")),
+						// on a Gardener cluster, API server proxy traffic is routed through vpn-shoot, so service.name is set respectively
+						ContainResourceAttrs(HaveKeyWithValue("service.name", BeElementOf("unknown_service", "vpn-shoot"))),
 					),
 				))
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- On a Gardener cluster, API server proxy traffic is routed through vpn-shoot, so service.name is set respectively
