### PR TITLE
feat: Allow disabling module reconciliation via the override ConfigMap

### DIFF
--- a/docs/contributor/troubleshooting.md
+++ b/docs/contributor/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Pausing or Unpausing Reconciliations
 
-You must pause reconciliations to be able to debug the pipelines and, for example, try out a different pipeline configuration or a different OTel configuration. To pause or unpause reconciliations, follow these steps:
+You must pause reconciliations to be able to debug the pipelines or the Telemetry module. This is also useful to try out a different pipeline configuration or a different OTel configuration. To pause or unpause reconciliations, follow these steps:
 
 1. Create an overriding `telemetry-override-config` ConfigMap in the operator's namespace.
 2. Perform debugging operations.
@@ -30,9 +30,11 @@ data:
       paused: true
     metrics:
       paused: true
+    telemetry:
+      paused: true
 ```
 
-The `global`, `tracing`, `logging` and `metrics` fields are optional.
+The `global`, `tracing`, `logging`, `metrics` and `telemetry` fields are optional.
 
 **Caveats**
 If you change the pipeline CR when the reconciliation is paused, these changes will not be applied immediately but in a periodic reconciliation cycle of one hour. To reconcile earlier, restart Telemetry Manager.

--- a/internal/overrides/config.go
+++ b/internal/overrides/config.go
@@ -1,10 +1,11 @@
 package overrides
 
 type Config struct {
-	Global  GlobalConfig  `yaml:"global,omitempty"`
-	Tracing TracingConfig `yaml:"tracing,omitempty"`
-	Logging LoggingConfig `yaml:"logging,omitempty"`
-	Metrics MetricConfig  `yaml:"metrics,omitempty"`
+	Global    GlobalConfig    `yaml:"global,omitempty"`
+	Tracing   TracingConfig   `yaml:"tracing,omitempty"`
+	Logging   LoggingConfig   `yaml:"logging,omitempty"`
+	Metrics   MetricConfig    `yaml:"metrics,omitempty"`
+	Telemetry TelemetryConfig `yaml:"telemetry,omitempty"`
 }
 
 type GlobalConfig struct {
@@ -20,5 +21,9 @@ type LoggingConfig struct {
 }
 
 type MetricConfig struct {
+	Paused bool `yaml:"paused,omitempty"`
+}
+
+type TelemetryConfig struct {
 	Paused bool `yaml:"paused,omitempty"`
 }

--- a/main.go
+++ b/main.go
@@ -616,10 +616,11 @@ func createTelemetryReconciler(client client.Client, scheme *runtime.Scheme, web
 			OTLPServiceName: metricOTLPServiceName,
 			Namespace:       telemetryNamespace,
 		},
-		Webhook: webhookConfig,
+		Webhook:                webhookConfig,
+		OverridesConfigMapName: types.NamespacedName{Name: overridesConfigMapName, Namespace: telemetryNamespace},
 	}
 
-	return operatorcontrollers.NewTelemetryReconciler(client, telemetry.NewReconciler(client, scheme, config), config)
+	return operatorcontrollers.NewTelemetryReconciler(client, telemetry.NewReconciler(client, scheme, config, overridesHandler), config)
 }
 
 func createWebhookConfig() telemetry.WebhookConfig {

--- a/test/testkit/kyma/overrides/overrides.go
+++ b/test/testkit/kyma/overrides/overrides.go
@@ -28,6 +28,8 @@ tracing:
 logging:
   paused: true
 metrics:
+  paused: true
+telemetry:
   paused: true`
 
 type Overrides struct {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Allow disabling module reconciliation via the override ConfigMap in a similar mechanism as disabling reconciliation for logs, metrics and traces.
- Document the feature in the troubleshooting docs

Changes refer to particular issues, PRs or documents:

- #623

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->