### PR TITLE
test: Increase timeout for gomega.Eventually blocks

### DIFF
--- a/test/integration/istio/metrics_otlp_input_test.go
+++ b/test/integration/istio/metrics_otlp_input_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Metrics OTLP Input", Label("metrics"), func() {
 
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+				verifiers.ShouldNotExist(ctx, k8sClient, k8sObjects...)
 			})
 
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())

--- a/test/testkit/periodic/periodic.go
+++ b/test/testkit/periodic/periodic.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	// EventuallyTimeout is used when asserting an event with Eventually.
-	EventuallyTimeout = time.Second * 60
+	// EventuallyTimeout is used when asserting an event with Eventually. Should be larger than periodic reconciliation interval.
+	EventuallyTimeout = time.Second * 120
 
 	// ConsistentlyTimeout is used when asserting the absence of an event with Consistently.
 	ConsistentlyTimeout = time.Second * 10

--- a/test/testkit/verifiers/objects.go
+++ b/test/testkit/verifiers/objects.go
@@ -1,0 +1,22 @@
+package verifiers
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+)
+
+func ShouldNotExist(ctx context.Context, k8sClient client.Client, resources ...client.Object) {
+	for _, resource := range resources {
+		gomega.Eventually(func(g gomega.Gomega) {
+			key := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
+			err := k8sClient.Get(ctx, key, resource)
+			g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+		}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+	}
+}


### PR DESCRIPTION
<!--   

Thank you for your contribution!

Before submitting your pull request, please follow these steps:

1. Adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
5. Fill in the checklists below.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/docs/governance/01-governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

We recently changed the operator do to not watch Secrets outside the system namespace and lowered the periodic reconciliation frequency to 60s to compensate this. This change might have caused some test flakyness since gomega's Eventually blocks retried only for 60 seconds. This PR increases the timeout to ensure a reconciliation in rare cases.

<!-- Add a brief description of WHAT was done and WHY. -->

Changes proposed in this pull request:

- Increase timeout for gomega.Eventually blocks to 120s

## Related Issues and Documents

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Closes:

Related issues: https://github.com/kyma-project/telemetry-manager/issues/464, https://github.com/kyma-project/telemetry-manager/pull/489

## Traceability

- [ ] The PR is linked to a GitHub Issue.
- [ ] New features have a milestone label set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub Issue has a respective `area` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.

## Testability

The feature is unit-tested:

- [ ] Yes.
- [x] No, because unit tests are not needed.
- [ ] No, because of ...

The feature is e2e-tested:

- [ ] Yes.
- [x] No, because e2e-tests are not needed.
- [ ] No, because of ...

<!--
Please describe the tests you ran to verify your changes if needed. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
-->
Tests conducted for the PR:

<!-- Test description goes here -->

## Codebase

- [ ] My code follows the [Effective Go](https://go.dev/doc/effective_go) style guidelines.
- [ ] The code was planned and designed following the defined architecture and the separation of concerns.
- [ ] The code has sufficient comments, particularly for all hard-to-understand areas.
- [ ] This PR adds value and shows no feature creep.
- [ ] I have augmented the test suite that proves my fix is effective or that my feature works.
- [ ] Adjusted the documentation if the change is user-facing.
