### PR TITLE
fix: Exclude metric scraping from Istio interception

### DIFF
--- a/internal/resources/otelcollector/agent.go
+++ b/internal/resources/otelcollector/agent.go
@@ -129,9 +129,9 @@ func makeIstioTLSPodAnnotations(istioCertPath string) map[string]string {
 proxyMetadata:
   OUTPUT_CERTS: %s
 `, istioCertPath),
-		"sidecar.istio.io/userVolumeMount":              fmt.Sprintf(`[{"name": "%s", "mountPath": "%s"}]`, istioCertVolumeName, istioCertPath),
-		"traffic.sidecar.istio.io/includeOutboundPorts": strconv.Itoa(ports.OTLPGRPC),
-		"traffic.sidecar.istio.io/excludeInboundPorts":  strconv.Itoa(ports.Metrics),
-		"traffic.sidecar.istio.io/excludeOutboundPorts": strconv.Itoa(ports.IstioEnvoy),
+		"sidecar.istio.io/userVolumeMount":                 fmt.Sprintf(`[{"name": "%s", "mountPath": "%s"}]`, istioCertVolumeName, istioCertPath),
+		"traffic.sidecar.istio.io/includeOutboundPorts":    strconv.Itoa(ports.OTLPGRPC),
+		"traffic.sidecar.istio.io/excludeInboundPorts":     strconv.Itoa(ports.Metrics),
+		"traffic.sidecar.istio.io/includeOutboundIPRanges": "",
 	}
 }

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -76,7 +76,7 @@ func TestApplyAgentResources(t *testing.T) {
 		require.Equal(t, "", podAnnotations["traffic.sidecar.istio.io/includeInboundPorts"])
 		require.Equal(t, "4317", podAnnotations["traffic.sidecar.istio.io/includeOutboundPorts"])
 		require.Equal(t, "8888", podAnnotations["traffic.sidecar.istio.io/excludeInboundPorts"])
-		require.Equal(t, "15090", podAnnotations["traffic.sidecar.istio.io/excludeOutboundPorts"])
+		require.Equal(t, "", podAnnotations["traffic.sidecar.istio.io/includeOutboundIPRanges"])
 
 		//collector container
 		require.Len(t, ds.Spec.Template.Spec.Containers, 1)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Backport #830 

Changes refer to particular issues, PRs or documents:

- #824 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->