### PR TITLE
fix: Improve stability of post-submit job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ OS_ARCH ?= $(shell uname -m)
 OS_TYPE ?= $(shell uname)
 PROJECT_DIR ?= $(shell pwd)
 ARTIFACTS ?= $(shell pwd)/artifacts
-GARDENER_GCP_MACHINE_TYPE ?= n1-standard-8
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -363,7 +362,6 @@ endif
 run-tests-with-git-image: ## Run e2e tests on existing cluster using image related to git commit sha
 	kubectl create namespace kyma-system
 	IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} make deploy-dev
-	make run-e2e-test
 	make run-integration-test-istio
 
 .PHONY: gardener-integration-test
@@ -375,7 +373,7 @@ gardener-integration-test: ## Provision gardener cluster and run integration tes
 
 .PHONY: provision-gardener
 provision-gardener: kyma ## Provision gardener cluster with latest k8s version
-	${KYMA} provision gardener gcp -t ${GARDENER_GCP_MACHINE_TYPE} -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION}\
+	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION}\
 		--hibernation-start="00 ${HIBERNATION_HOUR} * * ?"
 
 .PHONY: deprovision-gardener

--- a/test/integration/istio/traces_test.go
+++ b/test/integration/istio/traces_test.go
@@ -213,7 +213,6 @@ func verifyCustomIstiofiedAppSpans(backendURL string) {
 			ContainResourceAttrs(HaveKeyWithValue("service.name", "monitoring-custom-metrics")),
 			ContainResourceAttrs(HaveKeyWithValue("k8s.pod.name", "istiofied-trace-emitter")),
 			ContainResourceAttrs(HaveKeyWithValue("k8s.namespace.name", "istio-permissive-mtls")),
-			ContainResourceAttrs(HaveKeyWithValue("k8s.node.name", "k3d-kyma-server-0")),
 		))))
 	}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }
@@ -228,7 +227,6 @@ func verifyCustomAppSpans(backendURL string) {
 			ContainResourceAttrs(HaveKeyWithValue("service.name", "monitoring-custom-metrics")),
 			ContainResourceAttrs(HaveKeyWithValue("k8s.pod.name", "trace-emitter")),
 			ContainResourceAttrs(HaveKeyWithValue("k8s.namespace.name", "app-namespace")),
-			ContainResourceAttrs(HaveKeyWithValue("k8s.node.name", "k3d-kyma-server-0")),
 		))))
 	}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Reduce the number of tests that are being executed on the gardener cluster.
- Execute istio integration tests as of now.
- Reduce the size of the VM
- Remove k8s attribute node check to be able to execute the test on k3d and gardener as well
- Tested on n1-standard-4

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->