### PR TITLE
fix: Exclude system namespaces correctly

### DIFF
--- a/internal/fluentbit/config/builder/input.go
+++ b/internal/fluentbit/config/builder/input.go
@@ -26,7 +26,7 @@ func createInputSection(pipeline *telemetryv1alpha1.LogPipeline, includePath, ex
 }
 
 func createIncludePath(pipeline *telemetryv1alpha1.LogPipeline) string {
-	var toInclude []string
+	var includePath []string
 
 	includeNamespaces := []string{"*"}
 	if len(pipeline.Spec.Input.Application.Namespaces.Include) > 0 {
@@ -40,15 +40,15 @@ func createIncludePath(pipeline *telemetryv1alpha1.LogPipeline) string {
 
 	for _, ns := range includeNamespaces {
 		for _, container := range includeContainers {
-			toInclude = append(toInclude, makeLogPath(ns, "*", container))
+			includePath = append(includePath, makeLogPath(ns, "*", container))
 		}
 	}
 
-	return strings.Join(toInclude, ",")
+	return strings.Join(includePath, ",")
 }
 
 func createExcludePath(pipeline *telemetryv1alpha1.LogPipeline) string {
-	toExclude := []string{
+	excludePath := []string{
 		makeLogPath("kyma-system", "telemetry-fluent-bit-*", "fluent-bit"),
 	}
 
@@ -58,14 +58,14 @@ func createExcludePath(pipeline *telemetryv1alpha1.LogPipeline) string {
 	}
 
 	for _, ns := range excludeNamespaces {
-		toExclude = append(toExclude, makeLogPath(ns, "*", "*"))
+		excludePath = append(excludePath, makeLogPath(ns, "*", "*"))
 	}
 
 	for _, container := range pipeline.Spec.Input.Application.Containers.Exclude {
-		toExclude = append(toExclude, makeLogPath("*", "*", container))
+		excludePath = append(excludePath, makeLogPath("*", "*", container))
 	}
 
-	return strings.Join(toExclude, ",")
+	return strings.Join(excludePath, ",")
 }
 
 func makeLogPath(namespace, pod, container string) string {

--- a/internal/fluentbit/config/builder/input.go
+++ b/internal/fluentbit/config/builder/input.go
@@ -28,16 +28,18 @@ func createInputSection(pipeline *telemetryv1alpha1.LogPipeline, includePath, ex
 func createIncludePath(pipeline *telemetryv1alpha1.LogPipeline) string {
 	var toInclude []string
 
-	if len(pipeline.Spec.Input.Application.Namespaces.Include) == 0 {
-		pipeline.Spec.Input.Application.Namespaces.Include = append(pipeline.Spec.Input.Application.Namespaces.Include, "*")
+	includeNamespaces := []string{"*"}
+	if len(pipeline.Spec.Input.Application.Namespaces.Include) > 0 {
+		includeNamespaces = pipeline.Spec.Input.Application.Namespaces.Include
 	}
 
-	if len(pipeline.Spec.Input.Application.Containers.Include) == 0 {
-		pipeline.Spec.Input.Application.Containers.Include = append(pipeline.Spec.Input.Application.Containers.Include, "*")
+	includeContainers := []string{"*"}
+	if len(pipeline.Spec.Input.Application.Containers.Include) > 0 {
+		includeContainers = pipeline.Spec.Input.Application.Containers.Include
 	}
 
-	for _, ns := range pipeline.Spec.Input.Application.Namespaces.Include {
-		for _, container := range pipeline.Spec.Input.Application.Containers.Include {
+	for _, ns := range includeNamespaces {
+		for _, container := range includeContainers {
 			toInclude = append(toInclude, makeLogPath(ns, "*", container))
 		}
 	}
@@ -50,11 +52,12 @@ func createExcludePath(pipeline *telemetryv1alpha1.LogPipeline) string {
 		makeLogPath("kyma-system", "telemetry-fluent-bit-*", "fluent-bit"),
 	}
 
-	if !pipeline.Spec.Input.Application.Namespaces.System {
-		pipeline.Spec.Input.Application.Namespaces.Exclude = append(pipeline.Spec.Input.Application.Namespaces.Exclude, namespaces.System()...)
+	excludeNamespaces := pipeline.Spec.Input.Application.Namespaces.Exclude
+	if !pipeline.Spec.Input.Application.Namespaces.System && len(pipeline.Spec.Input.Application.Namespaces.Include) == 0 && len(pipeline.Spec.Input.Application.Namespaces.Exclude) == 0 {
+		excludeNamespaces = namespaces.System()
 	}
 
-	for _, ns := range pipeline.Spec.Input.Application.Namespaces.Exclude {
+	for _, ns := range excludeNamespaces {
 		toExclude = append(toExclude, makeLogPath(ns, "*", "*"))
 	}
 

--- a/internal/fluentbit/config/builder/input_test.go
+++ b/internal/fluentbit/config/builder/input_test.go
@@ -38,22 +38,51 @@ func TestCreateInput(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestCreateInputWithIncludePath(t *testing.T) {
+func TestCreateIncludeAndExcludePath(t *testing.T) {
 	var tests = []struct {
-		pipeline *telemetryv1alpha1.LogPipeline
-		expected []string
+		name             string
+		pipeline         *telemetryv1alpha1.LogPipeline
+		expectedIncludes []string
+		expectedExcludes []string
 	}{
 		{
+			"empty",
+			&telemetryv1alpha1.LogPipeline{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-logpipeline"},
+			},
+			[]string{
+				"/var/log/containers/*_*_*-*.log",
+			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+				"/var/log/containers/*_kyma-system_*-*.log",
+				"/var/log/containers/*_kube-system_*-*.log",
+				"/var/log/containers/*_istio-system_*-*.log",
+				"/var/log/containers/*_compass-system_*-*.log",
+			},
+		},
+		{
+			"include system",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
-					Input: telemetryv1alpha1.Input{},
+					Input: telemetryv1alpha1.Input{
+						Application: telemetryv1alpha1.ApplicationInput{
+							Namespaces: telemetryv1alpha1.InputNamespaces{
+								System: true,
+							},
+						},
+					},
 				},
 			},
 			[]string{
 				"/var/log/containers/*_*_*-*.log",
 			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+			},
 		},
 		{
+			"include foo namespace",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -70,8 +99,12 @@ func TestCreateInputWithIncludePath(t *testing.T) {
 			[]string{
 				"/var/log/containers/*_foo_*-*.log",
 			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+			},
 		},
 		{
+			"include foo container",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -88,8 +121,16 @@ func TestCreateInputWithIncludePath(t *testing.T) {
 			[]string{
 				"/var/log/containers/*_*_foo-*.log",
 			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+				"/var/log/containers/*_kyma-system_*-*.log",
+				"/var/log/containers/*_kube-system_*-*.log",
+				"/var/log/containers/*_istio-system_*-*.log",
+				"/var/log/containers/*_compass-system_*-*.log",
+			},
 		},
 		{
+			"include foo namespace and bar container",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -111,8 +152,12 @@ func TestCreateInputWithIncludePath(t *testing.T) {
 			[]string{
 				"/var/log/containers/*_foo_bar-*.log",
 			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+			},
 		},
 		{
+			"include foo and bar namespace, include istio-proxy container",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -136,69 +181,13 @@ func TestCreateInputWithIncludePath(t *testing.T) {
 				"/var/log/containers/*_foo_istio-proxy-*.log",
 				"/var/log/containers/*_bar_istio-proxy-*.log",
 			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+			},
 		},
-	}
 
-	for _, test := range tests {
-		actual := strings.Split(createIncludePath(test.pipeline), ",")
-		require.Equal(t, test.expected, actual)
-	}
-}
-
-func TestCreateInputWithExcludePath(t *testing.T) {
-	var tests = []struct {
-		pipeline *telemetryv1alpha1.LogPipeline
-		expected []string
-	}{
 		{
-			&telemetryv1alpha1.LogPipeline{
-				Spec: telemetryv1alpha1.LogPipelineSpec{
-					Input: telemetryv1alpha1.Input{
-						Application: telemetryv1alpha1.ApplicationInput{
-							Namespaces: telemetryv1alpha1.InputNamespaces{
-								System: true,
-							},
-						},
-					},
-				},
-			},
-			[]string{
-				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
-			},
-		},
-		{
-			&telemetryv1alpha1.LogPipeline{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-logpipeline"},
-			},
-			[]string{
-				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
-				"/var/log/containers/*_kyma-system_*-*.log",
-				"/var/log/containers/*_kube-system_*-*.log",
-				"/var/log/containers/*_istio-system_*-*.log",
-				"/var/log/containers/*_compass-system_*-*.log",
-			},
-		},
-		{
-			&telemetryv1alpha1.LogPipeline{
-				Spec: telemetryv1alpha1.LogPipelineSpec{
-					Input: telemetryv1alpha1.Input{
-						Application: telemetryv1alpha1.ApplicationInput{
-							Namespaces: telemetryv1alpha1.InputNamespaces{
-								System: true,
-								Exclude: []string{
-									"foo",
-								},
-							},
-						},
-					},
-				},
-			},
-			[]string{
-				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
-				"/var/log/containers/*_foo_*-*.log",
-			},
-		},
-		{
+			"exclude foo namespace",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -213,15 +202,15 @@ func TestCreateInputWithExcludePath(t *testing.T) {
 				},
 			},
 			[]string{
+				"/var/log/containers/*_*_*-*.log",
+			},
+			[]string{
 				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
 				"/var/log/containers/*_foo_*-*.log",
-				"/var/log/containers/*_kyma-system_*-*.log",
-				"/var/log/containers/*_kube-system_*-*.log",
-				"/var/log/containers/*_istio-system_*-*.log",
-				"/var/log/containers/*_compass-system_*-*.log",
 			},
 		},
 		{
+			"include system, exclude foo container",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -239,11 +228,15 @@ func TestCreateInputWithExcludePath(t *testing.T) {
 				},
 			},
 			[]string{
+				"/var/log/containers/*_*_*-*.log",
+			},
+			[]string{
 				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
 				"/var/log/containers/*_*_foo-*.log",
 			},
 		},
 		{
+			"exclude foo container",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
@@ -258,6 +251,9 @@ func TestCreateInputWithExcludePath(t *testing.T) {
 				},
 			},
 			[]string{
+				"/var/log/containers/*_*_*-*.log",
+			},
+			[]string{
 				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
 				"/var/log/containers/*_kyma-system_*-*.log",
 				"/var/log/containers/*_kube-system_*-*.log",
@@ -267,12 +263,12 @@ func TestCreateInputWithExcludePath(t *testing.T) {
 			},
 		},
 		{
+			"exclude foo namespace, exclude bar container",
 			&telemetryv1alpha1.LogPipeline{
 				Spec: telemetryv1alpha1.LogPipelineSpec{
 					Input: telemetryv1alpha1.Input{
 						Application: telemetryv1alpha1.ApplicationInput{
 							Namespaces: telemetryv1alpha1.InputNamespaces{
-								System: true,
 								Exclude: []string{
 									"foo",
 								},
@@ -287,15 +283,53 @@ func TestCreateInputWithExcludePath(t *testing.T) {
 				},
 			},
 			[]string{
+				"/var/log/containers/*_*_*-*.log",
+			},
+			[]string{
 				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
 				"/var/log/containers/*_foo_*-*.log",
 				"/var/log/containers/*_*_bar-*.log",
 			},
 		},
+		{
+			"include system and foo namespaces",
+			&telemetryv1alpha1.LogPipeline{
+				Spec: telemetryv1alpha1.LogPipelineSpec{
+					Input: telemetryv1alpha1.Input{
+						Application: telemetryv1alpha1.ApplicationInput{
+							Namespaces: telemetryv1alpha1.InputNamespaces{
+								Include: []string{
+									"kyma-system",
+									"kube-system",
+									"istio-system",
+									"compass-system",
+									"foo",
+								},
+							},
+						},
+					},
+				},
+			},
+			[]string{
+				"/var/log/containers/*_kyma-system_*-*.log",
+				"/var/log/containers/*_kube-system_*-*.log",
+				"/var/log/containers/*_istio-system_*-*.log",
+				"/var/log/containers/*_compass-system_*-*.log",
+				"/var/log/containers/*_foo_*-*.log",
+			},
+			[]string{
+				"/var/log/containers/telemetry-fluent-bit-*_kyma-system_fluent-bit-*.log",
+			},
+		},
 	}
 
 	for _, test := range tests {
-		actual := strings.Split(createExcludePath(test.pipeline), ",")
-		require.Equal(t, test.expected, actual)
+		t.Run(test.name, func(t *testing.T) {
+			actualIncludes := strings.Split(createIncludePath(test.pipeline), ",")
+			require.Equal(t, test.expectedIncludes, actualIncludes, "Unexpected include paths for test: %s", test.name)
+
+			actualExcludes := strings.Split(createExcludePath(test.pipeline), ",")
+			require.Equal(t, test.expectedExcludes, actualExcludes, "Unexpected exclude paths for test: %s", test.name)
+		})
 	}
 }

--- a/test/e2e/logs_exclude_namespaces_test.go
+++ b/test/e2e/logs_exclude_namespaces_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"net/http"
 
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,7 +41,7 @@ var _ = Describe("Logs Exclude Namespace", Label("logs"), Ordered, func() {
 		logPipeline := kitk8s.NewLogPipeline(pipelineName).
 			WithSecretKeyRef(mockBackend.HostSecretRef()).
 			WithHTTPOutput().
-			WithExcludeNamespaces([]string{"kyma-system"})
+			WithExcludeNamespaces([]string{kitkyma.SystemNamespaceName})
 		objs = append(objs, logPipeline.K8sObject())
 
 		return objs
@@ -81,7 +82,7 @@ var _ = Describe("Logs Exclude Namespace", Label("logs"), Ordered, func() {
 				g.Expect(resp).To(HaveHTTPBody(
 					ContainLd(
 						SatisfyAll(
-							ContainLogRecord(WithNamespace(Equal("kube-system"))),
+							ContainLogRecord(WithNamespace(Equal(kitkyma.KubeNamespace))),
 							ContainLogRecord(WithNamespace(Equal(mockNs))),
 						)),
 				))
@@ -94,7 +95,7 @@ var _ = Describe("Logs Exclude Namespace", Label("logs"), Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(Not(ContainLd(ContainLogRecord(
-					WithNamespace(Equal("kyma-system"))))),
+					WithNamespace(Equal(kitkyma.SystemNamespaceName))))),
 				))
 			}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})

--- a/test/e2e/logs_exclude_namespaces_test.go
+++ b/test/e2e/logs_exclude_namespaces_test.go
@@ -5,13 +5,13 @@ package e2e
 import (
 	"net/http"
 
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_exclude_namespaces_test.go
+++ b/test/e2e/logs_exclude_namespaces_test.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+)
+
+var _ = Describe("Logs Exclude Namespace", Label("logs"), Ordered, func() {
+	const (
+		mockNs          = "log-exclude-namespace-mocks"
+		mockBackendName = "log-receiver-exclude-namespace"
+		logProducerName = "log-producer-exclude-namespace"
+		pipelineName    = "pipeline-exclude-namespace-test"
+	)
+	var telemetryExportURL string
+
+	makeResources := func() []client.Object {
+		var objs []client.Object
+		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
+
+		mockBackend := backend.New(mockBackendName, mockNs, backend.SignalTypeLogs)
+		mockLogProducer := loggen.New(logProducerName, mockNs)
+		objs = append(objs, mockBackend.K8sObjects()...)
+		objs = append(objs, mockLogProducer.K8sObject(kitk8s.WithLabel("app", "logging-exclude-namespace")))
+		telemetryExportURL = mockBackend.TelemetryExportURL(proxyClient)
+
+		logPipeline := kitk8s.NewLogPipeline(pipelineName).
+			WithSecretKeyRef(mockBackend.HostSecretRef()).
+			WithHTTPOutput().
+			WithExcludeNamespaces([]string{"kyma-system"})
+		objs = append(objs, logPipeline.K8sObject())
+
+		return objs
+	}
+
+	Context("Before deploying a logpipeline", func() {
+		It("Should have a healthy webhook", func() {
+			verifiers.WebhookShouldBeHealthy(ctx, k8sClient)
+		})
+	})
+
+	Context("When a logpipeline that excludes containers exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeResources()
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+		})
+
+		It("Should have a running logpipeline", func() {
+			verifiers.LogPipelineShouldBeRunning(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have a log backend running", func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: mockBackendName})
+		})
+
+		It("Should have a log producer running", func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+		})
+
+		It("Should have any logs in the backend", func() {
+			Eventually(func(g Gomega) {
+				resp, err := proxyClient.Get(telemetryExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(
+					ContainLd(
+						SatisfyAll(
+							ContainLogRecord(WithNamespace(Equal("kube-system"))),
+							ContainLogRecord(WithNamespace(Equal(mockNs))),
+						)),
+				))
+			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+
+		It("Should have no kyma-system logs in the backend", func() {
+			Consistently(func(g Gomega) {
+				resp, err := proxyClient.Get(telemetryExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(Not(ContainLd(ContainLogRecord(
+					WithNamespace(Equal("kyma-system"))))),
+				))
+			}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/logs_include_namespaces_test.go
+++ b/test/e2e/logs_include_namespaces_test.go
@@ -1,0 +1,104 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+)
+
+var _ = Describe("Logs Include Namespaces", Label("logs"), Ordered, func() {
+	const (
+		mockNs          = "log-include-namespaces-mocks"
+		systemNamespace = "kyma-system"
+		mockBackendName = "log-receiver-include-namespaces"
+		logProducerName = "log-producer-include-namespaces"
+		pipelineName    = "pipeline-include-namespaces-test"
+	)
+	var telemetryExportURL string
+
+	makeResources := func() []client.Object {
+		var objs []client.Object
+		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
+
+		mockBackend := backend.New(mockBackendName, mockNs, backend.SignalTypeLogs)
+		mockLogProducer := loggen.New(logProducerName, mockNs)
+		objs = append(objs, mockBackend.K8sObjects()...)
+		objs = append(objs, mockLogProducer.K8sObject(kitk8s.WithLabel("app", "logging-include-namespaces")))
+		telemetryExportURL = mockBackend.TelemetryExportURL(proxyClient)
+
+		logPipeline := kitk8s.NewLogPipeline(pipelineName).
+			WithSecretKeyRef(mockBackend.HostSecretRef()).
+			WithHTTPOutput().
+			WithIncludeNamespaces([]string{"kyma-system", mockNs}).
+			WithExcludeContainers([]string{logProducerName})
+		objs = append(objs, logPipeline.K8sObject())
+
+		return objs
+	}
+
+	Context("Before deploying a logpipeline", func() {
+		It("Should have a healthy webhook", func() {
+			verifiers.WebhookShouldBeHealthy(ctx, k8sClient)
+		})
+	})
+
+	Context("When a logpipeline that includes namespaces exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeResources()
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+		})
+
+		It("Should have a running logpipeline", func() {
+			verifiers.LogPipelineShouldBeRunning(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have a log backend running", func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: mockBackendName})
+		})
+
+		It("Should have a log producer running", func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+		})
+
+		It("Should have logs from expected namespaces", func() {
+			Eventually(func(g Gomega) {
+				resp, err := proxyClient.Get(telemetryExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(
+					ContainLd(
+						SatisfyAll(
+							ContainLogRecord(WithNamespace(Equal(systemNamespace))),
+							ContainLogRecord(WithNamespace(Equal(mockNs))),
+						)),
+				))
+			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+
+		It("Should have no no logs from kube-system in the backend", func() {
+			Consistently(func(g Gomega) {
+				resp, err := proxyClient.Get(telemetryExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+				g.Expect(resp).To(HaveHTTPBody(Not(ContainLd(ContainLogRecord(
+					WithNamespace(Equal("kube-system"))))),
+				))
+			}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/logs_include_namespaces_test.go
+++ b/test/e2e/logs_include_namespaces_test.go
@@ -5,13 +5,13 @@ package e2e
 import (
 	"net/http"
 
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_include_namespaces_test.go
+++ b/test/e2e/logs_include_namespaces_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Logs Include Namespaces", Label("logs"), Ordered, func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should have no no logs from kube-system in the backend", func() {
+		It("Should have no logs from kube-system in the backend", func() {
 			Consistently(func(g Gomega) {
 				resp, err := proxyClient.Get(telemetryExportURL)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/testkit/k8s/log_pipeline.go
+++ b/test/testkit/k8s/log_pipeline.go
@@ -15,6 +15,8 @@ type LogPipeline struct {
 	name              string
 	secretKeyRef      *telemetryv1alpha1.SecretKeyRef
 	systemNamespaces  bool
+	includeNamespaces []string
+	excludeNamespaces []string
 	includeContainers []string
 	excludeContainers []string
 	keepAnnotations   bool
@@ -40,6 +42,16 @@ func (p *LogPipeline) WithSecretKeyRef(secretKeyRef *telemetryv1alpha1.SecretKey
 
 func (p *LogPipeline) WithSystemNamespaces(enable bool) *LogPipeline {
 	p.systemNamespaces = enable
+	return p
+}
+
+func (p *LogPipeline) WithIncludeNamespaces(namespaces []string) *LogPipeline {
+	p.includeNamespaces = namespaces
+	return p
+}
+
+func (p *LogPipeline) WithExcludeNamespaces(namespaces []string) *LogPipeline {
+	p.excludeNamespaces = namespaces
 	return p
 }
 
@@ -154,7 +166,9 @@ func (p *LogPipeline) K8sObject() *telemetryv1alpha1.LogPipeline {
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
 					Namespaces: telemetryv1alpha1.InputNamespaces{
-						System: p.systemNamespaces,
+						System:  p.systemNamespaces,
+						Include: p.includeNamespaces,
+						Exclude: p.excludeNamespaces,
 					},
 					Containers: telemetryv1alpha1.InputContainers{
 						Include: p.includeContainers,

--- a/test/testkit/kyma/common_names.go
+++ b/test/testkit/kyma/common_names.go
@@ -7,6 +7,7 @@ import (
 const (
 	DefaultNamespaceName     = "default"
 	SystemNamespaceName      = "kyma-system"
+	KubeNamespace            = "kube-system"
 	IstioSystemNamespaceName = "istio-system"
 
 	MetricGatewayBaseName = "telemetry-metric-gateway"

--- a/test/testkit/matchers/log/log_matchers.go
+++ b/test/testkit/matchers/log/log_matchers.go
@@ -30,11 +30,6 @@ func ContainLd(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return WithLds(gomega.ContainElement(matcher))
 }
 
-// ConsistOfLds is an alias for WithLds(gomega.ConsistOf()).
-func ConsistOfLds(matcher types.GomegaMatcher) types.GomegaMatcher {
-	return WithLds(gomega.ConsistOf(matcher))
-}
-
 func WithLogRecords(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return gomega.WithTransform(func(ld plog.Logs) ([]plog.LogRecord, error) {
 		return getLogRecords(ld), nil
@@ -46,11 +41,6 @@ func ContainLogRecord(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return WithLogRecords(gomega.ContainElement(matcher))
 }
 
-// ConsistOfLogRecords is an alias for WithLogRecords(gomega.ConsistOf()).
-func ConsistOfLogRecords(matcher types.GomegaMatcher) types.GomegaMatcher {
-	return WithLogRecords(gomega.ConsistOf(matcher))
-}
-
 func WithContainerName(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return gomega.WithTransform(func(lr plog.LogRecord) string {
 		kubernetesAttrs := getKubernetesAttributes(lr)
@@ -60,6 +50,18 @@ func WithContainerName(matcher types.GomegaMatcher) types.GomegaMatcher {
 		}
 
 		return containerName.Str()
+	}, matcher)
+}
+
+func WithNamespace(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.WithTransform(func(lr plog.LogRecord) string {
+		kubernetesAttrs := getKubernetesAttributes(lr)
+		namespaceName, hasNamespaceName := kubernetesAttrs.Get("namespace_name")
+		if !hasNamespaceName || namespaceName.Type() != pcommon.ValueTypeStr {
+			return ""
+		}
+
+		return namespaceName.Str()
 	}, matcher)
 }
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Exclude system namespaces in LogPipelines only if no other includes or excludes set

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/778

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->