### PR TITLE
feat: Enhance Status Message for Max Pipeline Count Exceeded

### DIFF
--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -137,7 +137,7 @@ The state of the metric components is determined by the status condition of type
 | True             | MetricGatewayDeploymentReady          | Metric gateway Deployment is ready                                                                                                           |
 | True             | MetricAgentDaemonSetReady             | Metric agent DaemonSet is ready                                                                                                              |
 | False            | MetricPipelineReferencedSecretMissing | One or more referenced Secrets are missing                                                                                                   |
-| False            | MetricPipelineWaitingForLock          | Waiting for the lock                                                                                                                         |
+| False            | MaxPipelinesExceeded                  | Maximum Pipeline count limit exceeded                                                                                                                         |
 | False            | MetricGatewayDeploymentNotReady       | Metric gateway Deployment is not ready                                                                                                       |
 | False            | MetricAgentDaemonSetNotReady          | Metric agent DaemonSet is not ready                                                                                                          |
 | False            | ResourceBlocksDeletion                | The deletion of the module is blocked. To unblock the deletion, delete the following resources: MetricPipelines (resource-1, resource-2,...) |

--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -137,7 +137,7 @@ The state of the metric components is determined by the status condition of type
 | True             | MetricGatewayDeploymentReady          | Metric gateway Deployment is ready                                                                                                           |
 | True             | MetricAgentDaemonSetReady             | Metric agent DaemonSet is ready                                                                                                              |
 | False            | MetricPipelineReferencedSecretMissing | One or more referenced Secrets are missing                                                                                                   |
-| False            | MaxPipelinesExceeded                  | Maximum Pipeline count limit exceeded                                                                                                                         |
+| False            | MaxPipelinesExceeded                  | Maximum pipeline count exceeded                                                                                                              |
 | False            | MetricGatewayDeploymentNotReady       | Metric gateway Deployment is not ready                                                                                                       |
 | False            | MetricAgentDaemonSetNotReady          | Metric agent DaemonSet is not ready                                                                                                          |
 | False            | ResourceBlocksDeletion                | The deletion of the module is blocked. To unblock the deletion, delete the following resources: MetricPipelines (resource-1, resource-2,...) |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -160,7 +160,7 @@ The state of the metric components is determined by the status condition of type
 | True             | ConfigurationGenerated  | Metric pipeline configuration successfully generated |
 | False            | DeploymentNotReady      | Metric gateway Deployment is not ready               |
 | False            | DaemonSetNotReady       | Metric agent DaemonSet is not ready                  |
-| False            | MaxPipelinesExceeded    | Maximum Pipeline count limit exceeded                |
+| False            | MaxPipelinesExceeded    | Maximum pipeline count exceeded                      |
 | False            | ReferencedSecretMissing | One or more referenced Secrets are missing           |
 
 

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -153,14 +153,14 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 
 The state of the metric components is determined by the status condition of type `MetricComponentsHealthy`:
 
-| Condition status | Condition reason | Message                                                                                                                                      |
-|------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------| 
-| True             | DeploymentReady | Metric gateway Deployment is ready                                                                                                           |
-| True             | DaemonSetReady | Metric agent DaemonSet is ready                                                                                                              |
-| True             | ConfigurationGenerated | Metric pipeline configuration successfully generated                                                                                         |
-| False            | DeploymentNotReady | Metric gateway Deployment is not ready                                                                                                       |
-| False            | DaemonSetNotReady | Metric agent DaemonSet is not ready                                                                                                          |
-| False            | WaitingForLock | The deletion of the module is blocked. To unblock the deletion, delete the following resources: MetricPipelines (resource-1, resource-2,...) |
-| False            | ReferencedSecretMissing | One or more referenced Secrets are missing                                                                                                   |
+| Condition status | Condition reason        | Message                                              |
+|------------------|-------------------------|------------------------------------------------------| 
+| True             | DeploymentReady         | Metric gateway Deployment is ready                   |
+| True             | DaemonSetReady          | Metric agent DaemonSet is ready                      |
+| True             | ConfigurationGenerated  | Metric pipeline configuration successfully generated |
+| False            | DeploymentNotReady      | Metric gateway Deployment is not ready               |
+| False            | DaemonSetNotReady       | Metric agent DaemonSet is not ready                  |
+| False            | MaxPipelinesExceeded    | Maximum Pipeline count limit exceeded                |
+| False            | ReferencedSecretMissing | One or more referenced Secrets are missing           |
 
 

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -31,7 +31,7 @@ const (
 var message = map[string]string{
 	ReasonNoPipelineDeployed:      "No pipelines have been deployed",
 	ReasonReferencedSecretMissing: "One or more referenced Secrets are missing",
-	ReasonMaxPipelinesExceeded:    "Maximum Pipeline count limit exceeded",
+	ReasonMaxPipelinesExceeded:    "Maximum pipeline count limit exceeded",
 
 	ReasonFluentBitDSNotReady:   "Fluent Bit DaemonSet is not ready",
 	ReasonFluentBitDSReady:      "Fluent Bit DaemonSet is ready",

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -9,7 +9,7 @@ const (
 const (
 	ReasonNoPipelineDeployed      = "NoPipelineDeployed"
 	ReasonReferencedSecretMissing = "ReferencedSecretMissing"
-	ReasonWaitingForLock          = "WaitingForLock"
+	ReasonMaxPipelinesExceeded    = "MaxPipelinesExceeded"
 	ReasonResourceBlocksDeletion  = "ResourceBlocksDeletion"
 
 	ReasonFluentBitDSNotReady   = "FluentBitDaemonSetNotReady"
@@ -31,7 +31,7 @@ const (
 var message = map[string]string{
 	ReasonNoPipelineDeployed:      "No pipelines have been deployed",
 	ReasonReferencedSecretMissing: "One or more referenced Secrets are missing",
-	ReasonWaitingForLock:          "Waiting for the lock",
+	ReasonMaxPipelinesExceeded:    "Maximum Pipeline count limit exceeded",
 
 	ReasonFluentBitDSNotReady:   "Fluent Bit DaemonSet is not ready",
 	ReasonFluentBitDSReady:      "Fluent Bit DaemonSet is ready",

--- a/internal/reconciler/metricpipeline/status_test.go
+++ b/internal/reconciler/metricpipeline/status_test.go
@@ -307,6 +307,6 @@ func TestUpdateStatus(t *testing.T) {
 		cond := meta.FindStatusCondition(updatedPipeline.Status.Conditions, conditions.TypeConfigurationGenerated)
 		require.NotNil(t, cond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionFalse, cond.Status)
-		require.Equal(t, conditions.ReasonWaitingForLock, cond.Reason)
+		require.Equal(t, conditions.ReasonMaxPipelinesExceeded, cond.Reason)
 	})
 }

--- a/internal/reconciler/telemetry/log_components_checker_test.go
+++ b/internal/reconciler/telemetry/log_components_checker_test.go
@@ -103,7 +103,7 @@ func TestLogComponentsCheck(t *testing.T) {
 				testutils.NewLogPipelineBuilder().WithStatusConditions(
 					testutils.LogPendingCondition(conditions.ReasonFluentBitDSNotReady), testutils.LogRunningCondition()).Build(),
 				testutils.NewLogPipelineBuilder().WithStatusConditions(
-					testutils.LogPendingCondition(conditions.ReasonWaitingForLock)).Build(),
+					testutils.LogPendingCondition(conditions.ReasonMaxPipelinesExceeded)).Build(),
 			},
 			telemetryInDeletion: false,
 			expectedCondition: &metav1.Condition{

--- a/internal/reconciler/telemetry/metric_components_checker.go
+++ b/internal/reconciler/telemetry/metric_components_checker.go
@@ -98,7 +98,7 @@ func (m *metricComponentsChecker) addReasonPrefix(reason string) string {
 		return "MetricGateway" + reason
 	case reason == conditions.ReasonMetricAgentDaemonSetReady || reason == conditions.ReasonMetricAgentDaemonSetNotReady:
 		return "MetricAgent" + reason
-	case reason == conditions.ReasonWaitingForLock || reason == conditions.ReasonReferencedSecretMissing:
+	case reason == conditions.ReasonReferencedSecretMissing:
 		return "MetricPipeline" + reason
 	}
 	return reason

--- a/internal/reconciler/telemetry/metric_components_checker_test.go
+++ b/internal/reconciler/telemetry/metric_components_checker_test.go
@@ -125,7 +125,7 @@ func TestMetricComponentsCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "should not be healthy if one pipeline waiting for lock",
+			name: "should not be healthy if max pipelines exceeded",
 			pipelines: []telemetryv1alpha1.MetricPipeline{
 				testutils.NewMetricPipelineBuilder().
 					WithStatusCondition(healthyGatewayCond).
@@ -135,15 +135,15 @@ func TestMetricComponentsCheck(t *testing.T) {
 				testutils.NewMetricPipelineBuilder().
 					WithStatusCondition(healthyGatewayCond).
 					WithStatusCondition(healthyAgentCond).
-					WithStatusCondition(metav1.Condition{Type: conditions.TypeConfigurationGenerated, Status: metav1.ConditionFalse, Reason: conditions.ReasonWaitingForLock}).
+					WithStatusCondition(metav1.Condition{Type: conditions.TypeConfigurationGenerated, Status: metav1.ConditionFalse, Reason: conditions.ReasonMaxPipelinesExceeded}).
 					Build(),
 			},
 			telemetryInDeletion: false,
 			expectedCondition: &metav1.Condition{
 				Type:    "MetricComponentsHealthy",
 				Status:  "False",
-				Reason:  "MetricPipelineWaitingForLock",
-				Message: "Waiting for the lock",
+				Reason:  "MaxPipelinesExceeded",
+				Message: "Maximum Pipeline count limit exceeded",
 			},
 		},
 		{

--- a/internal/reconciler/telemetry/metric_components_checker_test.go
+++ b/internal/reconciler/telemetry/metric_components_checker_test.go
@@ -143,7 +143,7 @@ func TestMetricComponentsCheck(t *testing.T) {
 				Type:    "MetricComponentsHealthy",
 				Status:  "False",
 				Reason:  "MaxPipelinesExceeded",
-				Message: "Maximum Pipeline count limit exceeded",
+				Message: "Maximum pipeline count limit exceeded",
 			},
 		},
 		{

--- a/internal/reconciler/telemetry/trace_components_checker_test.go
+++ b/internal/reconciler/telemetry/trace_components_checker_test.go
@@ -86,7 +86,7 @@ func TestTraceComponentsCheck(t *testing.T) {
 				testutils.NewTracePipelineBuilder().WithStatusConditions(
 					testutils.TracePendingCondition(conditions.ReasonTraceGatewayDeploymentNotReady), testutils.TraceRunningCondition()).Build(),
 				testutils.NewTracePipelineBuilder().WithStatusConditions(
-					testutils.TracePendingCondition(conditions.ReasonWaitingForLock)).Build(),
+					testutils.TracePendingCondition(conditions.ReasonMaxPipelinesExceeded)).Build(),
 			},
 			telemetryInDeletion: false,
 			expectedCondition: &metav1.Condition{

--- a/internal/reconciler/tracepipeline/status.go
+++ b/internal/reconciler/tracepipeline/status.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/secretref"
 )
 
-func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, lockAcquired bool) error {
+func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, withinPipelineCountLimit bool) error {
 	log := logf.FromContext(ctx)
 
 	var pipeline telemetryv1alpha1.TracePipeline
@@ -30,8 +30,8 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, lock
 		return nil
 	}
 
-	if !lockAcquired {
-		pending := telemetryv1alpha1.NewTracePipelineCondition(conditions.ReasonWaitingForLock, telemetryv1alpha1.TracePipelinePending)
+	if !withinPipelineCountLimit {
+		pending := telemetryv1alpha1.NewTracePipelineCondition(conditions.ReasonMaxPipelinesExceeded, telemetryv1alpha1.TracePipelinePending)
 
 		if pipeline.Status.HasCondition(telemetryv1alpha1.TracePipelineRunning) {
 			log.V(1).Info(fmt.Sprintf("Updating the status of %s to %s. Resetting previous conditions", pipeline.Name, pending.Type))

--- a/internal/reconciler/tracepipeline/status_test.go
+++ b/internal/reconciler/tracepipeline/status_test.go
@@ -269,7 +269,7 @@ func TestUpdateStatus(t *testing.T) {
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipelineName}, &updatedPipeline)
 		require.Len(t, updatedPipeline.Status.Conditions, 1)
 		require.Equal(t, updatedPipeline.Status.Conditions[0].Type, telemetryv1alpha1.TracePipelinePending)
-		require.Equal(t, updatedPipeline.Status.Conditions[0].Reason, conditions.ReasonWaitingForLock)
+		require.Equal(t, updatedPipeline.Status.Conditions[0].Reason, conditions.ReasonMaxPipelinesExceeded)
 	})
 
 	t.Run("should add pending condition if acquired lock but trace gateway is not ready", func(t *testing.T) {

--- a/test/e2e/metrics_multi_pipeline_test.go
+++ b/test/e2e/metrics_multi_pipeline_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Metrics Multi-Pipeline", Label("metrics"), func() {
 					g.Expect(k8sClient.Get(ctx, key, &fetched)).To(Succeed())
 					g.Expect(meta.IsStatusConditionFalse(fetched.Status.Conditions, conditions.TypeConfigurationGenerated)).To(BeTrue())
 					actualReason := meta.FindStatusCondition(fetched.Status.Conditions, conditions.TypeConfigurationGenerated).Reason
-					g.Expect(actualReason).To(Equal(conditions.ReasonWaitingForLock))
+					g.Expect(actualReason).To(Equal(conditions.ReasonMaxPipelinesExceeded))
 				}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 				verifiers.MetricGatewayConfigShouldNotContainPipeline(ctx, k8sClient, pipeline.Name())
 			})


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The old reason/message was `WaitingForLock`, which is too technical from an end-user perspective. This PR renames it to `MaxPipelinesExceeded`, which is much more intuitive. The change affects both Metric and Trace Pipeline

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/563

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->