### PR TITLE
chore: Refactor status handling

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,4 +9,3 @@ images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
   newTag: main
-  newTag: v20

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -89,14 +89,14 @@ func New(condType, reason string, status metav1.ConditionStatus, generation int6
 		Type:               condType,
 		Status:             status,
 		Reason:             reason,
-		Message:            CommonMessageFor(reason, messageMap),
+		Message:            MessageFor(reason, messageMap),
 		ObservedGeneration: generation,
 	}
 }
 
-// CommonMessageFor returns a human-readable message corresponding to a given reason.
+// MessageFor returns a human-readable message corresponding to a given reason.
 // In more advanced scenarios, you may craft custom messages tailored to specific use cases.
-func CommonMessageFor(reason string, messageMap map[string]string) string {
+func MessageFor(reason string, messageMap map[string]string) string {
 	if condMessage, found := commonMessage[reason]; found {
 		return condMessage
 	}

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestCommonMessageFor(t *testing.T) {
+func TestMessageFor(t *testing.T) {
 	t.Run("should return correct message which is common to all pipelines", func(t *testing.T) {
 		message := MessageFor(ReasonReferencedSecretMissing, LogsMessage)
 		require.Equal(t, commonMessage[ReasonReferencedSecretMissing], message)

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -11,23 +11,23 @@ import (
 
 func TestCommonMessageFor(t *testing.T) {
 	t.Run("should return correct message which is common to all pipelines", func(t *testing.T) {
-		message := CommonMessageFor(ReasonReferencedSecretMissing, LogsMessage)
+		message := MessageFor(ReasonReferencedSecretMissing, LogsMessage)
 		require.Equal(t, commonMessage[ReasonReferencedSecretMissing], message)
 	})
 
 	t.Run("should return correct message which is unique to each pipeline", func(t *testing.T) {
-		logsDaemonSetNotReadyMessage := CommonMessageFor(ReasonDaemonSetNotReady, LogsMessage)
+		logsDaemonSetNotReadyMessage := MessageFor(ReasonDaemonSetNotReady, LogsMessage)
 		require.Equal(t, LogsMessage[ReasonDaemonSetNotReady], logsDaemonSetNotReadyMessage)
 
-		tracesDeploymentNotReadyMessage := CommonMessageFor(ReasonDeploymentNotReady, TracesMessage)
+		tracesDeploymentNotReadyMessage := MessageFor(ReasonDeploymentNotReady, TracesMessage)
 		require.Equal(t, TracesMessage[ReasonDeploymentNotReady], tracesDeploymentNotReadyMessage)
 
-		metricsDeploymentNotReadyMessage := CommonMessageFor(ReasonDeploymentNotReady, MetricsMessage)
+		metricsDeploymentNotReadyMessage := MessageFor(ReasonDeploymentNotReady, MetricsMessage)
 		require.Equal(t, MetricsMessage[ReasonDeploymentNotReady], metricsDeploymentNotReadyMessage)
 	})
 
 	t.Run("should return empty message for reasons which do not have a dedicated message", func(t *testing.T) {
-		metricsAgentNotRequiredMessage := CommonMessageFor(ReasonMetricAgentNotRequired, MetricsMessage)
+		metricsAgentNotRequiredMessage := MessageFor(ReasonMetricAgentNotRequired, MetricsMessage)
 		require.Equal(t, "", metricsAgentNotRequiredMessage)
 	})
 }
@@ -44,7 +44,7 @@ func TestSetPendingCondition(t *testing.T) {
 		require.Equal(t, TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, reason, pendingCond.Reason)
-		pendingCondMsg := PendingTypeDeprecationMsg + CommonMessageFor(reason, LogsMessage)
+		pendingCondMsg := PendingTypeDeprecationMsg + MessageFor(reason, LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -56,14 +56,14 @@ func TestSetPendingCondition(t *testing.T) {
 				Type:               TypePending,
 				Status:             metav1.ConditionFalse,
 				Reason:             ReasonFluentBitDSNotReady,
-				Message:            PendingTypeDeprecationMsg + CommonMessageFor(ReasonFluentBitDSNotReady, LogsMessage),
+				Message:            PendingTypeDeprecationMsg + MessageFor(ReasonFluentBitDSNotReady, LogsMessage),
 				LastTransitionTime: metav1.Now(),
 			},
 			{
 				Type:               TypeRunning,
 				Status:             metav1.ConditionTrue,
 				Reason:             ReasonFluentBitDSReady,
-				Message:            RunningTypeDeprecationMsg + CommonMessageFor(ReasonFluentBitDSReady, LogsMessage),
+				Message:            RunningTypeDeprecationMsg + MessageFor(ReasonFluentBitDSReady, LogsMessage),
 				LastTransitionTime: metav1.Now(),
 			},
 		}
@@ -80,7 +80,7 @@ func TestSetPendingCondition(t *testing.T) {
 		require.Equal(t, TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, reason, pendingCond.Reason)
-		pendingCondMsg := PendingTypeDeprecationMsg + CommonMessageFor(reason, LogsMessage)
+		pendingCondMsg := PendingTypeDeprecationMsg + MessageFor(reason, LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -94,7 +94,7 @@ func TestSetRunningCondition(t *testing.T) {
 				Type:               TypePending,
 				Status:             metav1.ConditionTrue,
 				Reason:             ReasonFluentBitDSNotReady,
-				Message:            PendingTypeDeprecationMsg + CommonMessageFor(ReasonFluentBitDSNotReady, LogsMessage),
+				Message:            PendingTypeDeprecationMsg + MessageFor(ReasonFluentBitDSNotReady, LogsMessage),
 				LastTransitionTime: metav1.Now(),
 			},
 		}
@@ -108,7 +108,7 @@ func TestSetRunningCondition(t *testing.T) {
 		require.Equal(t, TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionFalse, pendingCond.Status)
 		require.Equal(t, ReasonFluentBitDSNotReady, pendingCond.Reason)
-		pendingCondMsg := PendingTypeDeprecationMsg + CommonMessageFor(ReasonFluentBitDSNotReady, LogsMessage)
+		pendingCondMsg := PendingTypeDeprecationMsg + MessageFor(ReasonFluentBitDSNotReady, LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -118,7 +118,7 @@ func TestSetRunningCondition(t *testing.T) {
 		require.Equal(t, TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)
 		require.Equal(t, reason, runningCond.Reason)
-		runningCondMsg := RunningTypeDeprecationMsg + CommonMessageFor(reason, LogsMessage)
+		runningCondMsg := RunningTypeDeprecationMsg + MessageFor(reason, LogsMessage)
 		require.Equal(t, runningCondMsg, runningCond.Message)
 		require.Equal(t, generation, runningCond.ObservedGeneration)
 		require.NotEmpty(t, runningCond.LastTransitionTime)

--- a/internal/reconciler/logparser/status_test.go
+++ b/internal/reconciler/logparser/status_test.go
@@ -55,7 +55,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, agentHealthyCond, "could not find condition of type %s", conditions.TypeAgentHealthy)
 		require.Equal(t, metav1.ConditionFalse, agentHealthyCond.Status)
 		require.Equal(t, conditions.ReasonDaemonSetNotReady, agentHealthyCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonDaemonSetNotReady, conditions.LogsMessage), agentHealthyCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonDaemonSetNotReady, conditions.LogsMessage), agentHealthyCond.Message)
 		require.Equal(t, updatedParser.Generation, agentHealthyCond.ObservedGeneration)
 		require.NotEmpty(t, agentHealthyCond.LastTransitionTime)
 
@@ -67,7 +67,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSNotReady, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedParser.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -86,7 +86,7 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonFluentBitDSNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -116,7 +116,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, agentHealthyCond, "could not find condition of type %s", conditions.TypeAgentHealthy)
 		require.Equal(t, metav1.ConditionTrue, agentHealthyCond.Status)
 		require.Equal(t, conditions.ReasonDaemonSetReady, agentHealthyCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage), agentHealthyCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage), agentHealthyCond.Message)
 		require.Equal(t, updatedParser.Generation, agentHealthyCond.ObservedGeneration)
 		require.NotEmpty(t, agentHealthyCond.LastTransitionTime)
 
@@ -125,7 +125,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSReady, runningCond.Reason)
-		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage)
+		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage)
 		require.Equal(t, runningCondMsg, runningCond.Message)
 		require.Equal(t, updatedParser.Generation, runningCond.ObservedGeneration)
 		require.NotEmpty(t, runningCond.LastTransitionTime)
@@ -144,28 +144,28 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypeAgentHealthy,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonDaemonSetReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeConfigurationGenerated,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonConfigurationGenerated,
-						Message:            conditions.CommonMessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionFalse,
 						Reason:             conditions.ReasonFluentBitDSNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeRunning,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonFluentBitDSReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -199,7 +199,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSNotReady, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedParser.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)

--- a/internal/reconciler/logpipeline/status_test.go
+++ b/internal/reconciler/logpipeline/status_test.go
@@ -61,7 +61,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, agentHealthyCond, "could not find condition of type %s", conditions.TypeAgentHealthy)
 		require.Equal(t, metav1.ConditionFalse, agentHealthyCond.Status)
 		require.Equal(t, conditions.ReasonDaemonSetNotReady, agentHealthyCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonDaemonSetNotReady, conditions.LogsMessage), agentHealthyCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonDaemonSetNotReady, conditions.LogsMessage), agentHealthyCond.Message)
 		require.Equal(t, updatedPipeline.Generation, agentHealthyCond.ObservedGeneration)
 		require.NotEmpty(t, agentHealthyCond.LastTransitionTime)
 
@@ -73,7 +73,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSNotReady, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -116,7 +116,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, agentHealthyCond, "could not find condition of type %s", conditions.TypeAgentHealthy)
 		require.Equal(t, metav1.ConditionTrue, agentHealthyCond.Status)
 		require.Equal(t, conditions.ReasonDaemonSetReady, agentHealthyCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage), agentHealthyCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage), agentHealthyCond.Message)
 		require.Equal(t, updatedPipeline.Generation, agentHealthyCond.ObservedGeneration)
 		require.NotEmpty(t, agentHealthyCond.LastTransitionTime)
 
@@ -125,7 +125,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSReady, runningCond.Reason)
-		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage)
+		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage)
 		require.Equal(t, runningCondMsg, runningCond.Message)
 		require.Equal(t, updatedPipeline.Generation, runningCond.ObservedGeneration)
 		require.NotEmpty(t, runningCond.LastTransitionTime)
@@ -174,7 +174,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, configurationGeneratedCond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionFalse, configurationGeneratedCond.Status)
 		require.Equal(t, conditions.ReasonReferencedSecretMissing, configurationGeneratedCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonReferencedSecretMissing, conditions.LogsMessage), configurationGeneratedCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonReferencedSecretMissing, conditions.LogsMessage), configurationGeneratedCond.Message)
 		require.Equal(t, updatedPipeline.Generation, configurationGeneratedCond.ObservedGeneration)
 		require.NotEmpty(t, configurationGeneratedCond.LastTransitionTime)
 
@@ -186,7 +186,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonReferencedSecretMissing, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonReferencedSecretMissing, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonReferencedSecretMissing, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -243,7 +243,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, configurationGeneratedCond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionTrue, configurationGeneratedCond.Status)
 		require.Equal(t, conditions.ReasonConfigurationGenerated, configurationGeneratedCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage), configurationGeneratedCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage), configurationGeneratedCond.Message)
 		require.Equal(t, updatedPipeline.Generation, configurationGeneratedCond.ObservedGeneration)
 		require.NotEmpty(t, configurationGeneratedCond.LastTransitionTime)
 
@@ -252,7 +252,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSReady, runningCond.Reason)
-		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage)
+		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage)
 		require.Equal(t, runningCondMsg, runningCond.Message)
 		require.Equal(t, updatedPipeline.Generation, runningCond.ObservedGeneration)
 		require.NotEmpty(t, runningCond.LastTransitionTime)
@@ -295,7 +295,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, configurationGeneratedCond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionFalse, configurationGeneratedCond.Status)
 		require.Equal(t, conditions.ReasonUnsupportedLokiOutput, configurationGeneratedCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonUnsupportedLokiOutput, conditions.LogsMessage), configurationGeneratedCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonUnsupportedLokiOutput, conditions.LogsMessage), configurationGeneratedCond.Message)
 		require.Equal(t, updatedPipeline.Generation, configurationGeneratedCond.ObservedGeneration)
 		require.NotEmpty(t, configurationGeneratedCond.LastTransitionTime)
 
@@ -307,7 +307,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonUnsupportedLokiOutput, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonUnsupportedLokiOutput, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonUnsupportedLokiOutput, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -326,28 +326,28 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypeAgentHealthy,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonDaemonSetReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeConfigurationGenerated,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonConfigurationGenerated,
-						Message:            conditions.CommonMessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionFalse,
 						Reason:             conditions.ReasonFluentBitDSNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeRunning,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonFluentBitDSReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -400,7 +400,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonFluentBitDSNotReady, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -419,28 +419,28 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypeAgentHealthy,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonDaemonSetReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeConfigurationGenerated,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonConfigurationGenerated,
-						Message:            conditions.CommonMessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionFalse,
 						Reason:             conditions.ReasonFluentBitDSNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeRunning,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonFluentBitDSReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -485,7 +485,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonReferencedSecretMissing, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonReferencedSecretMissing, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonReferencedSecretMissing, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -504,28 +504,28 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypeAgentHealthy,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonDaemonSetReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonDaemonSetReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeConfigurationGenerated,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonConfigurationGenerated,
-						Message:            conditions.CommonMessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonConfigurationGenerated, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionFalse,
 						Reason:             conditions.ReasonFluentBitDSNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeRunning,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonFluentBitDSReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
+						Message:            conditions.MessageFor(conditions.ReasonFluentBitDSReady, conditions.LogsMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -564,7 +564,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonUnsupportedLokiOutput, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonUnsupportedLokiOutput, conditions.LogsMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonUnsupportedLokiOutput, conditions.LogsMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)

--- a/internal/reconciler/telemetry/log_components_checker.go
+++ b/internal/reconciler/telemetry/log_components_checker.go
@@ -30,8 +30,6 @@ func (l *logComponentsChecker) Check(ctx context.Context, telemetryInDeletion bo
 		return &metav1.Condition{}, fmt.Errorf("failed to get list of LogParsers: %w", err)
 	}
 
-	// Remove "Running" and "Pending" conditions, since the Telemetry status shouldn't depend on these deprecated conditions
-	l.removePendingAndRunningConditions(logPipelines.Items)
 	reason := l.determineReason(logPipelines.Items, logParsers.Items, telemetryInDeletion)
 	status := l.determineConditionStatus(reason)
 	message := l.createMessageForReason(logPipelines.Items, logParsers.Items, reason)
@@ -44,13 +42,6 @@ func (l *logComponentsChecker) Check(ctx context.Context, telemetryInDeletion bo
 		Reason:  reasonWithPrefix,
 		Message: message,
 	}, nil
-}
-
-func (l *logComponentsChecker) removePendingAndRunningConditions(pipelines []telemetryv1alpha1.LogPipeline) {
-	for i := range pipelines {
-		meta.RemoveStatusCondition(&pipelines[i].Status.Conditions, conditions.TypePending)
-		meta.RemoveStatusCondition(&pipelines[i].Status.Conditions, conditions.TypeRunning)
-	}
 }
 
 func (l *logComponentsChecker) determineReason(pipelines []telemetryv1alpha1.LogPipeline, parsers []telemetryv1alpha1.LogParser, telemetryInDeletion bool) string {

--- a/internal/reconciler/telemetry/log_components_checker.go
+++ b/internal/reconciler/telemetry/log_components_checker.go
@@ -95,7 +95,7 @@ func (l *logComponentsChecker) determineConditionStatus(reason string) metav1.Co
 
 func (l *logComponentsChecker) createMessageForReason(pipelines []telemetryv1alpha1.LogPipeline, parsers []telemetryv1alpha1.LogParser, reason string) string {
 	if reason != conditions.ReasonResourceBlocksDeletion {
-		return conditions.CommonMessageFor(reason, conditions.LogsMessage)
+		return conditions.MessageFor(reason, conditions.LogsMessage)
 	}
 
 	return generateDeletionBlockedMessage(blockingResources{

--- a/internal/reconciler/telemetry/metric_components_checker.go
+++ b/internal/reconciler/telemetry/metric_components_checker.go
@@ -81,7 +81,7 @@ func (m *metricComponentsChecker) determineConditionStatus(reason string) metav1
 
 func (m *metricComponentsChecker) createMessageForReason(pipelines []telemetryv1alpha1.MetricPipeline, reason string) string {
 	if reason != conditions.ReasonResourceBlocksDeletion {
-		return conditions.CommonMessageFor(reason, conditions.MetricsMessage)
+		return conditions.MessageFor(reason, conditions.MetricsMessage)
 	}
 
 	return generateDeletionBlockedMessage(blockingResources{

--- a/internal/reconciler/telemetry/trace_components_checker.go
+++ b/internal/reconciler/telemetry/trace_components_checker.go
@@ -90,7 +90,7 @@ func (t *traceComponentsChecker) determineConditionStatus(reason string) metav1.
 
 func (t *traceComponentsChecker) createMessageForReason(pipelines []telemetryv1alpha1.TracePipeline, reason string) string {
 	if reason != conditions.ReasonResourceBlocksDeletion {
-		return conditions.CommonMessageFor(reason, conditions.TracesMessage)
+		return conditions.MessageFor(reason, conditions.TracesMessage)
 
 	}
 

--- a/internal/reconciler/telemetry/trace_components_checker.go
+++ b/internal/reconciler/telemetry/trace_components_checker.go
@@ -24,8 +24,6 @@ func (t *traceComponentsChecker) Check(ctx context.Context, telemetryInDeletion 
 		return &metav1.Condition{}, fmt.Errorf("failed to get list of TracePipelines: %w", err)
 	}
 
-	// Remove "Running" and "Pending" conditions, since the Telemetry status shouldn't depend on these deprecated conditions
-	t.removePendingAndRunningConditions(tracePipelines.Items)
 	reason := t.determineReason(tracePipelines.Items, telemetryInDeletion)
 	status := t.determineConditionStatus(reason)
 	message := t.createMessageForReason(tracePipelines.Items, reason)
@@ -39,13 +37,6 @@ func (t *traceComponentsChecker) Check(ctx context.Context, telemetryInDeletion 
 		Message: message,
 	}, nil
 
-}
-
-func (t *traceComponentsChecker) removePendingAndRunningConditions(pipelines []telemetryv1alpha1.TracePipeline) {
-	for i := range pipelines {
-		meta.RemoveStatusCondition(&pipelines[i].Status.Conditions, conditions.TypePending)
-		meta.RemoveStatusCondition(&pipelines[i].Status.Conditions, conditions.TypeRunning)
-	}
 }
 
 func (t *traceComponentsChecker) determineReason(pipelines []telemetryv1alpha1.TracePipeline, telemetryInDeletion bool) string {

--- a/internal/reconciler/tracepipeline/status_test.go
+++ b/internal/reconciler/tracepipeline/status_test.go
@@ -61,7 +61,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, gatewayHealthyCond, "could not find condition of type %s", conditions.TypeGatewayHealthy)
 		require.Equal(t, metav1.ConditionFalse, gatewayHealthyCond.Status)
 		require.Equal(t, conditions.ReasonDeploymentNotReady, gatewayHealthyCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonDeploymentNotReady, conditions.TracesMessage), gatewayHealthyCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonDeploymentNotReady, conditions.TracesMessage), gatewayHealthyCond.Message)
 		require.Equal(t, updatedPipeline.Generation, gatewayHealthyCond.ObservedGeneration)
 		require.NotEmpty(t, gatewayHealthyCond.LastTransitionTime)
 
@@ -73,7 +73,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonTraceGatewayDeploymentNotReady, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -115,7 +115,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, gatewayHealthyCond, "could not find condition of type %s", conditions.TypeGatewayHealthy)
 		require.Equal(t, metav1.ConditionTrue, gatewayHealthyCond.Status)
 		require.Equal(t, conditions.ReasonDeploymentReady, gatewayHealthyCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonDeploymentReady, conditions.TracesMessage), gatewayHealthyCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonDeploymentReady, conditions.TracesMessage), gatewayHealthyCond.Message)
 		require.Equal(t, updatedPipeline.Generation, gatewayHealthyCond.ObservedGeneration)
 		require.NotEmpty(t, gatewayHealthyCond.LastTransitionTime)
 
@@ -124,7 +124,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)
 		require.Equal(t, conditions.ReasonTraceGatewayDeploymentReady, runningCond.Reason)
-		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage)
+		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage)
 		require.Equal(t, runningCondMsg, runningCond.Message)
 		require.Equal(t, updatedPipeline.Generation, runningCond.ObservedGeneration)
 		require.NotEmpty(t, runningCond.LastTransitionTime)
@@ -143,14 +143,14 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionFalse,
 						Reason:             conditions.ReasonTraceGatewayDeploymentNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage),
+						Message:            conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeRunning,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonTraceGatewayDeploymentReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage),
+						Message:            conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -193,7 +193,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, configurationGeneratedCond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionFalse, configurationGeneratedCond.Status)
 		require.Equal(t, conditions.ReasonReferencedSecretMissing, configurationGeneratedCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonReferencedSecretMissing, conditions.TracesMessage), configurationGeneratedCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonReferencedSecretMissing, conditions.TracesMessage), configurationGeneratedCond.Message)
 		require.Equal(t, updatedPipeline.Generation, configurationGeneratedCond.ObservedGeneration)
 		require.NotEmpty(t, configurationGeneratedCond.LastTransitionTime)
 
@@ -205,7 +205,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonReferencedSecretMissing, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonReferencedSecretMissing, conditions.TracesMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonReferencedSecretMissing, conditions.TracesMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -264,7 +264,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, configurationGeneratedCond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionTrue, configurationGeneratedCond.Status)
 		require.Equal(t, conditions.ReasonConfigurationGenerated, configurationGeneratedCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonConfigurationGenerated, conditions.TracesMessage), configurationGeneratedCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonConfigurationGenerated, conditions.TracesMessage), configurationGeneratedCond.Message)
 		require.Equal(t, updatedPipeline.Generation, configurationGeneratedCond.ObservedGeneration)
 		require.NotEmpty(t, configurationGeneratedCond.LastTransitionTime)
 
@@ -273,7 +273,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)
 		require.Equal(t, conditions.ReasonTraceGatewayDeploymentReady, runningCond.Reason)
-		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage)
+		runningCondMsg := conditions.RunningTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage)
 		require.Equal(t, runningCondMsg, runningCond.Message)
 		require.Equal(t, updatedPipeline.Generation, runningCond.ObservedGeneration)
 		require.NotEmpty(t, runningCond.LastTransitionTime)
@@ -315,7 +315,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotNil(t, configurationGeneratedCond, "could not find condition of type %s", conditions.TypeConfigurationGenerated)
 		require.Equal(t, metav1.ConditionFalse, configurationGeneratedCond.Status)
 		require.Equal(t, conditions.ReasonMaxPipelinesExceeded, configurationGeneratedCond.Reason)
-		require.Equal(t, conditions.CommonMessageFor(conditions.ReasonMaxPipelinesExceeded, conditions.TracesMessage), configurationGeneratedCond.Message)
+		require.Equal(t, conditions.MessageFor(conditions.ReasonMaxPipelinesExceeded, conditions.TracesMessage), configurationGeneratedCond.Message)
 		require.Equal(t, updatedPipeline.Generation, configurationGeneratedCond.ObservedGeneration)
 		require.NotEmpty(t, configurationGeneratedCond.LastTransitionTime)
 
@@ -327,7 +327,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonMaxPipelinesExceeded, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonMaxPipelinesExceeded, conditions.TracesMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonMaxPipelinesExceeded, conditions.TracesMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)
@@ -352,28 +352,28 @@ func TestUpdateStatus(t *testing.T) {
 						Type:               conditions.TypeGatewayHealthy,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonDeploymentReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonDeploymentReady, conditions.TracesMessage),
+						Message:            conditions.MessageFor(conditions.ReasonDeploymentReady, conditions.TracesMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeConfigurationGenerated,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.TypeConfigurationGenerated,
-						Message:            conditions.CommonMessageFor(conditions.TypeConfigurationGenerated, conditions.TracesMessage),
+						Message:            conditions.MessageFor(conditions.TypeConfigurationGenerated, conditions.TracesMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypePending,
 						Status:             metav1.ConditionFalse,
 						Reason:             conditions.ReasonTraceGatewayDeploymentNotReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage),
+						Message:            conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 					{
 						Type:               conditions.TypeRunning,
 						Status:             metav1.ConditionTrue,
 						Reason:             conditions.ReasonTraceGatewayDeploymentReady,
-						Message:            conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage),
+						Message:            conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentReady, conditions.TracesMessage),
 						LastTransitionTime: metav1.Now(),
 					},
 				},
@@ -405,7 +405,7 @@ func TestUpdateStatus(t *testing.T) {
 		require.Equal(t, conditions.TypePending, pendingCond.Type)
 		require.Equal(t, metav1.ConditionTrue, pendingCond.Status)
 		require.Equal(t, conditions.ReasonTraceGatewayDeploymentNotReady, pendingCond.Reason)
-		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.CommonMessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage)
 		require.Equal(t, pendingCondMsg, pendingCond.Message)
 		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
 		require.NotEmpty(t, pendingCond.LastTransitionTime)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

Tackling the suggestions from the comments in #833
- Rename `CommonMessageFor` function to `MessageFor` in order to have a better reflection of its new logic
- Remove `removePendingAndRunningConditions` function from both `traceComponentsChecker` and `logComponentsChecker`. The deprecated conditions (`Running` and `Pending`) are already ignored in the `firstUnhealthyPipelineReason` function
- Remove extra `newTag` field in manager kustomization

Changes refer to particular issues, PRs or documents:

- #805 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->