### PR TITLE
fix: Restart Fluent Bit after mTLS certificate changed

### DIFF
--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -270,10 +270,15 @@ func (r *Reconciler) calculateChecksum(ctx context.Context) (string, error) {
 
 	var envSecret corev1.Secret
 	if err := r.Get(ctx, r.config.EnvSecret, &envSecret); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.EnvSecret.Namespace, r.config.EnvSecret.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s Secret: %v", r.config.EnvSecret.Namespace, r.config.EnvSecret.Name, err)
 	}
 
-	return configchecksum.Calculate([]corev1.ConfigMap{baseCm, parsersCm, luaCm, sectionsCm, filesCm}, []corev1.Secret{envSecret}), nil
+	var tlsSecret corev1.Secret
+	if err := r.Get(ctx, r.config.OutputTLSConfigSecret, &tlsSecret); err != nil {
+		return "", fmt.Errorf("failed to get %s/%s Secret: %v", r.config.OutputTLSConfigSecret.Namespace, r.config.OutputTLSConfigSecret.Name, err)
+	}
+
+	return configchecksum.Calculate([]corev1.ConfigMap{baseCm, parsersCm, luaCm, sectionsCm, filesCm}, []corev1.Secret{envSecret, tlsSecret}), nil
 }
 
 // getDeployableLogPipelines returns the list of log pipelines that are ready to be rendered into the Fluent Bit configuration.

--- a/internal/reconciler/logpipeline/reconciler_test.go
+++ b/internal/reconciler/logpipeline/reconciler_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -124,4 +126,190 @@ func TestGetDeployableLogPipelines(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCalculateChecksum(t *testing.T) {
+	config := Config{
+		DaemonSet: types.NamespacedName{
+			Namespace: "default",
+			Name:      "daemonset",
+		},
+		SectionsConfigMap: types.NamespacedName{
+			Namespace: "default",
+			Name:      "sections",
+		},
+		FilesConfigMap: types.NamespacedName{
+			Namespace: "default",
+			Name:      "files",
+		},
+		LuaConfigMap: types.NamespacedName{
+			Namespace: "default",
+			Name:      "lua",
+		},
+		ParsersConfigMap: types.NamespacedName{
+			Namespace: "default",
+			Name:      "parsers",
+		},
+		EnvSecret: types.NamespacedName{
+			Namespace: "default",
+			Name:      "env",
+		},
+		OutputTLSConfigSecret: types.NamespacedName{
+			Namespace: "default",
+			Name:      "tls",
+		},
+	}
+	dsConfig := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.DaemonSet.Name,
+			Namespace: config.DaemonSet.Namespace,
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+	sectionsConfig := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.SectionsConfigMap.Name,
+			Namespace: config.SectionsConfigMap.Namespace,
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+	filesConfig := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.FilesConfigMap.Name,
+			Namespace: config.FilesConfigMap.Namespace,
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+	luaConfig := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.LuaConfigMap.Name,
+			Namespace: config.LuaConfigMap.Namespace,
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+	parsersConfig := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.ParsersConfigMap.Name,
+			Namespace: config.ParsersConfigMap.Namespace,
+		},
+		Data: map[string]string{
+			"a": "b",
+		},
+	}
+	envSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.EnvSecret.Name,
+			Namespace: config.EnvSecret.Namespace,
+		},
+		Data: map[string][]byte{
+			"a": []byte("b"),
+		},
+	}
+	certSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.OutputTLSConfigSecret.Name,
+			Namespace: config.OutputTLSConfigSecret.Namespace,
+		},
+		Data: map[string][]byte{
+			"a": []byte("b"),
+		},
+	}
+
+	client := fake.NewClientBuilder().WithObjects(&dsConfig, &sectionsConfig, &filesConfig, &luaConfig, &parsersConfig, &envSecret, &certSecret).Build()
+	r := Reconciler{
+		Client: client,
+		config: config,
+	}
+	ctx := context.Background()
+
+	checksum, err := r.calculateChecksum(ctx)
+
+	t.Run("Initial checksum should not be empty", func(t *testing.T) {
+		require.NoError(t, err)
+		require.NotEmpty(t, checksum)
+	})
+
+	t.Run("Changing static config should update checksum", func(t *testing.T) {
+		dsConfig.Data["a"] = "c"
+		updateErr := client.Update(ctx, &dsConfig)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating static config")
+		checksum = newChecksum
+	})
+
+	t.Run("Changing sections config should update checksum", func(t *testing.T) {
+		sectionsConfig.Data["a"] = "c"
+		updateErr := client.Update(ctx, &sectionsConfig)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating sections config")
+		checksum = newChecksum
+	})
+
+	t.Run("Changing files config should update checksum", func(t *testing.T) {
+		filesConfig.Data["a"] = "c"
+		updateErr := client.Update(ctx, &filesConfig)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating files config")
+		checksum = newChecksum
+	})
+
+	t.Run("Changing LUA config should update checksum", func(t *testing.T) {
+		luaConfig.Data["a"] = "c"
+		updateErr := client.Update(ctx, &luaConfig)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating LUA config")
+		checksum = newChecksum
+	})
+
+	t.Run("Changing parsers config should update checksum", func(t *testing.T) {
+		parsersConfig.Data["a"] = "c"
+		updateErr := client.Update(ctx, &parsersConfig)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating parsers config")
+		checksum = newChecksum
+	})
+
+	t.Run("Changing env Secret should update checksum", func(t *testing.T) {
+		envSecret.Data["a"] = []byte("c")
+		updateErr := client.Update(ctx, &envSecret)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating env secret")
+		checksum = newChecksum
+	})
+
+	t.Run("Changing certificate Secret should update checksum", func(t *testing.T) {
+		certSecret.Data["a"] = []byte("c")
+		updateErr := client.Update(ctx, &certSecret)
+		require.NoError(t, updateErr)
+
+		newChecksum, checksumErr := r.calculateChecksum(ctx)
+		require.NoError(t, checksumErr)
+		require.NotEqualf(t, checksum, newChecksum, "Checksum not changed by updating certificate secret")
+	})
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The checksum generation missed including the tls secret. So changing tls secret would not restart the fluent-bit daemonset.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/670

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->