### PR TITLE
fix: Increase Fluent Bit Kubernetes filter buffer

### DIFF
--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -85,6 +85,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
     name                kubernetes
     match               log-pipeline.*
     annotations         off
+    buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
     kube_tag_prefix     log-pipeline.var.log.containers.

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -98,6 +98,7 @@ func TestMergeSectionsConfig(t *testing.T) {
     name                kubernetes
     match               foo.*
     annotations         on
+    buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
     kube_tag_prefix     foo.var.log.containers.
@@ -197,6 +198,7 @@ func TestMergeSectionsConfigCustomOutput(t *testing.T) {
     name                kubernetes
     match               foo.*
     annotations         on
+    buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
     kube_tag_prefix     foo.var.log.containers.

--- a/internal/fluentbit/config/builder/kubernetes_filter.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter.go
@@ -16,6 +16,7 @@ func createKubernetesFilter(pipeline *telemetryv1alpha1.LogPipeline) string {
 		AddConfigParam("kube_tag_prefix", fmt.Sprintf("%s.var.log.containers.", pipeline.Name)).
 		AddConfigParam("annotations", fmt.Sprintf("%v", fluentBitFlag(pipeline.Spec.Input.Application.KeepAnnotations))).
 		AddConfigParam("labels", fmt.Sprintf("%v", fluentBitFlag(!pipeline.Spec.Input.Application.DropLabels))).
+		AddConfigParam("buffer_size", "1MB").
 		Build()
 }
 

--- a/internal/fluentbit/config/builder/kubernetes_filter_test.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter_test.go
@@ -14,6 +14,7 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
     name                kubernetes
     match               test-logpipeline.*
     annotations         on
+    buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
     kube_tag_prefix     test-logpipeline.var.log.containers.
@@ -38,6 +39,7 @@ func TestCreateKubernetesFilterDropAll(t *testing.T) {
     name                kubernetes
     match               test-logpipeline.*
     annotations         off
+    buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
     kube_tag_prefix     test-logpipeline.var.log.containers.

--- a/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
+++ b/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
@@ -20,6 +20,7 @@
     name                kubernetes
     match               logpipeline-1.*
     annotations         off
+    buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
     kube_tag_prefix     logpipeline-1.var.log.containers.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Increase buffer size of Fluent Bit's Kubernetes filter. The previous buffer size caused missing Kubernetes metadata in situations where the buffer size was not sufficient.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/834

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->