### PR TITLE
docs: Use non headless service for loki example

### DIFF
--- a/docs/user/integration/loki/README.md
+++ b/docs/user/integration/loki/README.md
@@ -100,7 +100,7 @@ helm upgrade --install --create-namespace -n ${K8S_NAMESPACE} promtail grafana/p
   Install Fluent Bit with Kyma's LogPipeline
   </summary>
 
->**CAUTION:** This setup uses an unsupported output plugin for the LogPipline.
+>**CAUTION:** This setup uses an unsupported output plugin for the LogPipeline.
 
 Apply the LogPipeline:
 
@@ -118,7 +118,7 @@ Apply the LogPipeline:
       output:
          custom: |
             name   loki
-            host   ${HELM_LOKI_RELEASE}-headless.${K8S_NAMESPACE}.svc.cluster.local
+            host   ${HELM_LOKI_RELEASE}.${K8S_NAMESPACE}.svc.cluster.local
             port   3100
             auto_kubernetes_labels off
             labels job=fluentbit, container=\$kubernetes['container_name'], namespace=\$kubernetes['namespace_name'], pod=\$kubernetes['pod_name'], node=\$kubernetes['host'], app=\$kubernetes['labels']['app'],app=\$kubernetes['labels']['app.kubernetes.io/name']


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Use non headless-service for loki in the loki pipeline. 
- As with headless service the loki headless service uses the ip address from the loki pod. If for any reason the loki pod is restarted then the cached ip address of loki in fluent-bit pod is not updated and can cause log loss.


Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->