### PR TITLE
fix: Do not intercept outgoing connections from metric agent by Istio

### DIFF
--- a/internal/resources/otelcollector/agent.go
+++ b/internal/resources/otelcollector/agent.go
@@ -130,7 +130,8 @@ proxyMetadata:
   OUTPUT_CERTS: %s
 `, istioCertPath),
 		"sidecar.istio.io/userVolumeMount":              fmt.Sprintf(`[{"name": "%s", "mountPath": "%s"}]`, istioCertVolumeName, istioCertPath),
-		"traffic.sidecar.istio.io/includeInboundPorts":  "",
 		"traffic.sidecar.istio.io/includeOutboundPorts": strconv.Itoa(ports.OTLPGRPC),
+		"traffic.sidecar.istio.io/excludeInboundPorts":  strconv.Itoa(ports.Metrics),
+		"traffic.sidecar.istio.io/excludeOutboundPorts": strconv.Itoa(ports.IstioEnvoy),
 	}
 }

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -75,6 +75,8 @@ func TestApplyAgentResources(t *testing.T) {
 		require.Equal(t, "[{\"name\": \"istio-certs\", \"mountPath\": \"/etc/istio-output-certs\"}]", podAnnotations["sidecar.istio.io/userVolumeMount"])
 		require.Equal(t, "", podAnnotations["traffic.sidecar.istio.io/includeInboundPorts"])
 		require.Equal(t, "4317", podAnnotations["traffic.sidecar.istio.io/includeOutboundPorts"])
+		require.Equal(t, "8888", podAnnotations["traffic.sidecar.istio.io/excludeInboundPorts"])
+		require.Equal(t, "15090", podAnnotations["traffic.sidecar.istio.io/excludeOutboundPorts"])
 
 		//collector container
 		require.Len(t, ds.Spec.Template.Spec.Containers, 1)
@@ -196,6 +198,7 @@ func TestApplyAgentResources(t *testing.T) {
 		}, svc.Spec.Selector)
 		require.Equal(t, map[string]string{
 			"prometheus.io/port":   "8888",
+			"prometheus.io/scheme": "http",
 			"prometheus.io/scrape": "true",
 		}, svc.Annotations)
 		require.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)

--- a/internal/resources/otelcollector/core.go
+++ b/internal/resources/otelcollector/core.go
@@ -112,6 +112,7 @@ func makeMetricsService(name types.NamespacedName) *corev1.Service {
 			Annotations: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   strconv.Itoa(ports.Metrics),
+				"prometheus.io/scheme": "http",
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/internal/resources/otelcollector/gateway_test.go
+++ b/internal/resources/otelcollector/gateway_test.go
@@ -220,6 +220,7 @@ func TestApplyGatewayResources(t *testing.T) {
 		}, svc.Spec.Selector)
 		require.Equal(t, map[string]string{
 			"prometheus.io/port":   "8888",
+			"prometheus.io/scheme": "http",
 			"prometheus.io/scrape": "true",
 		}, svc.Annotations)
 		require.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)

--- a/test/integration/istio/metrics_istio_input_test.go
+++ b/test/integration/istio/metrics_istio_input_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Metrics Istio Input", Label("metrics"), func() {
 			"istio_tcp_connections_opened_total",
 			"istio_tcp_connections_closed_total",
 		}
-		istioProxyMetricResourceAttributes = []string{
+		istioProxyMetricAttributes = []string{
 			"connection_security_policy",
 			"destination_app",
 			"destination_canonical_revision",
@@ -128,13 +128,16 @@ var _ = Describe("Metrics Istio Input", Label("metrics"), func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should verify istio proxy metric resource attributes", func() {
+		It("Should verify istio proxy metric attributes", func() {
 			Eventually(func(g Gomega) {
 				resp, err := proxyClient.Get(telemetryExportURL)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(
-					ContainMd(ContainMetric(ContainDataPointAttrs(HaveKey(BeElementOf(istioProxyMetricResourceAttributes))))),
+					ContainMd(ContainMetric(SatisfyAll(
+						ContainDataPointAttrs(HaveKey(BeElementOf(istioProxyMetricAttributes))),
+						ContainDataPointAttrs(HaveKeyWithValue("source_workload_namespace", app1Ns)),
+					))),
 				))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Do not intercept outgoing connections from metric agent by Istio

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/606

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->