### PR TITLE
docs: Fix link to documentation for enabling module

### DIFF
--- a/docs/user/integration/dynatrace/README.md
+++ b/docs/user/integration/dynatrace/README.md
@@ -31,7 +31,7 @@ With the Kyma Telemetry module, you gain even more visibility by adding custom s
 ## Prerequisistes
 
 - Kyma as the target deployment environment
-- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [enabled](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [enabled](https://kyma-project.io/#/02-get-started/01-quick-install)
 - Active Dynatrace environment with permissions to create new access tokens
 - Helm 3.x if you want to deploy the [OpenTelemetry sample application](../opentelemetry-demo/README.md)
 

--- a/docs/user/integration/jaeger/README.md
+++ b/docs/user/integration/jaeger/README.md
@@ -21,7 +21,7 @@ Learn how to use [Jaeger](https://github.com/jaegertracing/helm-charts/tree/main
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](../../README.md) is [enabled](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](../../README.md) is [enabled](https://kyma-project.io/#/02-get-started/01-quick-install)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/docs/user/integration/loki/README.md
+++ b/docs/user/integration/loki/README.md
@@ -26,7 +26,7 @@ Learn how to use [Loki](https://github.com/grafana/loki/tree/main/production/hel
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [enabled](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [enabled](https://kyma-project.io/#/02-get-started/01-quick-install)
 - Kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/docs/user/integration/opentelemetry-demo/README.md
+++ b/docs/user/integration/opentelemetry-demo/README.md
@@ -22,7 +22,7 @@ Learn how to install the OpenTelemetry [demo application](https://github.com/ope
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](../../README.md) is [enabled](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](../../README.md) is [enabled](https://kyma-project.io/#/02-get-started/01-quick-install)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/docs/user/integration/sap-cloud-logging/README.md
+++ b/docs/user/integration/sap-cloud-logging/README.md
@@ -28,7 +28,7 @@ SAP Cloud Logging is an instance-based and environment-agnostic observability se
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](../README.md) is [enabled](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](../README.md) is [enabled](https://kyma-project.io/#/02-get-started/01-quick-install)
 - An instance of SAP Cloud Logging with OpenTelemetry enabled to ingest distributed traces.
   >**TIP:** It's recommended to create it with the SAP BTP Service Operator (see [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator?locale=en-US&version=Cloud)), because it takes care of creation and rotation of the required Secret. However, you can choose any other method of creating the instance and the Secret, as long as the parameter for OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters?locale=en-US&version=Cloud).
 - A Secret in the respective namespace in the Kyma cluster, holding the credentials and endpoints for the instance. In this guide, the Secret is named `sap-cloud-logging` and the namespace `sap-cloud-logging-integration` as illustrated in this [example](./secret-example.yaml).


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix link to documentation for enabling module

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->