### PR TITLE
feat: Add support additional endpoint path

### DIFF
--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -79,7 +79,7 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
-        // Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces
+	// Defines OTLP export URL path (only for the HTTP protocol). This value overridesmake auto-appended paths /v1/metrics and /v1/traces
 	Path string `json:"path,omitempty"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -79,7 +79,7 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
-	// Defines OTLP export URL path (only for HTTP protocol), this value will override auto appended paths /v1/metrics and /v1/traces
+        // Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces
 	Path string `json:"path,omitempty"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -79,7 +79,7 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
-	// Defines OTLP export URL path (only for the HTTP protocol). This value overridesmake auto-appended paths /v1/metrics and /v1/traces
+	// Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces
 	Path string `json:"path,omitempty"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -71,7 +71,7 @@ type OtlpTLS struct {
 // OtlpOutput OTLP output configuration
 // +kubebuilder:validation:XValidation:rule="((!has(self.path) || size(self.path) <= 0) && (has(self.protocol) && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol == 'http')", message="Path is only available with HTTP protocol"
 type OtlpOutput struct {
-	// Defines the OTLP protocol (HTTP or gRPC). Default is gRPC.
+	// Defines the OTLP protocol (http or grpc). Default is grpc.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:default:=grpc
 	// +kubebuilder:validation:Enum=grpc;http
@@ -79,7 +79,7 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
-	// Defines OTLP export URL path (only for HTTP protocol)
+	// Defines OTLP export URL path (only for HTTP protocol), this value will override auto appended paths /v1/metrics and /v1/traces
 	Path string `json:"path,omitempty"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -79,8 +79,8 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
-	// Defines OTLP export URL path
-	Path string `json:"path"`
+	// Defines OTLP export URL path (only for http protocol)
+	Path string `json:"path,omitempty"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`
 	// Defines custom headers to be added to outgoing HTTP or GRPC requests.

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -71,7 +71,7 @@ type OtlpTLS struct {
 // OtlpOutput OTLP output configuration
 // +kubebuilder:validation:XValidation:rule="((!has(self.path) || size(self.path) <= 0) && (has(self.protocol) && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol == 'http')", message="Path is only available with HTTP protocol"
 type OtlpOutput struct {
-	// Defines the OTLP protocol (http or grpc). Default is GRPC.
+	// Defines the OTLP protocol (HTTP or gRPC). Default is gRPC.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:default:=grpc
 	// +kubebuilder:validation:Enum=grpc;http
@@ -79,7 +79,7 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
-	// Defines OTLP export URL path (only for http protocol)
+	// Defines OTLP export URL path (only for HTTP protocol)
 	Path string `json:"path,omitempty"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -68,6 +68,8 @@ type OtlpTLS struct {
 	Key *ValueType `json:"key,omitempty"`
 }
 
+// OtlpOutput OTLP output configuration
+// +kubebuilder:validation:XValidation:rule="(has(self.protocol) && self.protocol == 'http') && (has(self.path))", message="Path is only available with HTTP protocol"
 type OtlpOutput struct {
 	// Defines the OTLP protocol (http or grpc). Default is GRPC.
 	// +kubebuilder:validation:MinLength=1
@@ -77,6 +79,8 @@ type OtlpOutput struct {
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
+	// Defines OTLP export URL path
+	Path string `json:"path"`
 	// Defines authentication options for the OTLP output
 	Authentication *AuthenticationOptions `json:"authentication,omitempty"`
 	// Defines custom headers to be added to outgoing HTTP or GRPC requests.

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -69,7 +69,7 @@ type OtlpTLS struct {
 }
 
 // OtlpOutput OTLP output configuration
-// +kubebuilder:validation:XValidation:rule="(has(self.protocol) && self.protocol == 'http') && (has(self.path))", message="Path is only available with HTTP protocol"
+// +kubebuilder:validation:XValidation:rule="((!has(self.path) || size(self.path) <= 0) && (has(self.protocol) && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol == 'http')", message="Path is only available with HTTP protocol"
 type OtlpOutput struct {
 	// Defines the OTLP protocol (http or grpc). Default is GRPC.
 	// +kubebuilder:validation:MinLength=1

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -343,7 +343,7 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path
+                        description: Defines OTLP export URL path (only for http protocol)
                         type: string
                       protocol:
                         default: grpc
@@ -462,7 +462,6 @@ spec:
                         type: object
                     required:
                     - endpoint
-                    - path
                     type: object
                     x-kubernetes-validations:
                     - message: Path is only available with HTTP protocol

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -343,12 +343,14 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path (only for HTTP protocol)
+                        description: Defines OTLP export URL path (only for HTTP protocol),
+                          this value will override auto appended paths /v1/metrics
+                          and /v1/traces
                         type: string
                       protocol:
                         default: grpc
-                        description: Defines the OTLP protocol (HTTP or gRPC). Default
-                          is gRPC.
+                        description: Defines the OTLP protocol (http or grpc). Default
+                          is grpc.
                         enum:
                         - grpc
                         - http

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -465,7 +465,9 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: Path is only available with HTTP protocol
-                      rule: (has(self.protocol) && self.protocol == 'http') && (has(self.path))
+                      rule: ((!has(self.path) || size(self.path) <= 0) && (has(self.protocol)
+                        && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol
+                        == 'http')
                 required:
                 - otlp
                 type: object

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -343,12 +343,12 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path (only for http protocol)
+                        description: Defines OTLP export URL path (only for HTTP protocol)
                         type: string
                       protocol:
                         default: grpc
-                        description: Defines the OTLP protocol (http or grpc). Default
-                          is GRPC.
+                        description: Defines the OTLP protocol (HTTP or gRPC). Default
+                          is gRPC.
                         enum:
                         - grpc
                         - http

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -342,6 +342,8 @@ spec:
                           - name
                           type: object
                         type: array
+                      path:
+                        type: string
                       protocol:
                         default: grpc
                         description: Defines the OTLP protocol (http or grpc). Default
@@ -459,7 +461,11 @@ spec:
                         type: object
                     required:
                     - endpoint
+                    - path
                     type: object
+                    x-kubernetes-validations:
+                    - message: Path only available with HTTP protocol
+                      rule: (has(self.protocol) && self.protocol == 'http') && (has(self.path))
                 required:
                 - otlp
                 type: object

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -344,8 +344,8 @@ spec:
                         type: array
                       path:
                         description: Defines OTLP export URL path (only for the HTTP
-                          protocol). This value overridesmake auto-appended paths
-                          /v1/metrics and /v1/traces
+                          protocol). This value overrides auto-appended paths /v1/metrics
+                          and /v1/traces
                         type: string
                       protocol:
                         default: grpc

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -343,6 +343,7 @@ spec:
                           type: object
                         type: array
                       path:
+                        description: Defines OTLP export URL path
                         type: string
                       protocol:
                         default: grpc
@@ -464,7 +465,7 @@ spec:
                     - path
                     type: object
                     x-kubernetes-validations:
-                    - message: Path only available with HTTP protocol
+                    - message: Path is only available with HTTP protocol
                       rule: (has(self.protocol) && self.protocol == 'http') && (has(self.path))
                 required:
                 - otlp

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -343,8 +343,8 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path (only for HTTP protocol),
-                          this value will override auto appended paths /v1/metrics
+                        description: Defines OTLP export URL path (only for the HTTP
+                          protocol). This value overrides auto-appended paths /v1/metrics
                           and /v1/traces
                         type: string
                       protocol:

--- a/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -344,8 +344,8 @@ spec:
                         type: array
                       path:
                         description: Defines OTLP export URL path (only for the HTTP
-                          protocol). This value overrides auto-appended paths /v1/metrics
-                          and /v1/traces
+                          protocol). This value overridesmake auto-appended paths
+                          /v1/metrics and /v1/traces
                         type: string
                       protocol:
                         default: grpc

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -198,12 +198,12 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path (only for http protocol)
+                        description: Defines OTLP export URL path (only for HTTP protocol)
                         type: string
                       protocol:
                         default: grpc
-                        description: Defines the OTLP protocol (http or grpc). Default
-                          is GRPC.
+                        description: Defines the OTLP protocol (HTTP or gRPC). Default
+                          is gRPC.
                         enum:
                         - grpc
                         - http

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -199,8 +199,8 @@ spec:
                         type: array
                       path:
                         description: Defines OTLP export URL path (only for the HTTP
-                          protocol). This value overrides auto-appended paths /v1/metrics
-                          and /v1/traces
+                          protocol). This value overridesmake auto-appended paths
+                          /v1/metrics and /v1/traces
                         type: string
                       protocol:
                         default: grpc

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -199,8 +199,8 @@ spec:
                         type: array
                       path:
                         description: Defines OTLP export URL path (only for the HTTP
-                          protocol). This value overridesmake auto-appended paths
-                          /v1/metrics and /v1/traces
+                          protocol). This value overrides auto-appended paths /v1/metrics
+                          and /v1/traces
                         type: string
                       protocol:
                         default: grpc

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -198,8 +198,8 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path (only for HTTP protocol),
-                          this value will override auto appended paths /v1/metrics
+                        description: Defines OTLP export URL path (only for the HTTP
+                          protocol). This value overrides auto-appended paths /v1/metrics
                           and /v1/traces
                         type: string
                       protocol:

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -198,12 +198,14 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path (only for HTTP protocol)
+                        description: Defines OTLP export URL path (only for HTTP protocol),
+                          this value will override auto appended paths /v1/metrics
+                          and /v1/traces
                         type: string
                       protocol:
                         default: grpc
-                        description: Defines the OTLP protocol (HTTP or gRPC). Default
-                          is gRPC.
+                        description: Defines the OTLP protocol (http or grpc). Default
+                          is grpc.
                         enum:
                         - grpc
                         - http

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -198,6 +198,7 @@ spec:
                           type: object
                         type: array
                       path:
+                        description: Defines OTLP export URL path
                         type: string
                       protocol:
                         default: grpc
@@ -319,7 +320,7 @@ spec:
                     - path
                     type: object
                     x-kubernetes-validations:
-                    - message: Path only available with HTTP protocol
+                    - message: Path is only available with HTTP protocol
                       rule: (has(self.protocol) && self.protocol == 'http') && (has(self.path))
                 required:
                 - otlp

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -198,7 +198,7 @@ spec:
                           type: object
                         type: array
                       path:
-                        description: Defines OTLP export URL path
+                        description: Defines OTLP export URL path (only for http protocol)
                         type: string
                       protocol:
                         default: grpc
@@ -317,7 +317,6 @@ spec:
                         type: object
                     required:
                     - endpoint
-                    - path
                     type: object
                     x-kubernetes-validations:
                     - message: Path is only available with HTTP protocol

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -320,7 +320,9 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: Path is only available with HTTP protocol
-                      rule: (has(self.protocol) && self.protocol == 'http') && (has(self.path))
+                      rule: ((!has(self.path) || size(self.path) <= 0) && (has(self.protocol)
+                        && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol
+                        == 'http')
                 required:
                 - otlp
                 type: object

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -197,6 +197,8 @@ spec:
                           - name
                           type: object
                         type: array
+                      path:
+                        type: string
                       protocol:
                         default: grpc
                         description: Defines the OTLP protocol (http or grpc). Default
@@ -314,7 +316,11 @@ spec:
                         type: object
                     required:
                     - endpoint
+                    - path
                     type: object
+                    x-kubernetes-validations:
+                    - message: Path only available with HTTP protocol
+                      rule: (has(self.protocol) && self.protocol == 'http') && (has(self.path))
                 required:
                 - otlp
                 type: object

--- a/config/samples/telemetry_v1alpha1_metricpipeline.yaml
+++ b/config/samples/telemetry_v1alpha1_metricpipeline.yaml
@@ -160,5 +160,7 @@ spec:
       enabled: true
   output:
     otlp:
+      protocol: http
       endpoint:
         value: http://mock-metric-receiver.metric-receiver:4317
+      path: /v1/test

--- a/config/samples/telemetry_v1alpha1_metricpipeline.yaml
+++ b/config/samples/telemetry_v1alpha1_metricpipeline.yaml
@@ -160,7 +160,5 @@ spec:
       enabled: true
   output:
     otlp:
-      protocol: http
       endpoint:
         value: http://mock-metric-receiver.metric-receiver:4317
-      path: /v1/test

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,7 +80,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overridesmake auto-appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,6 +80,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
+| **output.&#x200b;otlp.&#x200b;path** (required) | string |  |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,7 +80,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path** (required) | string |  |
+| **output.&#x200b;otlp.&#x200b;path** (required) | string | Defines OTLP export URL path |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,7 +80,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol), this value will override auto appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,8 +80,8 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for http protocol) |
-| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol) |
+| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (HTTP or gRPC). Default is gRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca.&#x200b;value**  | string | The value as plain text. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,7 +80,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overridesmake auto-appended paths /v1/metrics and /v1/traces |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,7 +80,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path** (required) | string | Defines OTLP export URL path |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for http protocol) |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -80,8 +80,8 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol) |
-| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (HTTP or gRPC). Default is gRPC. |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol), this value will override auto appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca.&#x200b;value**  | string | The value as plain text. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,8 +109,8 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol) |
-| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (HTTP or gRPC). Default is gRPC. |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol), this value will override auto appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca.&#x200b;value**  | string | The value as plain text. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,7 +109,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path** (required) | string |  |
+| **output.&#x200b;otlp.&#x200b;path** (required) | string | Defines OTLP export URL path |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,7 +109,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overridesmake auto-appended paths /v1/metrics and /v1/traces |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,8 +109,8 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for http protocol) |
-| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol) |
+| **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (HTTP or gRPC). Default is gRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca.&#x200b;value**  | string | The value as plain text. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,7 +109,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for HTTP protocol), this value will override auto appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,6 +109,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
+| **output.&#x200b;otlp.&#x200b;path** (required) | string |  |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,7 +109,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path** (required) | string | Defines OTLP export URL path |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for http protocol) |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is GRPC. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -109,7 +109,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;otlp.&#x200b;headers.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overridesmake auto-appended paths /v1/metrics and /v1/traces |
+| **output.&#x200b;otlp.&#x200b;path**  | string | Defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths /v1/metrics and /v1/traces |
 | **output.&#x200b;otlp.&#x200b;protocol**  | string | Defines the OTLP protocol (http or grpc). Default is grpc. |
 | **output.&#x200b;otlp.&#x200b;tls**  | object | Defines TLS options for the OTLP output. |
 | **output.&#x200b;otlp.&#x200b;tls.&#x200b;ca**  | object | Defines an optional CA certificate for server certificate verification when using TLS. The certificate must be provided in PEM format. |

--- a/internal/otelcollector/config/exporters.go
+++ b/internal/otelcollector/config/exporters.go
@@ -1,11 +1,13 @@
 package config
 
 type OTLPExporter struct {
-	Endpoint       string            `yaml:"endpoint,omitempty"`
-	Headers        map[string]string `yaml:"headers,omitempty"`
-	TLS            TLS               `yaml:"tls,omitempty"`
-	SendingQueue   SendingQueue      `yaml:"sending_queue,omitempty"`
-	RetryOnFailure RetryOnFailure    `yaml:"retry_on_failure,omitempty"`
+	MetricsEndpoint string            `yaml:"metrics_endpoint,omitempty"`
+	TracesEndpoint  string            `yaml:"traces_endpoint,omitempty"`
+	Endpoint        string            `yaml:"endpoint,omitempty"`
+	Headers         map[string]string `yaml:"headers,omitempty"`
+	TLS             TLS               `yaml:"tls,omitempty"`
+	SendingQueue    SendingQueue      `yaml:"sending_queue,omitempty"`
+	RetryOnFailure  RetryOnFailure    `yaml:"retry_on_failure,omitempty"`
 }
 
 type TLS struct {

--- a/internal/otelcollector/config/metric/gateway/config_builder.go
+++ b/internal/otelcollector/config/metric/gateway/config_builder.go
@@ -34,7 +34,7 @@ func MakeConfig(ctx context.Context, c client.Reader, pipelines []telemetryv1alp
 			continue
 		}
 
-		otlpExporterBuilder := otlpexporter.NewConfigBuilder(c, pipeline.Spec.Output.Otlp, pipeline.Name, queueSize)
+		otlpExporterBuilder := otlpexporter.NewConfigBuilder(c, pipeline.Spec.Output.Otlp, pipeline.Name, queueSize, otlpexporter.SignalTypeMetric)
 		if err := declareComponentsForMetricPipeline(ctx, otlpExporterBuilder, &pipeline, cfg, envVars); err != nil {
 			return nil, nil, err
 		}

--- a/internal/otelcollector/config/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder_test.go
@@ -59,6 +59,44 @@ func TestMakeConfig(t *testing.T) {
 	require.Equal(t, "300s", otlpExporterConfig.RetryOnFailure.MaxElapsedTime)
 }
 
+func TestMakeConfigTraceWithPath(t *testing.T) {
+	output := &telemetryv1alpha1.OtlpOutput{
+		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Path:     "/v1/test",
+		Protocol: "http",
+	}
+
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
+	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, envVars)
+
+	require.NotNil(t, envVars["OTLP_ENDPOINT_TEST"])
+	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte("otlp-endpoint/v1/test"))
+
+	require.Equal(t, "${OTLP_ENDPOINT_TEST}", otlpExporterConfig.TracesEndpoint)
+	require.Empty(t, otlpExporterConfig.Endpoint)
+}
+
+func TestMakeConfigMetricWithPath(t *testing.T) {
+	output := &telemetryv1alpha1.OtlpOutput{
+		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Path:     "/v1/test",
+		Protocol: "http",
+	}
+
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeMetric)
+	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, envVars)
+
+	require.NotNil(t, envVars["OTLP_ENDPOINT_TEST"])
+	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte("otlp-endpoint/v1/test"))
+
+	require.Equal(t, "${OTLP_ENDPOINT_TEST}", otlpExporterConfig.MetricsEndpoint)
+	require.Empty(t, otlpExporterConfig.Endpoint)
+}
+
 func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 	headers := []telemetryv1alpha1.Header{
 		{

--- a/internal/otelcollector/config/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder_test.go
@@ -41,7 +41,7 @@ func TestMakeConfig(t *testing.T) {
 		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
 	}
 
-	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
 	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, envVars)
@@ -73,7 +73,7 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 		Headers:  headers,
 	}
 
-	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
 	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, envVars)
@@ -91,7 +91,7 @@ func TestMakeExporterConfigWithTLSInsecure(t *testing.T) {
 		TLS:      tls,
 	}
 
-	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
 	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, envVars)
@@ -109,7 +109,7 @@ func TestMakeExporterConfigWithTLSInsecureSkipVerify(t *testing.T) {
 		TLS:      tls,
 	}
 
-	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
 	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, envVars)
@@ -138,7 +138,7 @@ func TestMakeExporterConfigWithmTLS(t *testing.T) {
 		TLS:      tls,
 	}
 
-	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512)
+	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
 	otlpExporterConfig, envVars, err := cb.MakeConfig(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, envVars)

--- a/internal/otelcollector/config/otlpexporter/env_vars.go
+++ b/internal/otelcollector/config/otlpexporter/env_vars.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/url"
+	"path"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,6 +44,15 @@ func makeEnvVars(ctx context.Context, c client.Reader, output *telemetryv1alpha1
 	}
 	otlpEndpointVariable := makeOtlpEndpointVariable(pipelineName)
 	secretData[otlpEndpointVariable] = endpoint
+
+	if len(output.Path) > 0 {
+		u, err := url.Parse(string(endpoint))
+		if err != nil {
+			return nil, err
+		}
+		u.Path = path.Join(u.Path, output.Path)
+		secretData[otlpEndpointVariable] = []byte(u.String())
+	}
 
 	for _, header := range output.Headers {
 		key := makeHeaderVariable(header, pipelineName)

--- a/internal/otelcollector/config/trace/gateway/config_builder.go
+++ b/internal/otelcollector/config/trace/gateway/config_builder.go
@@ -34,7 +34,7 @@ func MakeConfig(ctx context.Context, c client.Reader, pipelines []telemetryv1alp
 			continue
 		}
 
-		otlpExporterBuilder := otlpexporter.NewConfigBuilder(c, pipeline.Spec.Output.Otlp, pipeline.Name, queueSize)
+		otlpExporterBuilder := otlpexporter.NewConfigBuilder(c, pipeline.Spec.Output.Otlp, pipeline.Name, queueSize, otlpexporter.SignalTypeTrace)
 		if err := addComponentsForTracePipeline(ctx, otlpExporterBuilder, &pipeline, cfg, envVars); err != nil {
 			return nil, nil, err
 		}

--- a/test/e2e/metrics_endpoint_path_validation_test.go
+++ b/test/e2e/metrics_endpoint_path_validation_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Metrics Validating Endpoint Path", Label("metrics"), Ordered, 
 		WithProtocol("http").
 		Persistent(isOperational()).K8sObject()
 
-	Context("When a metric pipeline set endpoint path", Ordered, func() {
+	Context("When a MetricPipeline sets endpoint path", Ordered, func() {
 
 		AfterAll(func() {
 			DeferCleanup(func() {
@@ -45,23 +45,23 @@ var _ = Describe("Metrics Validating Endpoint Path", Label("metrics"), Ordered, 
 			})
 		})
 
-		It("Should reject a metricpipeline with path and default protocol", func() {
+		It("Should reject a MetricPipeline with path and default protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
 		})
 
-		It("Should reject a metricpipeline with path and grpc protocol", func() {
+		It("Should reject a MetricPipeline with path and gRPC protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithGRPCAndPath)).ShouldNot(Succeed())
 		})
 
-		It("Should accept a metricpipeline with no path and grpc protocol", func() {
+		It("Should accept a MetricPipeline with no path and gRPC protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithGRPCAndWithoutPath)).Should(Succeed())
 		})
 
-		It("Should accept a metricpipeline with no path and http protocol", func() {
+		It("Should accept a MetricPipeline with no path and HTTP protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())
 		})
 
-		It("Should accept a metricpipeline with path and http protocol", func() {
+		It("Should accept a MetricPipeline with path and HTTP protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithHTTPAndPath)).Should(Succeed())
 		})
 	})

--- a/test/e2e/metrics_endpoint_path_validation_test.go
+++ b/test/e2e/metrics_endpoint_path_validation_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Metrics Validating Endpoint Path", Label("metrics"), Ordered, 
 
 	Context("When a MetricPipeline sets endpoint path", Ordered, func() {
 
-		AfterAll(func() {
+		BeforeAll(func() {
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient,
 					metricPipelineWithGRPCAndWithoutPath, metricPipelineWithHTTPAndPath, metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())

--- a/test/e2e/metrics_endpoint_path_validation_test.go
+++ b/test/e2e/metrics_endpoint_path_validation_test.go
@@ -3,10 +3,11 @@
 package e2e
 
 import (
-	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
-	kitmetricpipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitmetricpipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
 )
 
 var _ = Describe("Metrics Validating Endpoint Path", Label("metrics"), Ordered, func() {

--- a/test/e2e/metrics_endpoint_path_validation_test.go
+++ b/test/e2e/metrics_endpoint_path_validation_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+package e2e
+
+import (
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitmetricpipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Metrics Validating Endpoint Path", Label("metrics"), Ordered, func() {
+
+	metricPipelineDefaultGRPCWithPath := kitmetricpipeline.NewPipeline("metricpipeline-default-reject-with-path").
+		WithOutputEndpoint("mock-endpoint:4817").WithEndpointPath("/v1/mock/metrics").
+		Persistent(isOperational()).K8sObject()
+
+	metricPipelineWithGRPCAndPath := kitmetricpipeline.NewPipeline("metricpipeline-reject-with-grpc-and-path").
+		WithOutputEndpoint("mock-endpoint:4817").WithEndpointPath("/v1/mock/metrics").
+		WithProtocol("grpc").
+		Persistent(isOperational()).K8sObject()
+
+	metricPipelineWithGRPCAndWithoutPath := kitmetricpipeline.NewPipeline("metricpipeline-accept-with-grpc-and-no-path").
+		WithOutputEndpoint("mock-endpoint:4817").
+		WithProtocol("grpc").
+		Persistent(isOperational()).K8sObject()
+
+	metricPipelineWithHTTPAndPath := kitmetricpipeline.NewPipeline("metricpipeline-accept-with-http-and-path").
+		WithOutputEndpoint("mock-endpoint:4817").WithEndpointPath("/v1/mock/metrics").
+		WithProtocol("http").
+		Persistent(isOperational()).K8sObject()
+
+	metricPipelineWithHTTPAndWithoutPath := kitmetricpipeline.NewPipeline("metricpipeline-accept-with-http-and-no-path").
+		WithOutputEndpoint("mock-endpoint:4817").
+		WithProtocol("http").
+		Persistent(isOperational()).K8sObject()
+
+	Context("When a metric pipeline set endpoint path", Ordered, func() {
+
+		AfterAll(func() {
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient,
+					metricPipelineWithGRPCAndWithoutPath, metricPipelineWithHTTPAndPath, metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())
+			})
+		})
+
+		It("Should reject a metricpipeline with path and default protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
+		})
+
+		It("Should reject a metricpipeline with path and grpc protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithGRPCAndPath)).ShouldNot(Succeed())
+		})
+
+		It("Should accept a metricpipeline with no path and grpc protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithGRPCAndWithoutPath)).Should(Succeed())
+		})
+
+		It("Should accept a metricpipeline with no path and http protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())
+		})
+
+		It("Should accept a metricpipeline with path and http protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, metricPipelineWithHTTPAndPath)).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/metrics_endpoint_with_path_test.go
+++ b/test/e2e/metrics_endpoint_with_path_test.go
@@ -1,0 +1,47 @@
+//go:build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	kitmetricpipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+)
+
+var _ = Describe("Metrics Endpoint with Path", Label("metrics"), func() {
+	const (
+		path                    = "/v1/mock"
+		endpoint                = "metric-mock"
+		endpointEndpointDataKey = "OTLP_ENDPOINT_MOCK_METRIC_ENDPOINT_PATH"
+	)
+
+	makeResources := func() []client.Object {
+		var objs []client.Object
+
+		metricPipeline := kitmetricpipeline.NewPipeline("mock-metric-endpoint-path").
+			WithProtocol("http").
+			WithOutputEndpoint(endpoint).WithEndpointPath(path).
+			Persistent(true)
+		objs = append(objs, metricPipeline.K8sObject())
+		return objs
+	}
+
+	Context("When a MetricPipeline with path exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeResources()
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+		})
+
+		It("Should have a secret with endpoint and path", func() {
+			verifiers.SecretShouldHaveValue(ctx, k8sClient, kitkyma.MetricGatewaySecretName, endpointEndpointDataKey, endpoint+path)
+		})
+	})
+})

--- a/test/e2e/traces_endpoint_path_validation_test.go
+++ b/test/e2e/traces_endpoint_path_validation_test.go
@@ -45,23 +45,23 @@ var _ = Describe("Traces Validating Endpoint Path", Label("tracing"), Ordered, f
 			})
 		})
 
-		It("Should reject a tracepipeline with path and default protocol", func() {
+		It("Should reject a TracePipeline with path and default protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
 		})
 
-		It("Should reject a tracepipeline with path and grpc protocol", func() {
+		It("Should reject a TracePipeline with path and gRPC protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithGRPCAndPath)).ShouldNot(Succeed())
 		})
 
-		It("Should accept a tracepipeline with no path and grpc protocol", func() {
+		It("Should accept a TracePipeline with no path and gRPC protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithGRPCAndWithoutPath)).Should(Succeed())
 		})
 
-		It("Should accept a tracepipeline with no path and http protocol", func() {
+		It("Should accept a TracePipeline with no path and HTTP protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())
 		})
 
-		It("Should accept a tracepipeline with path and http protocol", func() {
+		It("Should accept a TracePipeline with path and HTTP protocol", func() {
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithHTTPAndPath)).Should(Succeed())
 		})
 	})

--- a/test/e2e/traces_endpoint_path_validation_test.go
+++ b/test/e2e/traces_endpoint_path_validation_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+package e2e
+
+import (
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kittracepipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Traces Validating Endpoint Path", Label("tracing"), Ordered, func() {
+
+	tracePipelineDefaultGRPCWithPath := kittracepipeline.NewPipeline("tracepipeline-default-reject-with-path").
+		WithOutputEndpoint("mock-endpoint:4817").WithEndpointPath("/v1/mock/traces").
+		Persistent(isOperational()).K8sObject()
+
+	tracePipelineWithGRPCAndPath := kittracepipeline.NewPipeline("tracepipeline-reject-with-grpc-and-path").
+		WithOutputEndpoint("mock-endpoint:4817").WithEndpointPath("/v1/mock/traces").
+		WithProtocol("grpc").
+		Persistent(isOperational()).K8sObject()
+
+	tracePipelineWithGRPCAndWithoutPath := kittracepipeline.NewPipeline("tracepipeline-accept-with-grpc-and-no-path").
+		WithOutputEndpoint("mock-endpoint:4817").
+		WithProtocol("grpc").
+		Persistent(isOperational()).K8sObject()
+
+	tracePipelineWithHTTPAndPath := kittracepipeline.NewPipeline("tracepipeline-accept-with-http-and-path").
+		WithOutputEndpoint("mock-endpoint:4817").WithEndpointPath("/v1/mock/traces").
+		WithProtocol("http").
+		Persistent(isOperational()).K8sObject()
+
+	tracePipelineWithHTTPAndWithoutPath := kittracepipeline.NewPipeline("tracepipeline-accept-with-http-and-no-path").
+		WithOutputEndpoint("mock-endpoint:4817").
+		WithProtocol("http").
+		Persistent(isOperational()).K8sObject()
+
+	Context("When a trace pipeline set endpoint path", Ordered, func() {
+
+		AfterAll(func() {
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient,
+					tracePipelineWithGRPCAndWithoutPath, tracePipelineWithHTTPAndPath, tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())
+			})
+		})
+
+		It("Should reject a tracepipeline with path and default protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
+		})
+
+		It("Should reject a tracepipeline with path and grpc protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithGRPCAndPath)).ShouldNot(Succeed())
+		})
+
+		It("Should accept a tracepipeline with no path and grpc protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithGRPCAndWithoutPath)).Should(Succeed())
+		})
+
+		It("Should accept a tracepipeline with no path and http protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())
+		})
+
+		It("Should accept a tracepipeline with path and http protocol", func() {
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, tracePipelineWithHTTPAndPath)).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/traces_endpoint_path_validation_test.go
+++ b/test/e2e/traces_endpoint_path_validation_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Traces Validating Endpoint Path", Label("tracing"), Ordered, f
 
 	Context("When a trace pipeline set endpoint path", Ordered, func() {
 
-		AfterAll(func() {
+		BeforeAll(func() {
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient,
 					tracePipelineWithGRPCAndWithoutPath, tracePipelineWithHTTPAndPath, tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())

--- a/test/e2e/traces_endpoint_path_validation_test.go
+++ b/test/e2e/traces_endpoint_path_validation_test.go
@@ -3,10 +3,11 @@
 package e2e
 
 import (
-	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
-	kittracepipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kittracepipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
 )
 
 var _ = Describe("Traces Validating Endpoint Path", Label("tracing"), Ordered, func() {

--- a/test/e2e/traces_endpoint_with_path_test.go
+++ b/test/e2e/traces_endpoint_with_path_test.go
@@ -1,0 +1,47 @@
+//go:build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	kittracepipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+)
+
+var _ = Describe("Traces Endpoint with Path", Label("tracing"), func() {
+	const (
+		path                    = "/v1/mock"
+		endpoint                = "trace-mock"
+		endpointEndpointDataKey = "OTLP_ENDPOINT_MOCK_TRACE_ENDPOINT_PATH"
+	)
+
+	makeResources := func() []client.Object {
+		var objs []client.Object
+
+		tracePipeline := kittracepipeline.NewPipeline("mock-trace-endpoint-path").
+			WithProtocol("http").
+			WithOutputEndpoint(endpoint).WithEndpointPath(path).
+			Persistent(true)
+		objs = append(objs, tracePipeline.K8sObject())
+		return objs
+	}
+
+	Context("When a TracePipeline with path exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeResources()
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+		})
+
+		It("Should have a secret with endpoint and path", func() {
+			verifiers.SecretShouldHaveValue(ctx, k8sClient, kitkyma.TraceGatewaySecretName, endpointEndpointDataKey, endpoint+path)
+		})
+	})
+})

--- a/test/testkit/kyma/common_names.go
+++ b/test/testkit/kyma/common_names.go
@@ -21,6 +21,7 @@ var (
 	MetricGatewayName          = types.NamespacedName{Name: MetricGatewayBaseName, Namespace: SystemNamespaceName}
 	MetricGatewayMetrics       = types.NamespacedName{Name: MetricGatewayBaseName + "-metrics", Namespace: SystemNamespaceName}
 	MetricGatewayNetworkPolicy = types.NamespacedName{Name: MetricGatewayBaseName + "-pprof-deny-ingress", Namespace: SystemNamespaceName}
+	MetricGatewaySecretName    = types.NamespacedName{Name: MetricGatewayBaseName, Namespace: SystemNamespaceName}
 
 	MetricAgentName          = types.NamespacedName{Name: MetricAgentBaseName, Namespace: SystemNamespaceName}
 	MetricAgentMetrics       = types.NamespacedName{Name: MetricAgentBaseName + "-metrics", Namespace: SystemNamespaceName}
@@ -29,6 +30,7 @@ var (
 	TraceGatewayName          = types.NamespacedName{Name: TraceGatewayBaseName, Namespace: SystemNamespaceName}
 	TraceGatewayMetrics       = types.NamespacedName{Name: TraceGatewayBaseName + "-metrics", Namespace: SystemNamespaceName}
 	TraceGatewayNetworkPolicy = types.NamespacedName{Name: TraceGatewayBaseName + "-pprof-deny-ingress", Namespace: SystemNamespaceName}
+	TraceGatewaySecretName    = types.NamespacedName{Name: TraceGatewayBaseName, Namespace: SystemNamespaceName}
 
 	TelemetryName = types.NamespacedName{Name: DefaultTelemetryName, Namespace: SystemNamespaceName}
 )

--- a/test/testkit/kyma/env.go
+++ b/test/testkit/kyma/env.go
@@ -1,0 +1,11 @@
+package kyma
+
+import "strings"
+
+func MakeEnvVarCompliant(input string) string {
+	result := input
+	result = strings.ToUpper(result)
+	result = strings.Replace(result, ".", "_", -1)
+	result = strings.Replace(result, "-", "_", -1)
+	return result
+}

--- a/test/testkit/kyma/telemetry/metric/pipeline.go
+++ b/test/testkit/kyma/telemetry/metric/pipeline.go
@@ -25,6 +25,8 @@ type Pipeline struct {
 	istio           *telemetryv1alpha1.MetricPipelineIstioInput
 	otlp            *telemetryv1alpha1.MetricPipelineOtlpInput
 	tls             *telemetryv1alpha1.OtlpTLS
+	protocol        string
+	endpointPath    string
 }
 
 func NewPipeline(name string) *Pipeline {
@@ -153,6 +155,16 @@ func (p *Pipeline) WithTLS(certs tls.Certs) *Pipeline {
 	return p
 }
 
+func (p *Pipeline) WithProtocol(protocol string) *Pipeline {
+	p.protocol = protocol
+	return p
+}
+
+func (p *Pipeline) WithEndpointPath(path string) *Pipeline {
+	p.endpointPath = path
+	return p
+}
+
 func (p *Pipeline) K8sObject() *telemetryv1alpha1.MetricPipeline {
 	var labels kitk8s.Labels
 	if p.persistent {
@@ -170,6 +182,14 @@ func (p *Pipeline) K8sObject() *telemetryv1alpha1.MetricPipeline {
 		}
 	} else {
 		otlpOutput.Endpoint.Value = p.otlpEndpoint
+	}
+
+	if len(p.protocol) > 0 {
+		otlpOutput.Protocol = p.protocol
+	}
+
+	if len(p.endpointPath) > 0 {
+		otlpOutput.Path = p.endpointPath
 	}
 
 	metricPipeline := telemetryv1alpha1.MetricPipeline{

--- a/test/testkit/kyma/telemetry/trace/pipeline.go
+++ b/test/testkit/kyma/telemetry/trace/pipeline.go
@@ -21,6 +21,8 @@ type Pipeline struct {
 	otlpEndpointRef *telemetryv1alpha1.SecretKeyRef
 	otlpEndpoint    string
 	tls             *telemetryv1alpha1.OtlpTLS
+	protocol        string
+	endpointPath    string
 }
 
 func NewPipeline(name string) *Pipeline {
@@ -73,6 +75,16 @@ func (p *Pipeline) Persistent(persistent bool) *Pipeline {
 	return p
 }
 
+func (p *Pipeline) WithProtocol(protocol string) *Pipeline {
+	p.protocol = protocol
+	return p
+}
+
+func (p *Pipeline) WithEndpointPath(path string) *Pipeline {
+	p.endpointPath = path
+	return p
+}
+
 func (p *Pipeline) K8sObject() *telemetryv1alpha1.TracePipeline {
 	var labels kitk8s.Labels
 	if p.persistent {
@@ -90,6 +102,14 @@ func (p *Pipeline) K8sObject() *telemetryv1alpha1.TracePipeline {
 		}
 	} else {
 		otlpOutput.Endpoint.Value = p.otlpEndpoint
+	}
+
+	if len(p.protocol) > 0 {
+		otlpOutput.Protocol = p.protocol
+	}
+
+	if len(p.endpointPath) > 0 {
+		otlpOutput.Path = p.endpointPath
 	}
 
 	pipeline := telemetryv1alpha1.TracePipeline{

--- a/test/testkit/verifiers/secret.go
+++ b/test/testkit/verifiers/secret.go
@@ -1,0 +1,34 @@
+package verifiers
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+)
+
+func SecretShouldHaveValue(ctx context.Context, k8sClient client.Client, name types.NamespacedName, dataKey, dataValue string) {
+	Eventually(func(g Gomega) {
+		secret, err := isSecretExist(ctx, k8sClient, name)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		secretValue, found := secret.Data[dataKey]
+		g.Expect(found).Should(BeTrue())
+
+		g.Expect(string(secretValue)).Should(Equal(dataValue))
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
+}
+
+func isSecretExist(ctx context.Context, k8sClient client.Client, name types.NamespacedName) (*corev1.Secret, error) {
+	var secret corev1.Secret
+	err := k8sClient.Get(ctx, name, &secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+	return &secret, nil
+}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add new field `path` to the OTLPEndpoint
- Add validation rule check field `path` only valid with `protocol` HTTP
- When additional path configured with HTTP protocol, end URL should be used as is by the OTEL Collector (no auto append path `/v1/metrics | traces`)

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/594

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->