### PR TITLE
feat: Enrich the service.name attribute if its value follows the "unknown_service:<process.executable.name>" pattern

### DIFF
--- a/docs/user/gateways.md
+++ b/docs/user/gateways.md
@@ -21,7 +21,7 @@ The downside is that only a limited set of features is available. If you want to
 
 The gateways automatically enrich your data by adding the following attributes:
 
-- `service.name`: The logical name of the service that emits the telemetry data. If not provided by the user, it is populated from Kubernetes metadata, based on the following hierarchy of labels and names:
+- `service.name`: The logical name of the service that emits the telemetry data. If not provided by the user or its value contains the substring `unknown_service`, then it is populated from Kubernetes metadata, based on the following hierarchy of labels and names:
   1. `app.kubernetes.io/name` Pod label value.
   2. `app` Pod label value.
   3. Deployment/DaemonSet/StatefulSet/Job name.

--- a/internal/otelcollector/config/gatewayprocs/resolve_service_name_proc_test.go
+++ b/internal/otelcollector/config/gatewayprocs/resolve_service_name_proc_test.go
@@ -10,14 +10,14 @@ func TestResolveServiceNameStatements(t *testing.T) {
 	require := require.New(t)
 
 	expectedStatements := []string{
-		"set(attributes[\"service.name\"], attributes[\"kyma.kubernetes_io_app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], attributes[\"kyma.app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], attributes[\"k8s.deployment.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], attributes[\"k8s.daemonset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], attributes[\"k8s.statefulset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], attributes[\"k8s.job.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], attributes[\"k8s.pod.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
-		"set(attributes[\"service.name\"], \"unknown_service\") where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or attributes[\"service.name\"] == \"unknown_service\"",
+		"set(attributes[\"service.name\"], attributes[\"kyma.kubernetes_io_app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"kyma.app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.deployment.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.daemonset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.statefulset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.job.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.pod.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], \"unknown_service\") where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\"",
 	}
 
 	statements := ResolveServiceNameStatements()

--- a/internal/otelcollector/config/metric/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/metric/gateway/testdata/config.yaml
@@ -96,14 +96,14 @@ processors:
         metric_statements:
             - context: resource
               statements:
-                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], "unknown_service") where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
+                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], "unknown_service") where attributes["service.name"] == nil or attributes["service.name"] == ""
     resource/drop-kyma-attributes:
         attributes:
             - action: delete

--- a/internal/otelcollector/config/trace/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/trace/gateway/testdata/config.yaml
@@ -98,14 +98,14 @@ processors:
         trace_statements:
             - context: resource
               statements:
-                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
-                - set(attributes["service.name"], "unknown_service") where attributes["service.name"] == nil or attributes["service.name"] == "" or attributes["service.name"] == "unknown_service"
+                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], "unknown_service") where attributes["service.name"] == nil or attributes["service.name"] == ""
     resource/drop-kyma-attributes:
         attributes:
             - action: delete

--- a/test/e2e/metrics_service_name_test.go
+++ b/test/e2e/metrics_service_name_test.go
@@ -91,31 +91,31 @@ var _ = Describe("Metrics Service Name", Label("metrics"), func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		}
 
-		It("Should set service.name to app.kubernetes.io/name label value", func() {
+		It("Should set undefined service.name attribute to app.kubernetes.io/name label value", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithBothLabelsName, servicenamebundle.KubeAppLabelValue)
 		})
 
-		It("Should set service.name to app label value", func() {
+		It("Should set undefined service.name attribute to app label value", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithAppLabelName, servicenamebundle.AppLabelValue)
 		})
 
-		It("Should set service.name to Deployment name", func() {
+		It("Should set undefined service.name attribute to Deployment name", func() {
 			verifyServiceNameAttr(servicenamebundle.DeploymentName, servicenamebundle.DeploymentName)
 		})
 
-		It("Should set service.name to StatefulSet name", func() {
+		It("Should set undefined service.name attribute to StatefulSet name", func() {
 			verifyServiceNameAttr(servicenamebundle.StatefulSetName, servicenamebundle.StatefulSetName)
 		})
 
-		It("Should set service.name to DaemonSet name", func() {
+		It("Should set undefined service.name attribute to DaemonSet name", func() {
 			verifyServiceNameAttr(servicenamebundle.DaemonSetName, servicenamebundle.DaemonSetName)
 		})
 
-		It("Should set service.name to Job name", func() {
+		It("Should set undefined service.name attribute to Job name", func() {
 			verifyServiceNameAttr(servicenamebundle.JobName, servicenamebundle.JobName)
 		})
 
-		It("Should set service.name to unknown_service", func() {
+		It("Should set undefined service.name attribute to unknown_service", func() {
 			gatewayPushURL := proxyClient.ProxyURLForService(kitkyma.SystemNamespaceName, "telemetry-otlp-metrics", "v1/metrics/", ports.OTLPHTTP)
 			kitmetrics.MakeAndSendGaugeMetrics(proxyClient, gatewayPushURL)
 			Eventually(func(g Gomega) {
@@ -129,6 +129,10 @@ var _ = Describe("Metrics Service Name", Label("metrics"), func() {
 					),
 				))
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+
+		It("Should set unknown service.name attribute to Pod name", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
 		})
 
 		It("Should have no kyma resource attributes", func() {

--- a/test/e2e/metrics_service_name_test.go
+++ b/test/e2e/metrics_service_name_test.go
@@ -115,6 +115,10 @@ var _ = Describe("Metrics Service Name", Label("metrics"), func() {
 			verifyServiceNameAttr(servicenamebundle.JobName, servicenamebundle.JobName)
 		})
 
+		It("Should set undefined service.name attribute to Pod name", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithNoLabelsName, servicenamebundle.PodWithNoLabelsName)
+		})
+
 		It("Should set undefined service.name attribute to unknown_service", func() {
 			gatewayPushURL := proxyClient.ProxyURLForService(kitkyma.SystemNamespaceName, "telemetry-otlp-metrics", "v1/metrics/", ports.OTLPHTTP)
 			kitmetrics.MakeAndSendGaugeMetrics(proxyClient, gatewayPushURL)
@@ -131,7 +135,11 @@ var _ = Describe("Metrics Service Name", Label("metrics"), func() {
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should set unknown service.name attribute to Pod name", func() {
+		It("Should enrich service.name attribute when its value is unknown_service:<process.executable.name>", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServicePatternName, servicenamebundle.PodWithUnknownServicePatternName)
+		})
+
+		It("Should enrich service.name attribute when its value is unknown_service", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
 		})
 

--- a/test/e2e/traces_service_name_test.go
+++ b/test/e2e/traces_service_name_test.go
@@ -113,6 +113,10 @@ var _ = Describe("Traces Service Name", Label("traces"), func() {
 			verifyServiceNameAttr(servicenamebundle.JobName, servicenamebundle.JobName)
 		})
 
+		It("Should set undefined service.name attribute to Pod name", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithNoLabelsName, servicenamebundle.PodWithNoLabelsName)
+		})
+
 		It("Should set undefined service.name attribute to unknown_service", func() {
 			gatewayPushURL := proxyClient.ProxyURLForService(kitkyma.SystemNamespaceName, "telemetry-otlp-traces", "v1/traces/", ports.OTLPHTTP)
 			kittraces.MakeAndSendTraces(proxyClient, gatewayPushURL)
@@ -129,7 +133,11 @@ var _ = Describe("Traces Service Name", Label("traces"), func() {
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should set unknown service.name attribute to Pod name", func() {
+		It("Should enrich service.name attribute when its value is unknown_service:<process.executable.name>", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServicePatternName, servicenamebundle.PodWithUnknownServicePatternName)
+		})
+
+		It("Should enrich service.name attribute when its value is unknown_service", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
 		})
 

--- a/test/e2e/traces_service_name_test.go
+++ b/test/e2e/traces_service_name_test.go
@@ -89,31 +89,31 @@ var _ = Describe("Traces Service Name", Label("traces"), func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		}
 
-		It("Should set service.name to app.kubernetes.io/name label value", func() {
+		It("Should set undefined service.name attribute to app.kubernetes.io/name label value", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithBothLabelsName, servicenamebundle.KubeAppLabelValue)
 		})
 
-		It("Should set service.name to app label value", func() {
+		It("Should set undefined service.name attribute to app label value", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithAppLabelName, servicenamebundle.AppLabelValue)
 		})
 
-		It("Should set service.name to Deployment name", func() {
+		It("Should set undefined service.name attribute to Deployment name", func() {
 			verifyServiceNameAttr(servicenamebundle.DeploymentName, servicenamebundle.DeploymentName)
 		})
 
-		It("Should set service.name to StatefulSet name", func() {
+		It("Should set undefined service.name attribute to StatefulSet name", func() {
 			verifyServiceNameAttr(servicenamebundle.StatefulSetName, servicenamebundle.StatefulSetName)
 		})
 
-		It("Should set service.name to DaemonSet name", func() {
+		It("Should set undefined service.name attribute to DaemonSet name", func() {
 			verifyServiceNameAttr(servicenamebundle.DaemonSetName, servicenamebundle.DaemonSetName)
 		})
 
-		It("Should set service.name to Job name", func() {
+		It("Should set undefined service.name attribute to Job name", func() {
 			verifyServiceNameAttr(servicenamebundle.JobName, servicenamebundle.JobName)
 		})
 
-		It("Should set service.name to unknown_service", func() {
+		It("Should set undefined service.name attribute to unknown_service", func() {
 			gatewayPushURL := proxyClient.ProxyURLForService(kitkyma.SystemNamespaceName, "telemetry-otlp-traces", "v1/traces/", ports.OTLPHTTP)
 			kittraces.MakeAndSendTraces(proxyClient, gatewayPushURL)
 			Eventually(func(g Gomega) {
@@ -127,6 +127,10 @@ var _ = Describe("Traces Service Name", Label("traces"), func() {
 					),
 				))
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+
+		It("Should set unknown service.name attribute to Pod name", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
 		})
 
 		It("Should have no kyma resource attributes", func() {

--- a/test/integration/istio/metrics_otlp_input_test.go
+++ b/test/integration/istio/metrics_otlp_input_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Metrics OTLP Input", Label("metrics"), func() {
 		objs = append(objs, peerAuth.K8sObject(kitk8s.WithLabel("app", istiofiedBackendName)))
 
 		// Create 2 deployments (with and without side-car) which would push the metrics to the metrics gateway.
-		podSpec := telemetrygen.PodSpec(telemetrygen.SignalTypeMetrics)
+		podSpec := telemetrygen.PodSpec(telemetrygen.SignalTypeMetrics, "")
 		objs = append(objs,
 			kitk8s.NewDeployment(pushMetricsDepName, backendNs).WithPodSpec(podSpec).K8sObject(),
 			kitk8s.NewDeployment(pushMetricsIstiofiedDepName, istiofiedBackendNs).WithPodSpec(podSpec).K8sObject(),

--- a/test/testkit/mocks/servicenamebundle/service_name_bundle.go
+++ b/test/testkit/mocks/servicenamebundle/service_name_bundle.go
@@ -17,20 +17,23 @@ const (
 	AppLabelValue = "workload"
 
 	// Predefined names for Kubernetes resources
-	PodWithBothLabelsName     = "pod-with-both-app-labels" //#nosec G101 -- This is a false positive
-	PodWithAppLabelName       = "pod-with-app-label"
-	DeploymentName            = "deployment"
-	StatefulSetName           = "stateful-set"
-	DaemonSetName             = "daemon-set"
-	JobName                   = "job"
-	PodWithUnknownServiceName = "pod-with-unknown-service"
+	PodWithBothLabelsName            = "pod-with-both-app-labels" //#nosec G101 -- This is a false positive
+	PodWithAppLabelName              = "pod-with-app-label"
+	DeploymentName                   = "deployment"
+	StatefulSetName                  = "stateful-set"
+	DaemonSetName                    = "daemon-set"
+	JobName                          = "job"
+	PodWithNoLabelsName              = "pod-with-no-labels"
+	PodWithUnknownServicePatternName = "pod-with-unknown-service-pattern"
+	PodWithUnknownServiceName        = "pod-with-unknown-service"
 )
 
 // K8sObjects generates and returns a list of Kubernetes objects
 // that are set up for testing service name enrichment.
 func K8sObjects(namespace string, signalType telemetrygen.SignalType) []client.Object {
 	podSpecWithUndefinedServiceNameAttr := telemetrygen.PodSpec(signalType, "")
-	podSpecWithUnknownServiceNameAttr := telemetrygen.PodSpec(signalType, "unknown_service:bash")
+	podSpecWithUnknownServiceNamePatternAttr := telemetrygen.PodSpec(signalType, "unknown_service:bash")
+	podSpecWithUnknownServiceNameAttr := telemetrygen.PodSpec(signalType, "unknown_service")
 	return []client.Object{
 		kitk8s.NewPod(PodWithBothLabelsName, namespace).
 			WithLabel("app.kubernetes.io/name", KubeAppLabelValue).
@@ -45,6 +48,8 @@ func K8sObjects(namespace string, signalType telemetrygen.SignalType) []client.O
 		kitk8s.NewStatefulSet(StatefulSetName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
 		kitk8s.NewDaemonSet(DaemonSetName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
 		kitk8s.NewJob(JobName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
+		kitk8s.NewPod(PodWithNoLabelsName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
+		kitk8s.NewPod(PodWithUnknownServicePatternName, namespace).WithPodSpec(podSpecWithUnknownServiceNamePatternAttr).K8sObject(),
 		kitk8s.NewPod(PodWithUnknownServiceName, namespace).WithPodSpec(podSpecWithUnknownServiceNameAttr).K8sObject(),
 	}
 }

--- a/test/testkit/mocks/servicenamebundle/service_name_bundle.go
+++ b/test/testkit/mocks/servicenamebundle/service_name_bundle.go
@@ -17,31 +17,34 @@ const (
 	AppLabelValue = "workload"
 
 	// Predefined names for Kubernetes resources
-	PodWithBothLabelsName = "pod-with-both-app-labels" //#nosec G101 -- This is a false positive
-	PodWithAppLabelName   = "pod-with-app-label"
-	DeploymentName        = "deployment"
-	StatefulSetName       = "stateful-set"
-	DaemonSetName         = "daemon-set"
-	JobName               = "job"
+	PodWithBothLabelsName     = "pod-with-both-app-labels" //#nosec G101 -- This is a false positive
+	PodWithAppLabelName       = "pod-with-app-label"
+	DeploymentName            = "deployment"
+	StatefulSetName           = "stateful-set"
+	DaemonSetName             = "daemon-set"
+	JobName                   = "job"
+	PodWithUnknownServiceName = "pod-with-unknown-service"
 )
 
 // K8sObjects generates and returns a list of Kubernetes objects
 // that are set up for testing service name enrichment.
 func K8sObjects(namespace string, signalType telemetrygen.SignalType) []client.Object {
-	podSpec := telemetrygen.PodSpec(signalType)
+	podSpecWithUndefinedServiceNameAttr := telemetrygen.PodSpec(signalType, "")
+	podSpecWithUnknownServiceNameAttr := telemetrygen.PodSpec(signalType, "unknown_service:bash")
 	return []client.Object{
 		kitk8s.NewPod(PodWithBothLabelsName, namespace).
 			WithLabel("app.kubernetes.io/name", KubeAppLabelValue).
 			WithLabel("app", AppLabelValue).
-			WithPodSpec(podSpec).
+			WithPodSpec(podSpecWithUndefinedServiceNameAttr).
 			K8sObject(),
 		kitk8s.NewPod(PodWithAppLabelName, namespace).
 			WithLabel("app", AppLabelValue).
-			WithPodSpec(podSpec).
+			WithPodSpec(podSpecWithUndefinedServiceNameAttr).
 			K8sObject(),
-		kitk8s.NewDeployment(DeploymentName, namespace).WithPodSpec(podSpec).K8sObject(),
-		kitk8s.NewStatefulSet(StatefulSetName, namespace).WithPodSpec(podSpec).K8sObject(),
-		kitk8s.NewDaemonSet(DaemonSetName, namespace).WithPodSpec(podSpec).K8sObject(),
-		kitk8s.NewJob(JobName, namespace).WithPodSpec(podSpec).K8sObject(),
+		kitk8s.NewDeployment(DeploymentName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
+		kitk8s.NewStatefulSet(StatefulSetName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
+		kitk8s.NewDaemonSet(DaemonSetName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
+		kitk8s.NewJob(JobName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
+		kitk8s.NewPod(PodWithUnknownServiceName, namespace).WithPodSpec(podSpecWithUnknownServiceNameAttr).K8sObject(),
 	}
 }

--- a/test/testkit/mocks/telemetrygen/telemetrygen.go
+++ b/test/testkit/mocks/telemetrygen/telemetrygen.go
@@ -1,11 +1,12 @@
 package telemetrygen
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"fmt"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 )
 

--- a/test/testkit/mocks/telemetrygen/telemetrygen.go
+++ b/test/testkit/mocks/telemetrygen/telemetrygen.go
@@ -5,6 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"fmt"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 )
 
@@ -33,16 +34,18 @@ const (
 )
 
 func New(namespace string) *kitk8s.Pod {
-	return kitk8s.NewPod("telemetrygen", namespace).WithPodSpec(PodSpec(SignalTypeMetrics))
+	return kitk8s.NewPod("telemetrygen", namespace).WithPodSpec(PodSpec(SignalTypeMetrics, ""))
 }
 
-func PodSpec(signalType SignalType) corev1.PodSpec {
+func PodSpec(signalType SignalType, serviceNameAttrValue string) corev1.PodSpec {
 	var gatewayPushURL string
 	if signalType == SignalTypeTraces {
 		gatewayPushURL = "telemetry-otlp-traces.kyma-system:4317"
 	} else if signalType == SignalTypeMetrics {
 		gatewayPushURL = "telemetry-otlp-metrics.kyma-system:4317"
 	}
+
+	serviceNameAttr := fmt.Sprintf("service.name=\"%s\"", serviceNameAttrValue)
 
 	return corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -58,7 +61,7 @@ func PodSpec(signalType SignalType) corev1.PodSpec {
 					"--otlp-endpoint",
 					gatewayPushURL,
 					"--otlp-attributes",
-					"service.name=\"\"",
+					serviceNameAttr,
 					"--otlp-insecure",
 				},
 				ImagePullPolicy: corev1.PullAlways,


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Enrich the service.name attribute if its value follows the "unknown_service:<process.executable.name>" pattern
- Adjust unit tests
- Add e2e tests

Changes refer to particular issues, PRs or documents:

- #565 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->