### PR TITLE
feat: Improve regexp for detecting the unknown_service pattern in the service.name attribute

### DIFF
--- a/docs/user/gateways.md
+++ b/docs/user/gateways.md
@@ -21,7 +21,7 @@ The downside is that only a limited set of features is available. If you want to
 
 The gateways automatically enrich your data by adding the following attributes:
 
-- `service.name`: The logical name of the service that emits the telemetry data. If not provided by the user or its value follows the `unknown_service:<process.executable.name>` pattern as described in the [specification](https://opentelemetry.io/docs/specs/semconv/resource/#service), then it is populated from Kubernetes metadata, based on the following hierarchy of labels and names:
+- `service.name`: The logical name of the service that emits the telemetry data. If not provided by the user or if its value follows the `unknown_service:<process.executable.name>` pattern as described in the [specification](https://opentelemetry.io/docs/specs/semconv/resource/#service), then it is populated from Kubernetes metadata, based on the following hierarchy of labels and names:
   1. `app.kubernetes.io/name` Pod label value.
   2. `app` Pod label value.
   3. Deployment/DaemonSet/StatefulSet/Job name.

--- a/docs/user/gateways.md
+++ b/docs/user/gateways.md
@@ -21,7 +21,7 @@ The downside is that only a limited set of features is available. If you want to
 
 The gateways automatically enrich your data by adding the following attributes:
 
-- `service.name`: The logical name of the service that emits the telemetry data. If not provided by the user or its value contains the substring `unknown_service`, then it is populated from Kubernetes metadata, based on the following hierarchy of labels and names:
+- `service.name`: The logical name of the service that emits the telemetry data. If not provided by the user or its value follows the `unknown_service:<process.executable.name>` pattern as described in the [specification](https://opentelemetry.io/docs/specs/semconv/resource/#service), then it is populated from Kubernetes metadata, based on the following hierarchy of labels and names:
   1. `app.kubernetes.io/name` Pod label value.
   2. `app` Pod label value.
   3. Deployment/DaemonSet/StatefulSet/Job name.

--- a/internal/otelcollector/config/gatewayprocs/resolve_service_name_proc.go
+++ b/internal/otelcollector/config/gatewayprocs/resolve_service_name_proc.go
@@ -42,7 +42,7 @@ func inferServiceNameFromAttr(attrKey string) string {
 	serviceNameNotDefinedCondition := fmt.Sprintf(
 		"%s or %s",
 		serviceNameNotDefinedBasicCondition,
-		ottlexpr.IsMatch("attributes[\"service.name\"]", "unknown_service"),
+		ottlexpr.IsMatch("attributes[\"service.name\"]", "^unknown_service(:.+)?$"),
 	)
 	return fmt.Sprintf(
 		"set(attributes[\"service.name\"], attributes[\"%s\"]) where %s",

--- a/internal/otelcollector/config/gatewayprocs/resolve_service_name_proc_test.go
+++ b/internal/otelcollector/config/gatewayprocs/resolve_service_name_proc_test.go
@@ -10,13 +10,13 @@ func TestResolveServiceNameStatements(t *testing.T) {
 	require := require.New(t)
 
 	expectedStatements := []string{
-		"set(attributes[\"service.name\"], attributes[\"kyma.kubernetes_io_app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
-		"set(attributes[\"service.name\"], attributes[\"kyma.app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
-		"set(attributes[\"service.name\"], attributes[\"k8s.deployment.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
-		"set(attributes[\"service.name\"], attributes[\"k8s.daemonset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
-		"set(attributes[\"service.name\"], attributes[\"k8s.statefulset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
-		"set(attributes[\"service.name\"], attributes[\"k8s.job.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
-		"set(attributes[\"service.name\"], attributes[\"k8s.pod.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"unknown_service\")",
+		"set(attributes[\"service.name\"], attributes[\"kyma.kubernetes_io_app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
+		"set(attributes[\"service.name\"], attributes[\"kyma.app_name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.deployment.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.daemonset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.statefulset.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.job.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
+		"set(attributes[\"service.name\"], attributes[\"k8s.pod.name\"]) where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\" or IsMatch(attributes[\"service.name\"], \"^unknown_service(:.+)?$\")",
 		"set(attributes[\"service.name\"], \"unknown_service\") where attributes[\"service.name\"] == nil or attributes[\"service.name\"] == \"\"",
 	}
 

--- a/internal/otelcollector/config/metric/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/metric/gateway/testdata/config.yaml
@@ -96,13 +96,13 @@ processors:
         metric_statements:
             - context: resource
               statements:
-                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
                 - set(attributes["service.name"], "unknown_service") where attributes["service.name"] == nil or attributes["service.name"] == ""
     resource/drop-kyma-attributes:
         attributes:

--- a/internal/otelcollector/config/trace/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/trace/gateway/testdata/config.yaml
@@ -98,13 +98,13 @@ processors:
         trace_statements:
             - context: resource
               statements:
-                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
-                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "unknown_service")
+                - set(attributes["service.name"], attributes["kyma.kubernetes_io_app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["kyma.app_name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.daemonset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.statefulset.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.job.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
+                - set(attributes["service.name"], attributes["k8s.pod.name"]) where attributes["service.name"] == nil or attributes["service.name"] == "" or IsMatch(attributes["service.name"], "^unknown_service(:.+)?$")
                 - set(attributes["service.name"], "unknown_service") where attributes["service.name"] == nil or attributes["service.name"] == ""
     resource/drop-kyma-attributes:
         attributes:

--- a/test/e2e/metrics_service_name_test.go
+++ b/test/e2e/metrics_service_name_test.go
@@ -135,12 +135,18 @@ var _ = Describe("Metrics Service Name", Label("metrics"), func() {
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should enrich service.name attribute when its value is unknown_service:<process.executable.name>", func() {
+		It("Should enrich service.name attribute when its value is unknown_service", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
+		})
+
+		It("Should enrich service.name attribute when its value is following the unknown_service:<process.executable.name> pattern", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServicePatternName, servicenamebundle.PodWithUnknownServicePatternName)
 		})
 
-		It("Should enrich service.name attribute when its value is unknown_service", func() {
-			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
+		It("Should NOT enrich service.name attribute when its value is not following the unknown_service:<process.executable.name> pattern", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithInvalidStartForUnknownServicePatternName, servicenamebundle.AttrWithInvalidStartForUnknownServicePattern)
+			verifyServiceNameAttr(servicenamebundle.PodWithInvalidEndForUnknownServicePatternName, servicenamebundle.AttrWithInvalidEndForUnknownServicePattern)
+			verifyServiceNameAttr(servicenamebundle.PodWithMissingProcessForUnknownServicePatternName, servicenamebundle.AttrWithMissingProcessForUnknownServicePattern)
 		})
 
 		It("Should have no kyma resource attributes", func() {

--- a/test/e2e/traces_service_name_test.go
+++ b/test/e2e/traces_service_name_test.go
@@ -133,12 +133,18 @@ var _ = Describe("Traces Service Name", Label("traces"), func() {
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should enrich service.name attribute when its value is unknown_service:<process.executable.name>", func() {
+		It("Should enrich service.name attribute when its value is unknown_service", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
+		})
+
+		It("Should enrich service.name attribute when its value is following the unknown_service:<process.executable.name> pattern", func() {
 			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServicePatternName, servicenamebundle.PodWithUnknownServicePatternName)
 		})
 
-		It("Should enrich service.name attribute when its value is unknown_service", func() {
-			verifyServiceNameAttr(servicenamebundle.PodWithUnknownServiceName, servicenamebundle.PodWithUnknownServiceName)
+		It("Should NOT enrich service.name attribute when its value is not following the unknown_service:<process.executable.name> pattern", func() {
+			verifyServiceNameAttr(servicenamebundle.PodWithInvalidStartForUnknownServicePatternName, servicenamebundle.AttrWithInvalidStartForUnknownServicePattern)
+			verifyServiceNameAttr(servicenamebundle.PodWithInvalidEndForUnknownServicePatternName, servicenamebundle.AttrWithInvalidEndForUnknownServicePattern)
+			verifyServiceNameAttr(servicenamebundle.PodWithMissingProcessForUnknownServicePatternName, servicenamebundle.AttrWithMissingProcessForUnknownServicePattern)
 		})
 
 		It("Should have no kyma resource attributes", func() {

--- a/test/testkit/mocks/servicenamebundle/service_name_bundle.go
+++ b/test/testkit/mocks/servicenamebundle/service_name_bundle.go
@@ -17,39 +17,53 @@ const (
 	AppLabelValue = "workload"
 
 	// Predefined names for Kubernetes resources
-	PodWithBothLabelsName            = "pod-with-both-app-labels" //#nosec G101 -- This is a false positive
-	PodWithAppLabelName              = "pod-with-app-label"
-	DeploymentName                   = "deployment"
-	StatefulSetName                  = "stateful-set"
-	DaemonSetName                    = "daemon-set"
-	JobName                          = "job"
-	PodWithNoLabelsName              = "pod-with-no-labels"
-	PodWithUnknownServicePatternName = "pod-with-unknown-service-pattern"
-	PodWithUnknownServiceName        = "pod-with-unknown-service"
+	PodWithBothLabelsName                             = "pod-with-both-app-labels" //#nosec G101 -- This is a false positive
+	PodWithAppLabelName                               = "pod-with-app-label"
+	DeploymentName                                    = "deployment"
+	StatefulSetName                                   = "stateful-set"
+	DaemonSetName                                     = "daemon-set"
+	JobName                                           = "job"
+	PodWithNoLabelsName                               = "pod-with-no-labels"
+	PodWithUnknownServiceName                         = "pod-with-unknown-service"
+	PodWithUnknownServicePatternName                  = "pod-with-unknown-service-pattern"
+	PodWithInvalidStartForUnknownServicePatternName   = "pod-with-invalid-start-for-unknown-service-pattern"
+	PodWithInvalidEndForUnknownServicePatternName     = "pod-with-invalid-end-for-unknown-service-pattern"
+	PodWithMissingProcessForUnknownServicePatternName = "pod-with-missing-process-for-unknown-service-pattern"
+
+	// Invalid values for the unknown_service:<process.executable.name> pattern
+	AttrWithInvalidStartForUnknownServicePattern   = "test_unknown_service"
+	AttrWithInvalidEndForUnknownServicePattern     = "unknown_service_test"
+	AttrWithMissingProcessForUnknownServicePattern = "unknown_service:"
 )
 
 // K8sObjects generates and returns a list of Kubernetes objects
 // that are set up for testing service name enrichment.
 func K8sObjects(namespace string, signalType telemetrygen.SignalType) []client.Object {
-	podSpecWithUndefinedServiceNameAttr := telemetrygen.PodSpec(signalType, "")
-	podSpecWithUnknownServiceNamePatternAttr := telemetrygen.PodSpec(signalType, "unknown_service:bash")
-	podSpecWithUnknownServiceNameAttr := telemetrygen.PodSpec(signalType, "unknown_service")
+	podSpecWithUndefinedService := telemetrygen.PodSpec(signalType, "")
+	podSpecWithUnknownService := telemetrygen.PodSpec(signalType, "unknown_service")
+	podSpecWithUnknownServicePattern := telemetrygen.PodSpec(signalType, "unknown_service:bash")
+	podSpecWithInvalidStartForUnknownServicePattern := telemetrygen.PodSpec(signalType, AttrWithInvalidStartForUnknownServicePattern)
+	podSpecWithInvalidEndForUnknownServicePattern := telemetrygen.PodSpec(signalType, AttrWithInvalidEndForUnknownServicePattern)
+	podSpecWithMissingProcessForUnknownServicePattern := telemetrygen.PodSpec(signalType, AttrWithMissingProcessForUnknownServicePattern)
 	return []client.Object{
 		kitk8s.NewPod(PodWithBothLabelsName, namespace).
 			WithLabel("app.kubernetes.io/name", KubeAppLabelValue).
 			WithLabel("app", AppLabelValue).
-			WithPodSpec(podSpecWithUndefinedServiceNameAttr).
+			WithPodSpec(podSpecWithUndefinedService).
 			K8sObject(),
 		kitk8s.NewPod(PodWithAppLabelName, namespace).
 			WithLabel("app", AppLabelValue).
-			WithPodSpec(podSpecWithUndefinedServiceNameAttr).
+			WithPodSpec(podSpecWithUndefinedService).
 			K8sObject(),
-		kitk8s.NewDeployment(DeploymentName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
-		kitk8s.NewStatefulSet(StatefulSetName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
-		kitk8s.NewDaemonSet(DaemonSetName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
-		kitk8s.NewJob(JobName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
-		kitk8s.NewPod(PodWithNoLabelsName, namespace).WithPodSpec(podSpecWithUndefinedServiceNameAttr).K8sObject(),
-		kitk8s.NewPod(PodWithUnknownServicePatternName, namespace).WithPodSpec(podSpecWithUnknownServiceNamePatternAttr).K8sObject(),
-		kitk8s.NewPod(PodWithUnknownServiceName, namespace).WithPodSpec(podSpecWithUnknownServiceNameAttr).K8sObject(),
+		kitk8s.NewDeployment(DeploymentName, namespace).WithPodSpec(podSpecWithUndefinedService).K8sObject(),
+		kitk8s.NewStatefulSet(StatefulSetName, namespace).WithPodSpec(podSpecWithUndefinedService).K8sObject(),
+		kitk8s.NewDaemonSet(DaemonSetName, namespace).WithPodSpec(podSpecWithUndefinedService).K8sObject(),
+		kitk8s.NewJob(JobName, namespace).WithPodSpec(podSpecWithUndefinedService).K8sObject(),
+		kitk8s.NewPod(PodWithNoLabelsName, namespace).WithPodSpec(podSpecWithUndefinedService).K8sObject(),
+		kitk8s.NewPod(PodWithUnknownServicePatternName, namespace).WithPodSpec(podSpecWithUnknownServicePattern).K8sObject(),
+		kitk8s.NewPod(PodWithUnknownServiceName, namespace).WithPodSpec(podSpecWithUnknownService).K8sObject(),
+		kitk8s.NewPod(PodWithInvalidStartForUnknownServicePatternName, namespace).WithPodSpec(podSpecWithInvalidStartForUnknownServicePattern).K8sObject(),
+		kitk8s.NewPod(PodWithInvalidEndForUnknownServicePatternName, namespace).WithPodSpec(podSpecWithInvalidEndForUnknownServicePattern).K8sObject(),
+		kitk8s.NewPod(PodWithMissingProcessForUnknownServicePatternName, namespace).WithPodSpec(podSpecWithMissingProcessForUnknownServicePattern).K8sObject(),
 	}
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Improve regexp for detecting the `unknown_service pattern:<process.executable.name>` in the service.name attribute
- Adjust the documentation
- Adjust unit tests
- Add e2e tests to ensure that `service.name` attribute is NOT enriched when its value is not following the `unknown_service:<process.executable.name>` pattern

Changes refer to particular issues, PRs or documents:

- #565 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->