### PR TITLE
chore: Avoid adding remote origin in release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,8 +260,8 @@ undeploy-dev: ## Undeploy resources based on the development variant from the K8
 ##@ Release Module
 
 .PHONY: release
-release: kyma kustomize ## Create module with its image pushed to prod registry and create a github release entry
-	KYMA=${KYMA} KUSTOMIZE=${KUSTOMIZE} IMG=${IMG} GORELEASER_VERSION=${GORELEASER_VERSION} ./hack/release.sh
+release: kustomize ## Prepare release artefacts and create a GitHub release
+	KUSTOMIZE=${KUSTOMIZE} IMG=${IMG} GORELEASER_VERSION=${GORELEASER_VERSION} ./hack/release.sh
 
 ##@ Build Dependencies
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -19,7 +19,6 @@ function prepare_release_artefacts() {
 
 function create_github_release() {
     echo "Creating the Github release"
-    git remote add origin https://github.com/kyma-project/telemetry-manager
     git reset --hard
     curl -sL https://git.io/goreleaser | VERSION=${GORELEASER_VERSION} bash
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Avoid adding remote origin in the release script. This is not needed anymore since the release target is now being executed in a GitHub action and the remote origin is already added in the [Checkout repo](https://github.com/kyma-project/telemetry-manager/blob/main/.github/workflows/push-release.yml#L11) step. Attempting to add the remote origin after it has already been added causes an error.
- Kyma cli is not a dependency anymore for the release make target, since we are not creating the ModuleTemplate in the release script anymore.

Changes refer to particular issues, PRs or documents:

- #566 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->