### PR TITLE
docs: Remove obsolete log attribute prefix limitations

### DIFF
--- a/docs/user/02-logs.md
+++ b/docs/user/02-logs.md
@@ -457,8 +457,6 @@ You cannot enable the following plugins, because they potentially harm the stabi
 
 The log attribute named `kubernetes` is a special attribute that's enriched by the `kubernetes` filter. When you use that attribute as part of your structured log payload, the metadata enriched by the filter are overwritten by the payload data. Filters that rely on the original metadata might no longer work as expected.
 
-Furthermore, the `__kyma__` prefix is used internally by Telemetry Manager. When you use the prefix attribute in your log data, the data might be overwritten.
-
 ### Buffer limits
 
 Fluent Bit buffers up to 1 GB of logs if a configured output cannot receive logs. The oldest logs are dropped when the limit is reached or after 300 retries.


### PR DESCRIPTION
## Description

PR #590 changed the Fluent Bit configuration to use one Kubernetes filter per LogPipeline. This also avoids filters for JSON manipulation that used the `__kyma__` attribute prefix.

Changes proposed in this pull request (what was done and why):

- Remove obsolete log attribute prefix limitations

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/479
- https://github.com/kyma-project/telemetry-manager/pull/590

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->