### PR TITLE
chore: Simplify pprof server set up

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-logr/zapr"
@@ -123,7 +122,6 @@ var (
 	metricGatewayDynamicMemoryRequest string
 
 	enableWebhook bool
-	mutex         sync.Mutex
 )
 
 const (


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Some time ago a `PprofBindAddress` was introduced in `controller-runtime`, which allows us to spare some code. This PR makes use of this hand instead of setting up pprof manually

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->