### PR TITLE
chore: Bump images and module version for releasing 1.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231117-fd906e1e
+IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231205-b118b822
 # ENVTEST_K8S_VERSION refers to the version of Kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.27.1
 ISTIO_VERSION ?= 1.2.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: v20231117-fd906e1e
+  newTag: v20231205-b118b822

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ const (
 	overridesConfigMapName = "telemetry-override-config"
 	overridesConfigMapKey  = "override-config"
 	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-a5234020"
-	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231108-b1ec4cab"
+	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231201-02a1befc"
 
 	fluentBitDaemonSet = "telemetry-fluent-bit"
 	webhookServiceName = "telemetry-operator-webhook"

--- a/module-config-dev.yaml
+++ b/module-config-dev.yaml
@@ -1,6 +1,6 @@
 name: kyma-project.io/module/telemetry
 channel: experimental
-version: 1.4.0-dev
+version: 1.5.0-dev
 manifest: telemetry-manager-dev.yaml
 security: sec-scanners-config.yaml
 defaultCR: ./config/samples/operator_v1alpha1_telemetry.yaml

--- a/module-config.yaml
+++ b/module-config.yaml
@@ -1,6 +1,6 @@
 name: kyma-project.io/module/telemetry
 channel: fast
-version: 1.4.0
+version: 1.5.0
 manifest: telemetry-manager.yaml
 security: sec-scanners-config.yaml
 defaultCR: ./config/samples/operator_v1alpha1_telemetry.yaml

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -3,7 +3,7 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231205-b118b822
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.89.0-25ff4383
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-a5234020
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231108-b1ec4cab
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231201-02a1befc
 whitesource:
   language: golang-mod
   subprojects: false

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: telemetry
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231117-fd906e1e
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231205-b118b822
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.89.0-25ff4383
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-a5234020
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231108-b1ec4cab


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bumped the operator image and module version in preparation of releasing version 1.5.0
- bumped image for directory-size-exporter

Changes refer to particular issues, PRs or documents:


## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->