### PR TITLE
test: Fix flaky E2E metrics tests (missing Secret)

### DIFF
--- a/test/e2e/metrics_secret_rotation_test.go
+++ b/test/e2e/metrics_secret_rotation_test.go
@@ -44,10 +44,10 @@ var _ = Describe("Metrics Secret Rotation", Label("metrics"), func() {
 		})
 
 		It("Should not have metric gateway deployment", func() {
-			Consistently(func(g Gomega) {
+			Consistently(func(g Gomega) error {
 				var deployment appsv1.Deployment
-				g.Expect(k8sClient.Get(ctx, kitkyma.MetricGatewayName, &deployment)).To(Succeed())
-			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).ShouldNot(Succeed())
+				return k8sClient.Get(ctx, kitkyma.MetricGatewayName, &deployment)
+			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(HaveOccurred())
 		})
 
 		It("Should have running metricpipeline", func() {

--- a/test/e2e/metrics_secret_rotation_test.go
+++ b/test/e2e/metrics_secret_rotation_test.go
@@ -16,6 +16,7 @@ import (
 	kitmetricpipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("Metrics Secret Rotation", Label("metrics"), func() {
@@ -44,10 +45,11 @@ var _ = Describe("Metrics Secret Rotation", Label("metrics"), func() {
 		})
 
 		It("Should not have metric gateway deployment", func() {
-			Consistently(func(g Gomega) error {
+			Eventually(func(g Gomega) bool {
 				var deployment appsv1.Deployment
-				return k8sClient.Get(ctx, kitkyma.MetricGatewayName, &deployment)
-			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(HaveOccurred())
+				err := k8sClient.Get(ctx, kitkyma.MetricGatewayName, &deployment)
+				return apierrors.IsNotFound(err)
+			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(BeTrue())
 		})
 
 		It("Should have running metricpipeline", func() {

--- a/test/e2e/metrics_secret_rotation_test.go
+++ b/test/e2e/metrics_secret_rotation_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -16,7 +17,6 @@ import (
 	kitmetricpipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/metric"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("Metrics Secret Rotation", Label("metrics"), func() {

--- a/test/e2e/traces_secret_rotation_test.go
+++ b/test/e2e/traces_secret_rotation_test.go
@@ -32,10 +32,10 @@ var _ = Describe("Traces Secret Rotation", Label("traces"), func() {
 		})
 
 		It("Should not have trace gateway deployment", func() {
-			Consistently(func(g Gomega) {
+			Consistently(func(g Gomega) error {
 				var deployment appsv1.Deployment
-				g.Expect(k8sClient.Get(ctx, kitkyma.TraceGatewayName, &deployment)).To(Succeed())
-			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).ShouldNot(Succeed())
+				return k8sClient.Get(ctx, kitkyma.TraceGatewayName, &deployment)
+			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(HaveOccurred())
 		})
 
 		It("Should have running tracepipeline", func() {

--- a/test/e2e/traces_secret_rotation_test.go
+++ b/test/e2e/traces_secret_rotation_test.go
@@ -6,13 +6,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	kittracepipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("Traces Secret Rotation", Label("traces"), func() {

--- a/test/e2e/traces_secret_rotation_test.go
+++ b/test/e2e/traces_secret_rotation_test.go
@@ -12,6 +12,7 @@ import (
 	kittracepipeline "github.com/kyma-project/telemetry-manager/test/testkit/kyma/telemetry/trace"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = Describe("Traces Secret Rotation", Label("traces"), func() {
@@ -32,10 +33,11 @@ var _ = Describe("Traces Secret Rotation", Label("traces"), func() {
 		})
 
 		It("Should not have trace gateway deployment", func() {
-			Consistently(func(g Gomega) error {
+			Eventually(func(g Gomega) bool {
 				var deployment appsv1.Deployment
-				return k8sClient.Get(ctx, kitkyma.TraceGatewayName, &deployment)
-			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(HaveOccurred())
+				err := k8sClient.Get(ctx, kitkyma.TraceGatewayName, &deployment)
+				return apierrors.IsNotFound(err)
+			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(BeTrue())
 		})
 
 		It("Should have running tracepipeline", func() {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Modify the assertion logic to verify the absence of the Gateway until it is Eventually not found, as opposed to using Consistently. We have noticed occasional test failures, which may be linked to leftover Gateway deployments from prior test executions that were not successfully deleted

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->