### PR TITLE
test: Validate Istio metric attributes

### DIFF
--- a/test/integration/istio/metrics_istio_input_test.go
+++ b/test/integration/istio/metrics_istio_input_test.go
@@ -175,10 +175,28 @@ var _ = Describe("Metrics Istio Input", Label("metrics"), func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(
-					ContainMd(ContainMetric(SatisfyAll(
-						ContainDataPointAttrs(HaveKey(BeElementOf(istioProxyMetricAttributes))),
-						ContainDataPointAttrs(HaveKeyWithValue("source_workload_namespace", app1Ns)),
-					))),
+					ContainMd(SatisfyAll(
+						ContainResourceAttrs(SatisfyAll(
+							HaveKeyWithValue("k8s.namespace.name", "app-1"),
+							HaveKeyWithValue("k8s.pod.name", "destination"),
+							HaveKeyWithValue("k8s.container.name", "istio-proxy"),
+							HaveKeyWithValue("service.name", "destination"),
+						)),
+						ContainMetric(SatisfyAll(
+							ContainDataPointAttrs(HaveKey(BeElementOf(istioProxyMetricAttributes))),
+							ContainDataPointAttrs(HaveKeyWithValue("source_workload_namespace", app1Ns)),
+							ContainDataPointAttrs(HaveKeyWithValue("destination_workload", "destination")),
+							ContainDataPointAttrs(HaveKeyWithValue("destination_app", "destination")),
+							ContainDataPointAttrs(HaveKeyWithValue("destination_service_name", "destination")),
+							ContainDataPointAttrs(HaveKeyWithValue("destination_service", "destination.app-1.svc.cluster.local")),
+							ContainDataPointAttrs(HaveKeyWithValue("destination_service_namespace", app1Ns)),
+							ContainDataPointAttrs(HaveKeyWithValue("destination_principal", "spiffe://cluster.local/ns/app-1/sa/default")),
+							ContainDataPointAttrs(HaveKeyWithValue("source_workload", "source")),
+							ContainDataPointAttrs(HaveKeyWithValue("source_principal", "spiffe://cluster.local/ns/app-1/sa/default")),
+							ContainDataPointAttrs(HaveKeyWithValue("response_code", "200")),
+							ContainDataPointAttrs(HaveKeyWithValue("request_protocol", "http")),
+							ContainDataPointAttrs(HaveKeyWithValue("connection_security_policy", "mutual_tls")),
+						)))),
 				))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- PR #609 fixed a but to not intercept the metric scraping of Istio proxies, which was indicated by wrong metric attributes. This PR enhances the corresponding integration test to validate that Istio metrics have the right attribute values.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/606

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->