### PR TITLE
chore: Improve release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -31,3 +31,4 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GORELEASER_CURRENT_TAG: "${{ github.ref_name }}" # Explicitly set release tag to do not use -dev tag

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.6.0
+IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
 # ENVTEST_K8S_VERSION refers to the version of Kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.27.1
 ISTIO_VERSION ?= 1.2.1
@@ -290,7 +290,7 @@ TABLE_GEN_VERSION ?= v0.0.0-20230523174756-3dae9f177ffd
 CONTROLLER_TOOLS_VERSION ?= v0.11.3
 K3D_VERSION ?= v5.4.7
 GINKGO_VERSION ?= v2.13.2
-GORELEASER_VERSION ?= v1.17.1
+GORELEASER_VERSION ?= v1.23.0
 GOLANGCI-LINT_VERSION ?= latest
 GO_TEST_COVERAGE_VERSION ?= v2.8.2
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: 1.6.0
+  newTag: main

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -19,8 +19,8 @@ This release process covers the steps to release new major and minor versions fo
    git push upstream {RELEASE_BRANCH}
    ```
 
-5. Bump the `telemetry-manager/main` branch with the new versions for the dependent images.
-   Create a PR to `telemetry-manager/main` with the following changes:
+5. Bump the `telemetry-manager/{RELEASE_BRANCH}` branch with the new versions for the dependent images.
+   Create a PR to `telemetry-manager/{RELEASE_BRANCH}` with the following changes:
    - `Makefile`:
       - For the `IMG` variable, update the tag of the `telemetry-manager` image with the new module version following the `x.y.z` pattern. For example, `IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.0.0`.
    - `config/manager/kustomization.yaml`:
@@ -39,7 +39,7 @@ This release process covers the steps to release new major and minor versions fo
    git tag {RELEASE_DEV_VERSION}
    ```
 
-   Replace {RELEASE_VERSION} with the new module version, for example, `1.0.0`, and replace {RELEASE_DEV_VERSION} with the new development module version, for example, `1.0.0-dev`. The release tags point to the HEAD commit in `telemetry-manager/main` and `telemetry-manager/{RELEASE_BRANCH}` branches.
+   Replace {RELEASE_VERSION} with the new module version, for example, `1.0.0`, and replace {RELEASE_DEV_VERSION} with the new development module version, for example, `1.0.0-dev`. The release tags point to the HEAD commit in `telemetry-manager/{RELEASE_BRANCH}` branches.
 
 8. Push the tags to the upstream repository.
 

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -59,6 +59,8 @@ This release process covers the steps to release new major and minor versions fo
      git push upstream {RELEASE_VERSION}
      ```
 
+10. If the previous release was a bugfix version that contains cherry-picked changes, these change might appear again in the generated change log. Edit the release description and remove redundant entries if necessary.
+
 ## Changelog
 
 Every PR's title must adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for an automatic changelog generation. It is enforced by a [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request) GitHub Action.

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -39,7 +39,7 @@ This release process covers the steps to release new major and minor versions fo
    git tag {RELEASE_DEV_VERSION}
    ```
 
-   Replace {RELEASE_VERSION} with the new module version, for example, `1.0.0`, and replace {RELEASE_DEV_VERSION} with the new development module version, for example, `1.0.0-dev`. The release tags point to the HEAD commit in `telemetry-manager/{RELEASE_BRANCH}` branches.
+   Replace {RELEASE_VERSION} with the new module version, for example, `1.0.0`, and replace {RELEASE_DEV_VERSION} with the new development module version, for example, `1.0.0-dev`. The release tags point to the HEAD commit in `telemetry-manager/{RELEASE_BRANCH}` branch.
 
 8. Push the tags to the upstream repository.
 
@@ -59,7 +59,7 @@ This release process covers the steps to release new major and minor versions fo
      git push upstream {RELEASE_VERSION}
      ```
 
-10. If the previous release was a bugfix version that contains cherry-picked changes, these change might appear again in the generated change log. Edit the release description and remove redundant entries if necessary.
+10. If the previous release was a bugfix version (patch release) that contains cherry-picked changes, these changes might appear again in the generated change log. Edit the release description and remove redundant entries if necessary.
 
 ## Changelog
 

--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -10,7 +10,16 @@ This release process covers the steps to release new major and minor versions fo
 
 3. Create a new [GitHub milestone](https://github.com/kyma-project/telemetry-manager/milestones) for the next version.
 
-4. Bump the `telemetry-manager/main` branch with the new versions for the dependent images.
+4. In the `telemetry-manager` repository, create a release branch.
+   The name of this branch must follow the `release-x.y` pattern, such as `release-1.0`.
+
+   ```bash
+   git fetch upstream
+   git checkout --no-track -b {RELEASE_BRANCH} upstream/main
+   git push upstream {RELEASE_BRANCH}
+   ```
+
+5. Bump the `telemetry-manager/main` branch with the new versions for the dependent images.
    Create a PR to `telemetry-manager/main` with the following changes:
    - `Makefile`:
       - For the `IMG` variable, update the tag of the `telemetry-manager` image with the new module version following the `x.y.z` pattern. For example, `IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.0.0`.
@@ -21,16 +30,7 @@ This release process covers the steps to release new major and minor versions fo
         - Update the tag of the `telemetry-manager` image with the new module version following the `x.y.z` pattern. For example, `europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.0.0`.
         - Ensure that all other images have the same versions as those used in the `main.go` file.
 
-5. Merge the PR.
-
-6. In the `telemetry-manager` repository, create a release branch.
-   The name of this branch must follow the `release-x.y` pattern, such as `release-1.0`.
-
-   ```bash
-   git fetch upstream
-   git checkout --no-track -b {RELEASE_BRANCH} upstream/main
-   git push upstream {RELEASE_BRANCH}
-   ```
+6. Merge the PR.
 
 7. In the `telemetry-manager/{RELEASE_BRANCH}` branch, create release tags for the head commit.
 

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: telemetry
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.6.0
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.89.0-25ff4383
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.1-8adfb683
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20231214-4555a23b


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Use `main` tag for telemetry-manager image
- Bump goreleaser to 1.23.0
- Update release docs

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/656

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->