### PR TITLE
fix: Add missing metric-gateway-priority-class argument

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,7 @@ spec:
         args:
         - --cert-dir=/tmp
         - --fluent-bit-priority-class-name=telemetry-priority-class-high
+        - --metric-gateway-priority-class=telemetry-priority-class
         - --trace-collector-priority-class=telemetry-priority-class
         - --validating-webhook-enabled=true
         image: controller:latest


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add the missing `metric-gateway-priority-class` argument when running the `manager` container. In the [PR](https://github.com/kyma-project/telemetry-manager/pull/629) for including the metrics feature in releases, we removed the Kustomize [patch](https://github.com/kyma-project/telemetry-manager/pull/629/files#diff-d509a51c050a776d450eb1d1da96db70a31e7f1a0dc0fbe5a2d081bd30b72a53) for the manager deployment, as it was not needed anymore, since the metrics feature will be enabled by default. However, it was forgotten to copy over the argument for the `metric-gateway-priority-class` to the manager deployment.

Changes refer to particular issues, PRs or documents:

- #623 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->