### PR TITLE
test: Fix noisy span filter E2E test

### DIFF
--- a/test/e2e/traces_noisy_span_filter_test.go
+++ b/test/e2e/traces_noisy_span_filter_test.go
@@ -82,11 +82,6 @@ var _ = Describe("Traces Noisy Span Filter", Label("traces"), func() {
 			verifiers.TracesShouldNotBePresent(proxyClient, urls.MockBackendExport(mockBackendName), traceID)
 		})
 
-		It("Should filter noisy kyma prometheus spans", func() {
-			traceID := kittraces.MakeAndSendPrometheusAgentTraces(proxyClient, urls.OTLPPush())
-			verifiers.TracesShouldNotBePresent(proxyClient, urls.MockBackendExport(mockBackendName), traceID)
-		})
-
 		It("Should filter noisy metric agent scrape spans", func() {
 			traceID := kittraces.MakeAndSendMetricAgentScrapeTraces(proxyClient, urls.OTLPPush())
 			verifiers.TracesShouldNotBePresent(proxyClient, urls.MockBackendExport(mockBackendName), traceID)

--- a/test/testkit/otlp/traces/helpers.go
+++ b/test/testkit/otlp/traces/helpers.go
@@ -54,20 +54,6 @@ func MakeAndSendVictoriaMetricsAgentTraces(proxyClient *apiserver.ProxyClient, o
 	return traceID
 }
 
-func MakeAndSendPrometheusAgentTraces(proxyClient *apiserver.ProxyClient, otlpPushURL string) pcommon.TraceID {
-	spanAttrs := pcommon.NewMap()
-	spanAttrs.PutStr("http.method", "GET")
-	spanAttrs.PutStr("component", "proxy")
-	spanAttrs.PutStr("OperationName", "Ingress")
-	spanAttrs.PutStr("user_agent", "Prometheus/0.1.0")
-
-	resourceAttrs := pcommon.NewMap()
-	resourceAttrs.PutStr("k8s.namespace.name", kitkyma.SystemNamespaceName)
-
-	traceID, _ := MakeAndSendTracesWithAttributes(proxyClient, otlpPushURL, spanAttrs, resourceAttrs)
-	return traceID
-}
-
 func MakeAndSendMetricAgentScrapeTraces(proxyClient *apiserver.ProxyClient, otlpPushURL string) pcommon.TraceID {
 	spanAttrs := pcommon.NewMap()
 	spanAttrs.PutStr("http.method", "GET")


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- We have recently removed the filter rule,  but forgot to adjust the E2E tests

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/pull/667

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->