### PR TITLE
chore: Update directory-size-exporter to use Go 1.21.5

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ const (
 	overridesConfigMapName = "telemetry-override-config"
 	overridesConfigMapKey  = "override-config"
 	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-a5234020"
-	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231201-02a1befc"
+	fluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231206-af68e692"
 
 	fluentBitDaemonSet = "telemetry-fluent-bit"
 	webhookServiceName = "telemetry-operator-webhook"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -3,7 +3,7 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:v20231205-b118b822
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.89.0-25ff4383
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.1.10-a5234020
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231201-02a1befc
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231206-af68e692
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Update directory-size-exporter to use Go 1.21.5

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/directory-size-exporter/pull/37

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->