### PR TITLE
chore: Improve import linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,10 +113,6 @@ issues:
       text: "shadow: declaration of \"err\" shadows declaration at line ([\\d]+)"
       linters:
         - govet
-    - linters: [ gci ]
-      path: test/e2e/(traces.*|metrics.*|logs.*)_test.go
-    - linters: [ gci ]
-      path: test/integration/(istio.*)_test.go
     - linters: [ dupl ]
       path: controllers/telemetry/(logparser|logpipeline|metricpipeline|tracepipeline)_controller.go
     - linters: [ dupl ]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -82,6 +82,7 @@ linters-settings:
 
   stylecheck:
     dot-import-whitelist:
+      # Allows using dot imports for Ginkgo and Gomega (out-of-the-box and custom matchers)
       - github.com/onsi/ginkgo/v2
       - github.com/onsi/gomega
       - github.com/kyma-project/telemetry-manager/test/testkit/matchers/log

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,14 +117,14 @@ issues:
       path: controllers/telemetry/(logparser|logpipeline|metricpipeline|tracepipeline)_controller.go
     - linters: [ dupl ]
       path: internal/kubernetes/utils.go
-    - linters: [ dupl ]
-      path: test/testkit/verifiers/(deployment|daemonset|metrics|traces).go
-    - linters: [ dupl ]
-      path: test/testkit/matchers/(log|metric|trace)_matchers.go
-      # Unify components checkers after getting rid of custom conditions in favor of metav1.Conditions
+    # Unify components checkers after getting rid of custom conditions in favor of metav1.Conditions
     - linters: [ dupl ]
       path: internal/reconciler/telemetry/(log|metric|trace)_components_checker.go
     - linters: [ dupl ]
-      path: main.go
+      path: test/testkit/matchers/(log|metric|trace)_matchers.go
     - linters: [ errcheck ]
       path: test/testkit/otlp/traces/traces.go
+    - linters: [ dupl ]
+      path: test/testkit/verifiers/(deployment|daemonset|metrics|traces).go
+    - linters: [ dupl ]
+      path: main.go

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -124,12 +124,6 @@ issues:
     - linters: [ dupl ]
       path: test/testkit/verifiers/(deployment|daemonset|metrics|traces).go
     - linters: [ dupl ]
-      path: test/e2e/metrics_test.go
-    - linters: [ dupl ]
-      path: test/e2e/logging_test.go
-    - linters: [ dupl ]
-      path: test/e2e/tracing_test.go
-    - linters: [ dupl ]
       path: internal/reconciler/tracepipeline/reconciler_test.go
     - linters: [ dupl ]
       path: test/testkit/matchers/(log|metric|trace)_matchers.go

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -118,13 +118,7 @@ issues:
     - linters: [ dupl ]
       path: internal/kubernetes/utils.go
     - linters: [ dupl ]
-      path: test/testkit/matchers/trace_matchers_test.go
-    - linters: [ dupl ]
-      path: test/testkit/matchers/prometheus_matcher_test.go
-    - linters: [ dupl ]
       path: test/testkit/verifiers/(deployment|daemonset|metrics|traces).go
-    - linters: [ dupl ]
-      path: internal/reconciler/tracepipeline/reconciler_test.go
     - linters: [ dupl ]
       path: test/testkit/matchers/(log|metric|trace)_matchers.go
       # Unify components checkers after getting rid of custom conditions in favor of metav1.Conditions

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,7 +61,6 @@ linters-settings:
       - default                                              # Imports that could not be matched to another section type.
       - prefix(github.com/kyma-project/telemetry-manager)    # Imports with the specified Prefix.
       - blank                                                # Blank imports
-      - dot                                                  # Dot imports
     custom-order: true
 
   goimports:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,10 +80,20 @@ linters-settings:
   misspell:
     locale: US
 
+  stylecheck:
+    dot-import-whitelist:
+      - github.com/onsi/ginkgo/v2
+      - github.com/onsi/gomega
+      - github.com/kyma-project/telemetry-manager/test/testkit/matchers/log
+      - github.com/kyma-project/telemetry-manager/test/testkit/matchers/metric
+      - github.com/kyma-project/telemetry-manager/test/testkit/matchers/trace
+      - github.com/kyma-project/telemetry-manager/test/testkit/matchers/prometheus
+
   nolintlint:
     allow-unused: true
     require-explanation: true
     require-specific: true
+
   revive:
     rules:
       - name: dot-imports

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help: ## Display this help.
 
 ##@ Development
 lint-autofix: golangci-lint ## Autofix all possible linting errors.
-	${GOLANGCI-LINT} run -E goimports --fix
+	${GOLANGCI-LINT} run --fix
 
 lint-manifests:
 	hack/lint-manifests.sh

--- a/controllers/operator/suite_test.go
+++ b/controllers/operator/suite_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,11 +37,6 @@ import (
 	operatorv1alpha1 "github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/telemetry"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	//nolint:gci // Mandatory kubebuilder imports scaffolding.
-	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/controllers/operator/telemetry_controller_test.go
+++ b/controllers/operator/telemetry_controller_test.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -10,9 +12,6 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Deploying a Telemetry", Ordered, func() {

--- a/controllers/telemetry/logparser_controller_test.go
+++ b/controllers/telemetry/logparser_controller_test.go
@@ -18,15 +18,14 @@ package telemetry
 import (
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/logparser"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/expfmt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,9 +22,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/fluentbit/config/builder"
 	logpipelinereconciler "github.com/kyma-project/telemetry-manager/internal/reconciler/logpipeline"
 	logpipelineresources "github.com/kyma-project/telemetry-manager/internal/resources/fluentbit"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/controllers/telemetry/metricpipeline_controller_test.go
+++ b/controllers/telemetry/metricpipeline_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -15,9 +17,6 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/metricpipeline"
 	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/controllers/telemetry/suite_test.go
+++ b/controllers/telemetry/suite_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	zapLog "go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,9 +46,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/logpipeline"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/metricpipeline"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/tracepipeline"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/controllers/telemetry/tracepipeline_controller_test.go
+++ b/controllers/telemetry/tracepipeline_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -15,9 +17,6 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/tracepipeline"
 	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/test/e2e/logs_annotation_test.go
+++ b/test/e2e/logs_annotation_test.go
@@ -5,20 +5,18 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 )
 
 var _ = Describe("Logs Keep Annotations", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_basic_test.go
+++ b/test/e2e/logs_basic_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -11,9 +13,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Logs Basic", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_custom_output_test.go
+++ b/test/e2e/logs_custom_output_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -11,9 +13,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Logs Custom Output", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_dedot_test.go
+++ b/test/e2e/logs_dedot_test.go
@@ -5,20 +5,18 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 )
 
 var _ = Describe("Logs Dedot", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_exclude_container_test.go
+++ b/test/e2e/logs_exclude_container_test.go
@@ -5,20 +5,18 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 )
 
 var _ = Describe("Logs Exclude Container", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_label_test.go
+++ b/test/e2e/logs_label_test.go
@@ -5,20 +5,18 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 )
 
 var _ = Describe("Logs Drop Labels", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_mtls_test.go
+++ b/test/e2e/logs_mtls_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -11,9 +13,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Logs mTLS", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_parser_test.go
+++ b/test/e2e/logs_parser_test.go
@@ -6,20 +6,18 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/logproducer"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 )
 
 var _ = Describe("Logs Parser", Label("logging"), Ordered, func() {

--- a/test/e2e/logs_webhook_test.go
+++ b/test/e2e/logs_webhook_test.go
@@ -3,15 +3,13 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
 )

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -14,9 +16,6 @@ import (
 
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Telemetry Manager", func() {

--- a/test/e2e/metrics_basic_test.go
+++ b/test/e2e/metrics_basic_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"

--- a/test/e2e/metrics_secret_rotation_test.go
+++ b/test/e2e/metrics_secret_rotation_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
@@ -10,9 +12,6 @@ import (
 	kitmetric "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Metrics Secret Rotation", Label("metrics"), func() {

--- a/test/e2e/metrics_service_name_test.go
+++ b/test/e2e/metrics_service_name_test.go
@@ -5,24 +5,22 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	kitmetric "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
-	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
-	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
-	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/metric"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/servicenamebundle"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	kitmetrics "github.com/kyma-project/telemetry-manager/test/testkit/otlp/metrics"
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
 )
 
 var _ = Describe("Metrics Service Name", Label("metrics"), func() {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,9 +22,6 @@ import (
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	"github.com/kyma-project/telemetry-manager/test/testkit/k8s/apiserver"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 const (

--- a/test/e2e/telemetry_test.go
+++ b/test/e2e/telemetry_test.go
@@ -5,6 +5,8 @@ package e2e
 import (
 	"slices"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,9 +19,6 @@ import (
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	kitlog "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var (

--- a/test/e2e/traces_basic_test.go
+++ b/test/e2e/traces_basic_test.go
@@ -6,26 +6,23 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	kittrace "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	kittraces "github.com/kyma-project/telemetry-manager/test/testkit/otlp/traces"
-	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
 )
 
 var _ = Describe("Traces Basic", Label("tracing"), func() {

--- a/test/e2e/traces_mtls_test.go
+++ b/test/e2e/traces_mtls_test.go
@@ -5,6 +5,8 @@ package e2e
 import (
 	"fmt"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,9 +18,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/urlprovider"
 	kittraces "github.com/kyma-project/telemetry-manager/test/testkit/otlp/traces"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Traces mTLS", Label("tracing"), func() {

--- a/test/e2e/traces_multi_pipeline_test.go
+++ b/test/e2e/traces_multi_pipeline_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"slices"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,9 +20,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/urlprovider"
 	kittraces "github.com/kyma-project/telemetry-manager/test/testkit/otlp/traces"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Traces Multi-Pipeline", Label("tracing"), func() {

--- a/test/e2e/traces_noisy_span_filter_test.go
+++ b/test/e2e/traces_noisy_span_filter_test.go
@@ -5,6 +5,8 @@ package e2e
 import (
 	"fmt"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,9 +18,6 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/urlprovider"
 	kittraces "github.com/kyma-project/telemetry-manager/test/testkit/otlp/traces"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Traces Noisy Span Filter", Label("tracing"), func() {

--- a/test/e2e/traces_secret_rotation_test.go
+++ b/test/e2e/traces_secret_rotation_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
@@ -10,9 +12,6 @@ import (
 	kittrace "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Traces Secret Rotation", Label("tracing"), func() {

--- a/test/e2e/traces_service_name_test.go
+++ b/test/e2e/traces_service_name_test.go
@@ -5,24 +5,22 @@ package e2e
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	kittrace "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
-	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
-	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
-	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/trace"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/servicenamebundle"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	kittraces "github.com/kyma-project/telemetry-manager/test/testkit/otlp/traces"
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
 )
 
 var _ = Describe("Traces Service Name", Label("tracing"), func() {

--- a/test/testkit/matchers/log/log_matcher_test.go
+++ b/test/testkit/matchers/log/log_matcher_test.go
@@ -1,10 +1,9 @@
 package log
 
 import (
-	"go.opentelemetry.io/collector/pdata/plog"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/collector/pdata/plog"
 )
 
 var _ = Describe("WithLds", func() {

--- a/test/testkit/matchers/metric/metric_matchers_test.go
+++ b/test/testkit/matchers/metric/metric_matchers_test.go
@@ -1,12 +1,11 @@
 package metric
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	kitmetrics "github.com/kyma-project/telemetry-manager/test/testkit/otlp/metrics"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("WithMds", func() {

--- a/test/testkit/matchers/trace/trace_matchers_test.go
+++ b/test/testkit/matchers/trace/trace_matchers_test.go
@@ -1,13 +1,12 @@
 package trace
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	kittraces "github.com/kyma-project/telemetry-manager/test/testkit/otlp/traces"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("WithTds", func() {

--- a/webhook/logpipeline/webhook_suite_test.go
+++ b/webhook/logpipeline/webhook_suite_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -39,9 +41,6 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/webhook/logpipeline/mocks"
 	validationmocks "github.com/kyma-project/telemetry-manager/webhook/logpipeline/validation/mocks"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 const (

--- a/webhook/logpipeline/webhook_test.go
+++ b/webhook/logpipeline/webhook_test.go
@@ -3,6 +3,8 @@ package logpipeline
 import (
 	"errors"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,9 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var testLogPipeline = types.NamespacedName{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove a separate `dot` section from `gci` linter configuration. This section contradicts `prefix(github.com/kyma-project/telemetry-manager)` when our own matcher are evaluated since we also use dot imports there.
- Fix `make autofix` by enabling all linters (not only `goimports`).
- Re-enable `gci` linting for E2E tests.
- Clean up the exclude rules.


## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->