### PR TITLE
chore: Add GITHUB_TOKEN env when running release make target

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -27,3 +27,5 @@ jobs:
 
       - name: Release
         run: make release
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- For the `GitHub Release` workflow, add the `GITHUB_TOKEN` environment variable in the step in which we run the release make target. This is needed so that `goreleaser` can publish a GitHub release

Changes refer to particular issues, PRs or documents:

- #566

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->