### PR TITLE
chore: Fix env variable injection for gardener integration test

### DIFF
--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   gardener-integration-test:
     strategy:
+        fail-fast: false # if one version is not working, continue tests on other versions
         matrix:
           k8s_version: [1.27, 1.28]
     runs-on: ubuntu-latest
@@ -36,7 +37,6 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         GITHUB_OWNER: "${{ github.repository_owner }}"
         GITHUB_REPO: "telemetry-manager"
-        GARDENER_K8S_VERSION: ${{ matrix.k8s_version }}
 
     # save gardener kubeconfig to a temp file in order to pass it to the command
     - name: Save serviceaccount to file
@@ -52,6 +52,7 @@ jobs:
         GARDENER_SECRET_NAME: ${{ secrets.GARDENER_SECRET_NAME }}
         GARDENER_PROJECT: ${{ secrets.GARDENER_PROJECT }}
         GARDENER_SA_PATH: /tmp/gardener-sa.yaml
+        GARDENER_K8S_VERSION: ${{ matrix.k8s_version }}
 
     - name: Send slack message on failure
       uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117

--- a/Makefile
+++ b/Makefile
@@ -394,8 +394,7 @@ gardener-integration-test: ## Provision gardener cluster and run integration tes
 
 .PHONY: provision-gardener
 provision-gardener: kyma ## Provision gardener cluster with latest k8s version
-	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n ${GARDENER_CLUSTER_NAME} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION_FULL}\
-		--hibernation-start="00 ${HIBERNATION_HOUR} * * ?"
+	${KYMA} provision gardener gcp -c ${GARDENER_SA_PATH} -n ${GARDENER_CLUSTER_NAME} -p ${GARDENER_PROJECT} -s ${GARDENER_SECRET_NAME} -k ${GARDENER_K8S_VERSION_FULL} --hibernation-start="00 ${HIBERNATION_HOUR} * * ?"
 
 .PHONY: deprovision-gardener
 deprovision-gardener: kyma ## Deprovision gardener cluster


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The env variable for determining the k8s version was applied to the wrong github action step, this PR fixes it

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/pull/774

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->