### PR TITLE
chore: Fetch all history in Github Release workflow

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # wait for the build to succeed so that the manager image is available
       - name: Wait for the 'post-telemetry-manager-build-release' job to succeed


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- By default, the [Checkout](https://github.com/actions/checkout) GitHub action only fetches a single commit. As a result, goreleaser will not be able to create the changelogs since the previous tags are not fetched. We need to set `fetch-depth: 0` to fetch all tags as documented [here](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches).

Changes refer to particular issues, PRs or documents:

- #566 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->