### PR TITLE
docs: Add missing space and separate links to integration guides

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -71,13 +71,17 @@ For more information, see [Metrics](04-metrics.md) and [Gateways](gateways.md).
 
 ## Integration Guides
 
-With the Telemetry module you can collect telemetry data and ship the data to backends. For details, read the following guides:
+With the Telemetry module you can collect telemetry data and ship the data to backends.
 
-- [OpenTelemetry Demo App](integration/opentelemetry-demo/README.md)
+Read the following guides for integration of different backends:
+
 - [SAP Cloud Logging](integration/sap-cloud-logging/README.md)
 - [Dynatrace](integration/dynatrace/README.md)
 - [Loki](integration/loki/README.md)
 - [Jaeger](integration/jaeger/README.md)
+
+Read the following guides to learn how to collect data from applications:
+- [OpenTelemetry Demo App](integration/opentelemetry-demo/README.md)
 
 ## API / Custom Resource Definitions
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -71,7 +71,7 @@ For more information, see [Metrics](04-metrics.md) and [Gateways](gateways.md).
 
 ## Integration Guides
 
-With the Telemetry module you can collect telemetry data and ship the data to backends.
+With the Telemetry module, you can collect telemetry data and ship the data to backends.
 
 Read the following guides for integration of different backends:
 

--- a/docs/user/integration/README.md
+++ b/docs/user/integration/README.md
@@ -2,6 +2,6 @@
 
 Kyma's Telemetry module makes it easy for you to integrate the telemetry services you need. The following guides support you step by step:
 
-Learn about OpenTelemetry in a near real-world environment and see it in action with the [OpenTelemetry Demo App](./opentelemetry-demo/README.md).
-
 If you'd like instructions how to integrate with several backends, check out the guides for [SAP Cloud Logging](./sap-cloud-logging/README.md), a [custom Loki stack](./loki/README.md), and a [custom Jaeger stack](./jaeger/README.md).
+
+Learn about OpenTelemetry in a near real-world environment and see it in action with the [OpenTelemetry Demo App](./opentelemetry-demo/README.md).

--- a/docs/user/integration/opentelemetry-demo/README.md
+++ b/docs/user/integration/opentelemetry-demo/README.md
@@ -91,7 +91,7 @@ Run the Helm upgrade command, which installs the chart if not present yet.
 helm upgrade --version 0.26.1 --install --create-namespace -n $K8S_NAMESPACE $HELM_OTEL_RELEASE open-telemetry/opentelemetry-demo -f https://raw.githubusercontent.com/kyma-project/telemetry-manager/main/docs/user/integration/opentelemetry-demo/values.yaml
 ```
 
-The previous command uses the[values.yaml](https://raw.githubusercontent.com/kyma-project/telemetry-manager/main/docs/user/integration/opentelemetry-demo/values.yaml) provided in this `opentelemetry-demo` folder, which contains customized settings deviating from the default settings. The customizations in the provided `values.yaml` cover the following areas:
+The previous command uses the [values.yaml](https://raw.githubusercontent.com/kyma-project/telemetry-manager/main/docs/user/integration/opentelemetry-demo/values.yaml) provided in this `opentelemetry-demo` folder, which contains customized settings deviating from the default settings. The customizations in the provided `values.yaml` cover the following areas:
 
 - Disable the observability tooling provided with the chart
 - Configure Kyma Telemetry instead


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add missing space
- separate links to integration guides to have them more obvious separated by category

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->