### PR TITLE
fix: Fixed link in docu and adjusted code checks to run also on docu changes only

### DIFF
--- a/.github/template/setup-golang/action.yaml
+++ b/.github/template/setup-golang/action.yaml
@@ -1,5 +1,5 @@
-name: Prepare checks
-description: Prepares everything for static code check execution
+name: Setup Golang
+description: Configures Golang with caching
 
 runs:
   using: "composite"

--- a/.github/workflows/pull-code-checks.yml
+++ b/.github/workflows/pull-code-checks.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Prepare test
-      uses: "./.github/template/prepare-checks"
+    - name: Setup Golang
+      uses: "./.github/template/setup-golang"
 
     - name: Run tests
       run: make test
@@ -29,8 +29,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Prepare test
-        uses: "./.github/template/prepare-checks"
+      - name: Setup Golang
+        uses: "./.github/template/setup-golang"
 
       - name: Run linting
         uses: golangci/golangci-lint-action@v3
@@ -38,32 +38,3 @@ jobs:
           install-mode: binary
           version: latest
           args: --timeout=5m --config=./.golangci.yaml
-
-  verify-manifests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Prepare test
-        uses: "./.github/template/prepare-checks"
-
-      - name: Verify manifests
-        run: make lint-manifests
-
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Validate links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: 'yes'  
-          use-verbose-mode: 'yes'
-          config-file: '.mlc.config.json'
-          folder-path: '.'
-          max-depth: -1
-          check-modified-files-only: 'yes'
-          base-branch: ${{ github.base_ref }}

--- a/.github/workflows/pull-docu-checks.yml
+++ b/.github/workflows/pull-docu-checks.yml
@@ -1,0 +1,38 @@
+name: PR Docu Checks
+
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "release-*"
+  workflow_dispatch:
+
+jobs:
+  verify-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Golang
+        uses: "./.github/template/setup-golang"
+
+      - name: Verify manifests
+        run: make lint-manifests
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Validate links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'  
+          use-verbose-mode: 'yes'
+          config-file: '.mlc.config.json'
+          folder-path: '.'
+          max-depth: -1
+          check-modified-files-only: 'yes'
+          base-branch: ${{ github.base_ref }}

--- a/.github/workflows/pull-github-checks.yml
+++ b/.github/workflows/pull-github-checks.yml
@@ -1,4 +1,4 @@
-name: PR Governance
+name: PR Github Checks
 
 on:
   pull_request_target:
@@ -29,5 +29,4 @@ jobs:
             fix
             test
           requireScope: false
-          # https://regex101.com/r/O5OZvC/1
           subjectPattern: ^([A-Z].*[^.]|bump .*)$

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -75,11 +75,11 @@ For more information, see [Metrics](04-metrics.md) and [Gateways](gateways.md).
 
 With the Telemetry module you can collect telemetry data and ship the data to backends. For details, read the following guides:
 
-- [OpenTelemetry Demo App](/telemetry-manager/user/integration/opentelemetry-demo/README.md)
-- [SAP Cloud Logging](/telemetry-manager/user/integration/sap-cloud-logging/README.md)
-- [Dynatrace](/telemetry-manager/user/integration/dynatrace/README.md)
-- [Loki](/telemetry-manager/user/integration/loki/README.md)
-- [Jaeger](/telemetry-manager/user/integration/jaeger/README.md)
+- [OpenTelemetry Demo App](telemetry-manager/user/integration/opentelemetry-demo/README.md)
+- [SAP Cloud Logging](telemetry-manager/user/integration/sap-cloud-logging/README.md)
+- [Dynatrace](telemetry-manager/user/integration/dynatrace/README.md)
+- [Loki](telemetry-manager/user/integration/loki/README.md)
+- [Jaeger](telemetry-manager/user/integration/jaeger/README.md)
 
 ## API / Custom Resource Definitions
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -13,7 +13,7 @@ Fundamentally, ["Observability"](https://opentelemetry.io/docs/concepts/observab
 
 Kyma's Telemetry module focuses exactly on the aspects of instrumentation, collection, and shipment that happen in the runtime and explicitly defocuses on backends.
 
-> **TIP:** An enterprise-grade setup demands a central solution outside the cluster, so we recommend in-cluster solutions only for testing purposes. If you want to install lightweight in-cluster backends for demo or development purposes, check the [Telemetry tutorials](05-tutorials.md).
+> **TIP:** An enterprise-grade setup demands a central solution outside the cluster, so we recommend in-cluster solutions only for testing purposes. If you want to install lightweight in-cluster backends for demo or development purposes, check the [Telemetry integration guides](#integration-guides).
 
 ## Features
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -75,11 +75,11 @@ For more information, see [Metrics](04-metrics.md) and [Gateways](gateways.md).
 
 With the Telemetry module you can collect telemetry data and ship the data to backends. For details, read the following guides:
 
-- [OpenTelemetry Demo App](telemetry-manager/user/integration/opentelemetry-demo/README.md)
-- [SAP Cloud Logging](telemetry-manager/user/integration/sap-cloud-logging/README.md)
-- [Dynatrace](telemetry-manager/user/integration/dynatrace/README.md)
-- [Loki](telemetry-manager/user/integration/loki/README.md)
-- [Jaeger](telemetry-manager/user/integration/jaeger/README.md)
+- [OpenTelemetry Demo App](integration/opentelemetry-demo/README.md)
+- [SAP Cloud Logging](integration/sap-cloud-logging/README.md)
+- [Dynatrace](integration/dynatrace/README.md)
+- [Loki](integration/loki/README.md)
+- [Jaeger](integration/jaeger/README.md)
 
 ## API / Custom Resource Definitions
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fixed broken link in docu
- Refactored github actions so that markdown checker is running on all commits, even if only docu changes are done

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/directory-size-exporter/pull/39

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->