### PR TITLE
chore: Test compatibility with next k8s version 1.28

### DIFF
--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   gardener-integration-test:
+    strategy:
+        max-parallel: 1 # avoid 2 clusters at the same time using same name
+        matrix:
+          k8s_version: [1.27, 1.28]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
@@ -33,6 +37,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         GITHUB_OWNER: "${{ github.repository_owner }}"
         GITHUB_REPO: "telemetry-manager"
+        GARDENER_K8S_VERSION: ${{ matrix.k8s_version }}
 
     # save gardener kubeconfig to a temp file in order to pass it to the command
     - name: Save serviceaccount to file

--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   gardener-integration-test:
     strategy:
-        max-parallel: 1 # avoid 2 clusters at the same time using same name
         matrix:
           k8s_version: [1.27, 1.28]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # Image URL to use all building/pushing image targets
 IMG ?= europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
 # ENVTEST_K8S_VERSION refers to the version of Kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.27.1
+ENVTEST_K8S_VERSION = 1.28.0
+GARDENER_K8S_VERSION = 1.28.4
 ISTIO_VERSION ?= 1.3.0
+
 # Operating system architecture
 OS_ARCH ?= $(shell uname -m)
 # Operating system type
@@ -369,9 +371,6 @@ $(KYMA):
 GIT_COMMIT_SHA=$(shell git rev-parse --short=8 HEAD)
 GIT_COMMIT_DATE=$(shell git show -s --format=%cd --date=format:'v%Y%m%d' ${GIT_COMMIT_SHA})
 HIBERNATION_HOUR=$(shell echo $$(( ( $(shell date +%H | sed s/^0//g) + 5 ) % 24 )))
-ifneq (,$(GARDENER_SA_PATH))
-GARDENER_K8S_VERSION?=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud gcp -o=jsonpath='{.spec.kubernetes.versions[0].version}')
-endif
 
 # log tests are excluded for now as they are too flaky
 .PHONY: run-tests-with-git-image

--- a/Makefile
+++ b/Makefile
@@ -393,10 +393,10 @@ gardener-integration-test: ## Provision gardener cluster and run integration tes
 
 .PHONY: provision-gardener
 provision-gardener: kyma ## Provision gardener cluster with latest k8s version
-	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION_FULL}\
+	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA}-${GARDENER_K8S_VERSION} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION_FULL}\
 		--hibernation-start="00 ${HIBERNATION_HOUR} * * ?"
 
 .PHONY: deprovision-gardener
 deprovision-gardener: kyma ## Deprovision gardener cluster
-	kubectl --kubeconfig=${GARDENER_SA_PATH} annotate shoot test-${GIT_COMMIT_SHA} confirmation.gardener.cloud/deletion=true
+	kubectl --kubeconfig=${GARDENER_SA_PATH} annotate shoot test-${GIT_COMMIT_SHA}-${GARDENER_K8S_VERSION} confirmation.gardener.cloud/deletion=true
 	kubectl --kubeconfig=${GARDENER_SA_PATH} delete shoot test-${GIT_COMMIT_SHA} --wait=false

--- a/Makefile
+++ b/Makefile
@@ -372,9 +372,10 @@ $(KYMA):
 GIT_COMMIT_SHA=$(shell git rev-parse --short=8 HEAD)
 GIT_COMMIT_DATE=$(shell git show -s --format=%cd --date=format:'v%Y%m%d' ${GIT_COMMIT_SHA})
 HIBERNATION_HOUR=$(shell echo $$(( ( $(shell date +%H | sed s/^0//g) + 5 ) % 24 )))
+GARDENER_CLUSTER_NAME=$(shell echo "test-${GIT_COMMIT_SHA}-${GARDENER_K8S_VERSION}" | sed 's/\.//g')
 
 ifneq (,$(GARDENER_SA_PATH))
-GARDENER_K8S_VERSION_FULL?=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud gcp -o go-template='{{range .spec.kubernetes.versions}}{{if and (eq .classification "supported") (lt .version "${GARDENER_K8S_VERSION}.a") (gt .version "${GARDENER_K8S_VERSION}")}}{{.version}}{{end}}{{end}}')
+GARDENER_K8S_VERSION_FULL=$(shell kubectl --kubeconfig=${GARDENER_SA_PATH} get cloudprofiles.core.gardener.cloud gcp -o go-template='{{range .spec.kubernetes.versions}}{{if and (eq .classification "supported") (lt .version "${GARDENER_K8S_VERSION}.a") (gt .version "${GARDENER_K8S_VERSION}")}}{{.version}}{{end}}{{end}}')
 endif
 
 # log tests are excluded for now as they are too flaky
@@ -393,10 +394,10 @@ gardener-integration-test: ## Provision gardener cluster and run integration tes
 
 .PHONY: provision-gardener
 provision-gardener: kyma ## Provision gardener cluster with latest k8s version
-	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n test-${GIT_COMMIT_SHA}-${GARDENER_K8S_VERSION} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION_FULL}\
+	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n ${GARDENER_CLUSTER_NAME} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION_FULL}\
 		--hibernation-start="00 ${HIBERNATION_HOUR} * * ?"
 
 .PHONY: deprovision-gardener
 deprovision-gardener: kyma ## Deprovision gardener cluster
-	kubectl --kubeconfig=${GARDENER_SA_PATH} annotate shoot test-${GIT_COMMIT_SHA}-${GARDENER_K8S_VERSION} confirmation.gardener.cloud/deletion=true
-	kubectl --kubeconfig=${GARDENER_SA_PATH} delete shoot test-${GIT_COMMIT_SHA} --wait=false
+	kubectl --kubeconfig=${GARDENER_SA_PATH} annotate shoot ${GARDENER_CLUSTER_NAME} confirmation.gardener.cloud/deletion=true
+	kubectl --kubeconfig=${GARDENER_SA_PATH} delete shoot ${GARDENER_CLUSTER_NAME} --wait=false


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Adjusted the gardener integration job to test on current and next k8s version

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->