### PR TITLE
chore: Set up unit test coverage check

### DIFF
--- a/.github/workflows/pull-code-checks.yml
+++ b/.github/workflows/pull-code-checks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run tests
       run: make test
 
-  linting:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -32,9 +32,21 @@ jobs:
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
 
-      - name: Run linting
+      - name: Run lint
         uses: golangci/golangci-lint-action@v3
         with:
           install-mode: binary
           version: latest
           args: --timeout=5m --config=./.golangci.yaml
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Golang
+        uses: "./.github/template/setup-golang"
+
+      - name: Run coverage check
+        run: make check-coverage

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -10,7 +10,7 @@ local-prefix: "github.com/kyma-project/telemetry-manager"
 threshold:
   # (optional; default 0)
   # The minimum coverage that each package should have
-  package: 50
+  package: 60
 
 # Holds regexp rules which will override thresholds for matched files or packages using their paths.
 #

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,44 @@
+# (mandatory) 
+# Path to coverprofile file (output of `go test -coverprofile` command)
+profile: cover.out
+
+# (optional) 
+# When specified reported file paths will not contain local prefix in the output
+local-prefix: "github.com/kyma-project/telemetry-manager"
+
+# Holds coverage thresholds percentages, values should be in range [0-100]
+threshold:
+  # (optional; default 0) 
+  # The minimum coverage that each file should have
+  file: 70
+
+  # (optional; default 0) 
+  # The minimum coverage that each package should have
+  package: 80
+
+  # (optional; default 0) 
+  # The minimum total coverage project should have
+  total: 95
+
+# Holds regexp rules which will override thresholds for matched files or packages using their paths.
+#
+# First rule from this list that matches file or package is going to apply new threshold to it. 
+# If project has multiple rules that match same path, override rules should be listed in order from 
+# specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `foo` package (default is 80, as configured above)
+  - threshold: 100
+    path: ^pkg/lib/foo$
+
+# Holds regexp rules which will exclude matched files or packages from coverage statistics
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - \.pb\.go$       # excludes all protobuf generated files
+    - ^apis            # exclude package `pkg/bar`
+    - ^controllers     # exclude package `pkg/bar`
+    - ^webhook/.*
+ 
+# NOTES:
+# - symbol `/` in all path regexps will be replaced by
+#   current OS file path separator to properly work on Windows

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -10,7 +10,7 @@ local-prefix: "github.com/kyma-project/telemetry-manager"
 threshold:
   # (optional; default 0)
   # The minimum coverage that each package should have
-  package: 60
+  package: 90
 
 # Holds regexp rules which will override thresholds for matched files or packages using their paths.
 #
@@ -18,21 +18,29 @@ threshold:
 # If project has multiple rules that match same path, override rules should be listed in order from
 # specific to more general rules.
 override:
-  # Increase coverage threshold to 100% for `foo` package (default is 80, as configured above)
+  # Temporarily decrease coverage threshold for certain packages, we need to increase the coverage and remove these entries from the list
   - threshold: 48
     path: ^webhook/dryrun$
+  - threshold: 57
+    path: ^internal/istiostatus$
+  - threshold: 86
+    path: ^internal/otelcollector/config/otlpexporter$
+  - threshold: 72
+    path: ^internal/resources/otelcollector$
+  - threshold: 86
+    path: ^internal/webhookcert$
 
 # Holds regexp rules which will exclude matched files or packages from coverage statistics
 exclude:
   # Exclude files or packages matching their paths
   paths:
-    - ^apis
-    - ^controllers
-    - ^internal/k8sutils
-    - ^internal/reconciler
-    - ^internal/setup
-    - ^test
-    - ^webhook/logpipeline
+    - ^apis                # apis should in general only contain Go structs and not unit tested
+    - ^controllers         # controllers are covered by envtests and e2e tests
+    - ^internal/k8sutils   # k8sutils has to be dissected into smaller single-purpose packages, for now excluding from coverage check
+    - ^internal/reconciler # reconciler are covered by envtests and e2e tests
+    - ^internal/setup      # contains simple utils for setting up watchers
+    - ^test                # e2e and integration tests
+    - ^webhook/logpipeline # logpipeline webhooks is covered by envtests and e2e tests
 
 # NOTES:
 # - symbol `/` in all path regexps will be replaced by

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,44 +1,39 @@
-# (mandatory) 
+# (mandatory)
 # Path to coverprofile file (output of `go test -coverprofile` command)
 profile: cover.out
 
-# (optional) 
+# (optional)
 # When specified reported file paths will not contain local prefix in the output
 local-prefix: "github.com/kyma-project/telemetry-manager"
 
 # Holds coverage thresholds percentages, values should be in range [0-100]
 threshold:
-  # (optional; default 0) 
-  # The minimum coverage that each file should have
-  file: 70
-
-  # (optional; default 0) 
+  # (optional; default 0)
   # The minimum coverage that each package should have
-  package: 80
-
-  # (optional; default 0) 
-  # The minimum total coverage project should have
-  total: 95
+  package: 50
 
 # Holds regexp rules which will override thresholds for matched files or packages using their paths.
 #
-# First rule from this list that matches file or package is going to apply new threshold to it. 
-# If project has multiple rules that match same path, override rules should be listed in order from 
+# First rule from this list that matches file or package is going to apply new threshold to it.
+# If project has multiple rules that match same path, override rules should be listed in order from
 # specific to more general rules.
 override:
   # Increase coverage threshold to 100% for `foo` package (default is 80, as configured above)
-  - threshold: 100
-    path: ^pkg/lib/foo$
+  - threshold: 48
+    path: ^webhook/dryrun$
 
 # Holds regexp rules which will exclude matched files or packages from coverage statistics
 exclude:
   # Exclude files or packages matching their paths
   paths:
-    - \.pb\.go$       # excludes all protobuf generated files
-    - ^apis            # exclude package `pkg/bar`
-    - ^controllers     # exclude package `pkg/bar`
-    - ^webhook/.*
- 
+    - ^apis
+    - ^controllers
+    - ^internal/k8sutils
+    - ^internal/reconciler
+    - ^internal/setup
+    - ^test
+    - ^webhook/logpipeline
+
 # NOTES:
 # - symbol `/` in all path regexps will be replaced by
 #   current OS file path separator to properly work on Windows

--- a/Makefile
+++ b/Makefile
@@ -196,10 +196,10 @@ run-integration-test-istio: ginkgo test-matchers ## run integration tests with i
 	mv junit.xml ${ARTIFACTS}
 
 .PHONY: check-coverage
-check-coverage: go-test-coverage envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile=cover.out -covermode=atomic -coverpkg=./...
+check-coverage: go-test-coverage
+	go test ./... -short -coverprofile=cover.out -covermode=atomic -coverpkg=./...
 	$(GO_TEST_COVERAGE) --config=./.testcoverage.yml
-	
+
 ##@ Build
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -183,13 +183,6 @@ e2e-deploy-module: kyma kustomize provision-k3d provision-test-env ## Provision 
 run-e2e-deploy-module: kyma kustomize ## Deploy module with the lifecycle manager.
 	KYMA=${KYMA} KUSTOMIZE=${KUSTOMIZE} ./hack/deploy-module.sh
 
-.PHONY:
-e2e-coverage: ginkgo
-	@$(GINKGO) outline --format indent test/e2e/metrics_test.go  | awk -F "," '{print $$1" "$$2}' | tail -n +2
-	@$(GINKGO) outline --format indent test/e2e/traces_test.go  | awk -F "," '{print $$1" "$$2}' | tail -n +2
-	@$(GINKGO) outline --format indent test/e2e/logs_test.go  | awk -F "," '{print $$1" "$$2}' | tail -n +2
-
-
 .PHONY: integration-test-istio
 integration-test-istio: ginkgo k3d | test-matchers provision-test-env ## Provision k3d cluster, deploy development variant and run integration tests with istio.
 	IMG=k3d-kyma-registry:5000/telemetry-manager:latest make deploy-dev

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,11 @@ run-integration-test-istio: ginkgo test-matchers ## run integration tests with i
 	mkdir -p ${ARTIFACTS}
 	mv junit.xml ${ARTIFACTS}
 
+.PHONY: check-coverage
+check-coverage: go-test-coverage envtest
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile=cover.out -covermode=atomic -coverpkg=./...
+	$(GO_TEST_COVERAGE) --config=./.testcoverage.yml
+	
 ##@ Build
 
 .PHONY: build
@@ -275,6 +280,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GINKGO ?= $(LOCALBIN)/ginkgo
 GOLANGCI-LINT ?= $(LOCALBIN)/golangci-lint
+GO_TEST_COVERAGE ?= $(LOCALBIN)/go-test-coverage
 K3D ?= $(LOCALBIN)/k3d
 KYMA ?= $(LOCALBIN)/kyma-$(KYMA_STABILITY)
 
@@ -286,6 +292,7 @@ K3D_VERSION ?= v5.4.7
 GINKGO_VERSION ?= v2.13.2
 GORELEASER_VERSION ?= v1.17.1
 GOLANGCI-LINT_VERSION ?= latest
+GO_TEST_COVERAGE_VERSION ?= v2.8.2
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -323,6 +330,12 @@ ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 $(GINKGO): $(LOCALBIN)
 	test -s $(GINKGO) && $(GINKGO) version | grep -q $(GINKGO_VERSION) || \
 	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+.PHONY: go-test-coverage
+go-test-coverage: $(GO_TEST_COVERAGE) ## Download go-test-coverage locally if necessary.
+$(GO_TEST_COVERAGE): $(LOCALBIN)
+	test -s $(GO_TEST_COVERAGE) && $(GO_TEST_COVERAGE) version | grep -q $(GO_TEST_COVERAGE_VERSION) || \
+	GOBIN=$(LOCALBIN) go install github.com/vladopajic/go-test-coverage/v2@$(GO_TEST_COVERAGE_VERSION)
 
 K3D_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh"
 .PHONY: k3d

--- a/controllers/operator/suite_test.go
+++ b/controllers/operator/suite_test.go
@@ -53,6 +53,10 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping envtest")
+	}
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/controllers/telemetry/suite_test.go
+++ b/controllers/telemetry/suite_test.go
@@ -61,6 +61,10 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping envtest")
+	}
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/webhook/logpipeline/webhook_suite_test.go
+++ b/webhook/logpipeline/webhook_suite_test.go
@@ -61,6 +61,10 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping envtest")
+	}
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "LogPipeline Webhook Suite")


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add a new make target to check unit test coverage using `go-test-coverage`
- Add a GitHub action
- Add an option to skip envtests, since they are not needed for the coverage
- Rename `linting` to `lint`

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->