### PR TITLE
fix: Change manager deployment name in upgrade test

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Deploy with latest tag
       shell: bash
       run: |
-        git fetch --tags  
+        git fetch --tags
         LATEST_TAG=$(git tag --sort=-creatordate | sed -n 1p)
         echo "Using tag ${LATEST_TAG}"
         git checkout ${LATEST_TAG}
@@ -36,9 +36,9 @@ jobs:
         echo "Deploying Manager using image europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA}"
         IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} make deploy-dev
 
-    - name: Wait for operator readiness
+    - name: Wait for manager readiness
       shell: bash
-      run: kubectl -n kyma-system rollout status deployment telemetry-operator --timeout=90s
+      run: kubectl -n kyma-system rollout status deployment telemetry-manager --timeout=90s
 
     - name: Run test on latest tag
       shell: bash
@@ -64,11 +64,6 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         GITHUB_OWNER: "${{ github.repository_owner }}"
         GITHUB_REPO: "telemetry-manager"
-
-    - name: Undeploy operator deployment
-      shell: bash
-      run: | 
-        kubectl -n kyma-system scale deployment telemetry-operator --replicas 0
 
     - name: Deploy with current version
       shell: bash


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Wait for telemetry-manager instead of telemetry-operator in upgrade test

Changes refer to particular issues, PRs or documents:

- #813

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->