### PR TITLE
docs: Remove leftover notes about metrics feature unavailability

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -65,8 +65,6 @@ For more information, see [Traces](03-traces.md) and [Gateways](gateways.md).
 
 ### Metric Gateway/Agent
 
-> **NOTE:** The feature is not available yet. To understand the current progress, watch this [epic](https://github.com/kyma-project/kyma/issues/13079).
-
 The metric gateway and agent are based on an [OTel Collector](https://opentelemetry.io/docs/collector/) [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) and a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). The gateway provides an [OTLP-based](https://opentelemetry.io/docs/reference/specification/protocol/) endpoint to which applications can push the metric signals. The agent scrapes annotated Prometheus-based workloads. According to a MetricPipeline configuration, the gateway processes and ships the metric data to a target system.
 
 For more information, see [Metrics](04-metrics.md) and [Gateways](gateways.md).

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -1,7 +1,5 @@
 # MetricPipeline
 
-> **Note:** The `metricpipeline.telemetry.kyma-project.io` CustomResourceDefinition is not available yet. To understand the current progress, watch this [epic](https://github.com/kyma-project/kyma/issues/13079).
-
 The `metricpipeline.telemetry.kyma-project.io` CustomResourceDefinition (CRD) is a detailed description of the kind of data and the format used to filter and ship metric data in Kyma. To get the current CRD and show the output in the YAML format, run this command:
 
 ```bash


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove leftover notes about metrics feature unavailability, since the feature will become available in the next release in fast channel

Changes refer to particular issues, PRs or documents:

- #623 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->