### PR TITLE
feat: Remove unused kyma prometheus filter rule

### DIFF
--- a/internal/otelcollector/config/trace/gateway/drop_noisy_spans.go
+++ b/internal/otelcollector/config/trace/gateway/drop_noisy_spans.go
@@ -32,7 +32,6 @@ var (
 
 	//TODO: should be system namespaces after solving https://github.com/kyma-project/telemetry-manager/issues/380
 	fromVMScrapeAgent        = ottlexpr.JoinWithAnd(componentIsProxy, methodIsGet, operationIsIngress, userAgentMatches("vm_promscrape"))
-	fromPrometheusWithinKyma = ottlexpr.JoinWithAnd(componentIsProxy, methodIsGet, operationIsIngress, namespacesIsKymaSystem, userAgentMatches("Prometheus\\\\/.*"))
 	fromTelemetryMetricAgent = ottlexpr.JoinWithAnd(componentIsProxy, methodIsGet, operationIsIngress, userAgentMatches("kyma-otelcol\\\\/.*"))
 )
 
@@ -49,7 +48,6 @@ func makeDropNoisySpansConfig() FilterProcessor {
 				toTelemetryTraceInternalService,
 				toTelemetryMetricService,
 				fromVMScrapeAgent,
-				fromPrometheusWithinKyma,
 				fromTelemetryMetricAgent,
 			},
 		},

--- a/internal/otelcollector/config/trace/gateway/processors_test.go
+++ b/internal/otelcollector/config/trace/gateway/processors_test.go
@@ -75,7 +75,7 @@ func TestProcessors(t *testing.T) {
 		collectorConfig, _, err := MakeConfig(ctx, fakeClient, []telemetryv1alpha1.TracePipeline{testutils.NewTracePipelineBuilder().Build()})
 		require.NoError(t, err)
 
-		require.Equal(t, 11, len(collectorConfig.Processors.DropNoisySpans.Traces.Span), "Span filter list size is wrong")
+		require.Equal(t, 10, len(collectorConfig.Processors.DropNoisySpans.Traces.Span), "Span filter list size is wrong")
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, toFromTelemetryFluentBit, "toFromTelemetryFluentBit span filter is missing")
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, toFromTelemetryTraceGateway, "toFromTelemetryTraceGateway span filter is missing")
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, toFromTelemetryMetricGateway, "toFromTelemetryMetricGateway span filter is missing")
@@ -85,7 +85,6 @@ func TestProcessors(t *testing.T) {
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, toTelemetryTraceInternalService, "toTelemetryTraceInternalService span filter is missing")
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, toTelemetryMetricService, "toTelemetryTraceInternalService span filter is missing")
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, fromVMScrapeAgent, "fromVmScrapeAgent span filter is missing")
-		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, fromPrometheusWithinKyma, "fromPrometheusWithinKyma span filter is missing")
 		require.Contains(t, collectorConfig.Processors.DropNoisySpans.Traces.Span, fromTelemetryMetricAgent, "fromTelemetryMetricAgent span filter is missing")
 	})
 }

--- a/internal/otelcollector/config/trace/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/trace/gateway/testdata/config.yaml
@@ -92,7 +92,6 @@ processors:
                 - attributes["component"] == "proxy" and attributes["http.method"] == "POST" and (attributes["OperationName"] == "Egress" or IsMatch(name, "egress.*") == true) and IsMatch(attributes["http.url"], "http(s)?:\\/\\/telemetry-trace-collector-internal\\.kyma-system(\\..*)?:(55678).*") == true
                 - attributes["component"] == "proxy" and attributes["http.method"] == "POST" and (attributes["OperationName"] == "Egress" or IsMatch(name, "egress.*") == true) and IsMatch(attributes["http.url"], "http(s)?:\\/\\/telemetry-otlp-metrics\\.kyma-system(\\..*)?:(4317|4318).*") == true
                 - attributes["component"] == "proxy" and attributes["http.method"] == "GET" and (attributes["OperationName"] == "Ingress" or IsMatch(name, "ingress.*") == true) and IsMatch(attributes["user_agent"], "vm_promscrape") == true
-                - attributes["component"] == "proxy" and attributes["http.method"] == "GET" and (attributes["OperationName"] == "Ingress" or IsMatch(name, "ingress.*") == true) and resource.attributes["k8s.namespace.name"] == "kyma-system" and IsMatch(attributes["user_agent"], "Prometheus\\/.*") == true
                 - attributes["component"] == "proxy" and attributes["http.method"] == "GET" and (attributes["OperationName"] == "Ingress" or IsMatch(name, "ingress.*") == true) and IsMatch(attributes["user_agent"], "kyma-otelcol\\/.*") == true
     transform/resolve-service-name:
         error_mode: ignore


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

-  Remove unused internal kyma prometheus rule as we dont have prometheus anymore.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/621

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->