### PR TITLE
chore: Use dot import for gomega matchers in testkit

### DIFF
--- a/test/testkit/verifiers/daemonset.go
+++ b/test/testkit/verifiers/daemonset.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,11 +14,11 @@ import (
 )
 
 func DaemonSetShouldBeReady(ctx context.Context, k8sClient client.Client, name types.NamespacedName) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		ready, err := isDaemonSetReady(ctx, k8sClient, name)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(ready).To(gomega.BeTrue())
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ready).To(BeTrue())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }
 
 func isDaemonSetReady(ctx context.Context, k8sClient client.Client, name types.NamespacedName) (bool, error) {

--- a/test/testkit/verifiers/deployment.go
+++ b/test/testkit/verifiers/deployment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,11 +14,11 @@ import (
 )
 
 func DeploymentShouldBeReady(ctx context.Context, k8sClient client.Client, name types.NamespacedName) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		ready, err := isDeploymentReady(ctx, k8sClient, name)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(ready).To(gomega.BeTrue())
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ready).To(BeTrue())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }
 
 func isDeploymentReady(ctx context.Context, k8sClient client.Client, name types.NamespacedName) (bool, error) {

--- a/test/testkit/verifiers/logs.go
+++ b/test/testkit/verifiers/logs.go
@@ -4,33 +4,33 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/test/testkit/k8s/apiserver"
-	"github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 )
 
 func LogsShouldBeDelivered(proxyClient *apiserver.ProxyClient, expectedPodNamePrefix string, telemetryExportURL string) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		resp, err := proxyClient.Get(telemetryExportURL)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
-		g.Expect(resp).To(gomega.HaveHTTPStatus(http.StatusOK))
-		g.Expect(resp).To(gomega.HaveHTTPBody(log.ContainLd(log.ContainLogRecord(
-			log.WithPodName(gomega.ContainSubstring(expectedPodNamePrefix))),
+		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+		g.Expect(resp).To(HaveHTTPBody(ContainLd(ContainLogRecord(
+			WithPodName(ContainSubstring(expectedPodNamePrefix))),
 		)))
-	}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(gomega.Succeed())
+	}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }
 
 func LogPipelineShouldBeRunning(ctx context.Context, k8sClient client.Client, pipelineName string) {
-	gomega.Eventually(func(g gomega.Gomega) bool {
+	Eventually(func(g Gomega) bool {
 		var pipeline telemetryv1alpha1.LogPipeline
 		key := types.NamespacedName{Name: pipelineName}
-		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(gomega.Succeed())
+		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 		return pipeline.Status.HasCondition(telemetryv1alpha1.LogPipelineRunning)
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.BeTrue())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(BeTrue())
 }

--- a/test/testkit/verifiers/metrics.go
+++ b/test/testkit/verifiers/metrics.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,86 +15,86 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/test/testkit/k8s/apiserver"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
-	"github.com/kyma-project/telemetry-manager/test/testkit/matchers/metric"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/metric"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 )
 
 func MetricPipelineShouldBeRunning(ctx context.Context, k8sClient client.Client, pipelineName string) {
-	gomega.Eventually(func(g gomega.Gomega) bool {
+	Eventually(func(g Gomega) bool {
 		var pipeline telemetryv1alpha1.MetricPipeline
 		key := types.NamespacedName{Name: pipelineName}
-		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(gomega.Succeed())
+		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 		return pipeline.Status.HasCondition(telemetryv1alpha1.MetricPipelineRunning)
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.BeTrue())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(BeTrue())
 }
 
 func MetricPipelineShouldNotBeRunning(ctx context.Context, k8sClient client.Client, pipelineName string) {
-	gomega.Consistently(func(g gomega.Gomega) {
+	Consistently(func(g Gomega) {
 		var pipeline telemetryv1alpha1.MetricPipeline
 		key := types.NamespacedName{Name: pipelineName}
-		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(gomega.Succeed())
-		g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.MetricPipelineRunning)).To(gomega.BeFalse())
-	}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+		g.Expect(pipeline.Status.HasCondition(telemetryv1alpha1.MetricPipelineRunning)).To(BeFalse())
+	}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 }
 
 func MetricGatewayConfigShouldContainPipeline(ctx context.Context, k8sClient client.Client, pipelineName string) {
-	gomega.Eventually(func(g gomega.Gomega) bool {
+	Eventually(func(g Gomega) bool {
 		var collectorConfig corev1.ConfigMap
-		g.Expect(k8sClient.Get(ctx, kitkyma.MetricGatewayName, &collectorConfig)).To(gomega.Succeed())
+		g.Expect(k8sClient.Get(ctx, kitkyma.MetricGatewayName, &collectorConfig)).To(Succeed())
 		configString := collectorConfig.Data["relay.conf"]
 		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
 		return strings.Contains(configString, pipelineAlias)
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.BeTrue())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(BeTrue())
 }
 
 func MetricGatewayConfigShouldNotContainPipeline(ctx context.Context, k8sClient client.Client, pipelineName string) {
-	gomega.Consistently(func(g gomega.Gomega) bool {
+	Consistently(func(g Gomega) bool {
 		var collectorConfig corev1.ConfigMap
-		g.Expect(k8sClient.Get(ctx, kitkyma.MetricGatewayName, &collectorConfig)).To(gomega.Succeed())
+		g.Expect(k8sClient.Get(ctx, kitkyma.MetricGatewayName, &collectorConfig)).To(Succeed())
 		configString := collectorConfig.Data["relay.conf"]
 		pipelineAlias := fmt.Sprintf("otlp/%s", pipelineName)
 		return !strings.Contains(configString, pipelineAlias)
-	}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(gomega.BeTrue())
+	}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(BeTrue())
 }
 
 func MetricsShouldBeDelivered(proxyClient *apiserver.ProxyClient, telemetryExportURL string, metrics []pmetric.Metric) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		resp, err := proxyClient.Get(telemetryExportURL)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(resp).To(gomega.HaveHTTPStatus(http.StatusOK))
-		g.Expect(resp).To(gomega.HaveHTTPBody(metric.ConsistOfMds(metric.WithMetrics(gomega.BeEquivalentTo(metrics)))))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+		g.Expect(resp).To(HaveHTTPBody(ConsistOfMds(WithMetrics(BeEquivalentTo(metrics)))))
 		err = resp.Body.Close()
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-	}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+	}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }
 
 func MetricsFromNamespaceShouldBeDelivered(proxyClient *apiserver.ProxyClient, telemetryExportURL, namespace string, metricNames []string) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		resp, err := proxyClient.Get(telemetryExportURL)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(resp).To(gomega.HaveHTTPStatus(http.StatusOK))
-		g.Expect(resp).To(gomega.HaveHTTPBody(
-			metric.ContainMd(gomega.SatisfyAll(
-				metric.ContainMetric(metric.WithName(gomega.BeElementOf(metricNames))),
-				metric.ContainResourceAttrs(gomega.HaveKeyWithValue("k8s.namespace.name", namespace)),
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+		g.Expect(resp).To(HaveHTTPBody(
+			ContainMd(SatisfyAll(
+				ContainMetric(WithName(BeElementOf(metricNames))),
+				ContainResourceAttrs(HaveKeyWithValue("k8s.namespace.name", namespace)),
 			)),
 		))
 		err = resp.Body.Close()
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-	}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+	}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }
 
 func MetricsFromNamespaceShouldNotBeDelivered(proxyClient *apiserver.ProxyClient, telemetryExportURL, namespace string) {
-	gomega.Consistently(func(g gomega.Gomega) {
+	Consistently(func(g Gomega) {
 		resp, err := proxyClient.Get(telemetryExportURL)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(resp).To(gomega.HaveHTTPStatus(http.StatusOK))
-		g.Expect(resp).To(gomega.HaveHTTPBody(
-			gomega.Not(metric.ContainMd(
-				metric.ContainResourceAttrs(gomega.HaveKeyWithValue("k8s.namespace.name", namespace)),
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+		g.Expect(resp).To(HaveHTTPBody(
+			Not(ContainMd(
+				ContainResourceAttrs(HaveKeyWithValue("k8s.namespace.name", namespace)),
 			)),
 		))
 		err = resp.Body.Close()
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-	}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+	}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }

--- a/test/testkit/verifiers/monitoring.go
+++ b/test/testkit/verifiers/monitoring.go
@@ -3,23 +3,23 @@ package verifiers
 import (
 	"net/http"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/kyma-project/telemetry-manager/test/testkit/k8s/apiserver"
-	"github.com/kyma-project/telemetry-manager/test/testkit/matchers/prometheus"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/prometheus"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 )
 
 func ShouldExposeCollectorMetrics(proxyClient *apiserver.ProxyClient, metricsURL string) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		resp, err := proxyClient.Get(metricsURL)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(resp).To(gomega.HaveHTTPStatus(http.StatusOK))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 
 		//Take otelcol_process_uptime metric as an example
-		g.Expect(resp).To(gomega.HaveHTTPBody(prometheus.ContainPrometheusMetric("otelcol_process_uptime")))
+		g.Expect(resp).To(HaveHTTPBody(ContainPrometheusMetric("otelcol_process_uptime")))
 
 		err = resp.Body.Close()
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }

--- a/test/testkit/verifiers/objects.go
+++ b/test/testkit/verifiers/objects.go
@@ -3,7 +3,7 @@ package verifiers
 import (
 	"context"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,10 +13,10 @@ import (
 
 func ShouldNotExist(ctx context.Context, k8sClient client.Client, resources ...client.Object) {
 	for _, resource := range resources {
-		gomega.Eventually(func(g gomega.Gomega) {
+		Eventually(func(g Gomega) {
 			key := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
 			err := k8sClient.Get(ctx, key, resource)
-			g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
-		}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 	}
 }

--- a/test/testkit/verifiers/telemetry.go
+++ b/test/testkit/verifiers/telemetry.go
@@ -3,7 +3,7 @@ package verifiers
 import (
 	"context"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -12,13 +12,13 @@ import (
 )
 
 func WebhookShouldBeHealthy(ctx context.Context, k8sClient client.Client) {
-	gomega.Eventually(func(g gomega.Gomega) {
+	Eventually(func(g Gomega) {
 		var endpoints corev1.Endpoints
-		g.Expect(k8sClient.Get(ctx, kitkyma.TelemetryOperatorWebhookServiceName, &endpoints)).To(gomega.Succeed())
-		g.Expect(endpoints.Subsets).NotTo(gomega.BeEmpty())
+		g.Expect(k8sClient.Get(ctx, kitkyma.TelemetryOperatorWebhookServiceName, &endpoints)).To(Succeed())
+		g.Expect(endpoints.Subsets).NotTo(BeEmpty())
 		for _, subset := range endpoints.Subsets {
-			g.Expect(subset.Addresses).NotTo(gomega.BeEmpty())
-			g.Expect(subset.NotReadyAddresses).To(gomega.BeEmpty())
+			g.Expect(subset.Addresses).NotTo(BeEmpty())
+			g.Expect(subset.NotReadyAddresses).To(BeEmpty())
 		}
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(gomega.Succeed())
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Since Gomega matcher imports were whitelisted in https://github.com/kyma-project/telemetry-manager/pull/612, we can now use dot imports also in the `testkit`, which makes the code much more readable and easier to write

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/pull/612

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->