### PR TITLE
feat: Add cpu.usage metrics and disable cpu.utilization metrics

### DIFF
--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -21,25 +21,25 @@ type Receivers struct {
 }
 
 type KubeletStatsReceiver struct {
-	CollectionInterval string            `yaml:"collection_interval"`
-	AuthType           string            `yaml:"auth_type"`
-	Endpoint           string            `yaml:"endpoint"`
-	InsecureSkipVerify bool              `yaml:"insecure_skip_verify"`
-	MetricGroups       []MetricGroupType `yaml:"metric_groups"`
-	Metrics            MetricsConfig     `yaml:"metrics"`
+	CollectionInterval string               `yaml:"collection_interval"`
+	AuthType           string               `yaml:"auth_type"`
+	Endpoint           string               `yaml:"endpoint"`
+	InsecureSkipVerify bool                 `yaml:"insecure_skip_verify"`
+	MetricGroups       []MetricGroupType    `yaml:"metric_groups"`
+	Metrics            KubeletMetricsConfig `yaml:"metrics"`
 }
 
-type MetricConfig struct {
+type KubeletMetricConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type MetricsConfig struct {
-	ContainerCPUUsage       MetricConfig `yaml:"container.cpu.usage"`
-	ContainerCPUUtilization MetricConfig `yaml:"container.cpu.utilization"`
-	K8sNodeCPUUsage         MetricConfig `yaml:"k8s.node.cpu.usage"`
-	K8sNodeCPUUtilization   MetricConfig `yaml:"k8s.node.cpu.utilization"`
-	K8sPodCPUUsage          MetricConfig `yaml:"k8s.pod.cpu.usage"`
-	K8sPodCPUUtilization    MetricConfig `yaml:"k8s.pod.cpu.utilization"`
+type KubeletMetricsConfig struct {
+	ContainerCPUUsage       KubeletMetricConfig `yaml:"container.cpu.usage"`
+	ContainerCPUUtilization KubeletMetricConfig `yaml:"container.cpu.utilization"`
+	K8sNodeCPUUsage         KubeletMetricConfig `yaml:"k8s.node.cpu.usage"`
+	K8sNodeCPUUtilization   KubeletMetricConfig `yaml:"k8s.node.cpu.utilization"`
+	K8sPodCPUUsage          KubeletMetricConfig `yaml:"k8s.pod.cpu.usage"`
+	K8sPodCPUUtilization    KubeletMetricConfig `yaml:"k8s.pod.cpu.utilization"`
 }
 
 type MetricGroupType string

--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -26,6 +26,20 @@ type KubeletStatsReceiver struct {
 	Endpoint           string            `yaml:"endpoint"`
 	InsecureSkipVerify bool              `yaml:"insecure_skip_verify"`
 	MetricGroups       []MetricGroupType `yaml:"metric_groups"`
+	Metrics            MetricsConfig     `yaml:"metrics"`
+}
+
+type MetricConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type MetricsConfig struct {
+	ContainerCPUUsage       MetricConfig `yaml:"container.cpu.usage"`
+	ContainerCPUUtilization MetricConfig `yaml:"container.cpu.utilization"`
+	K8sNodeCPUUsage         MetricConfig `yaml:"k8s.node.cpu.usage"`
+	K8sNodeCPUUtilization   MetricConfig `yaml:"k8s.node.cpu.utilization"`
+	K8sPodCPUUsage          MetricConfig `yaml:"k8s.pod.cpu.usage"`
+	K8sPodCPUUtilization    MetricConfig `yaml:"k8s.pod.cpu.utilization"`
 }
 
 type MetricGroupType string

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -47,13 +47,13 @@ func makeKubeletStatsConfig() *KubeletStatsReceiver {
 		InsecureSkipVerify: true,
 		Endpoint:           fmt.Sprintf("https://${env:%s}:%d", config.EnvVarCurrentNodeName, portKubelet),
 		MetricGroups:       []MetricGroupType{MetricGroupTypeContainer, MetricGroupTypePod},
-		Metrics: MetricsConfig{
-			ContainerCPUUsage:       MetricConfig{Enabled: true},
-			ContainerCPUUtilization: MetricConfig{Enabled: false},
-			K8sNodeCPUUsage:         MetricConfig{Enabled: true},
-			K8sNodeCPUUtilization:   MetricConfig{Enabled: false},
-			K8sPodCPUUsage:          MetricConfig{Enabled: true},
-			K8sPodCPUUtilization:    MetricConfig{Enabled: false},
+		Metrics: KubeletMetricsConfig{
+			ContainerCPUUsage:       KubeletMetricConfig{Enabled: true},
+			ContainerCPUUtilization: KubeletMetricConfig{Enabled: false},
+			K8sNodeCPUUsage:         KubeletMetricConfig{Enabled: true},
+			K8sNodeCPUUtilization:   KubeletMetricConfig{Enabled: false},
+			K8sPodCPUUsage:          KubeletMetricConfig{Enabled: true},
+			K8sPodCPUUtilization:    KubeletMetricConfig{Enabled: false},
 		},
 	}
 }

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -47,6 +47,14 @@ func makeKubeletStatsConfig() *KubeletStatsReceiver {
 		InsecureSkipVerify: true,
 		Endpoint:           fmt.Sprintf("https://${env:%s}:%d", config.EnvVarCurrentNodeName, portKubelet),
 		MetricGroups:       []MetricGroupType{MetricGroupTypeContainer, MetricGroupTypePod},
+		Metrics: MetricsConfig{
+			ContainerCPUUsage:       MetricConfig{Enabled: true},
+			ContainerCPUUtilization: MetricConfig{Enabled: false},
+			K8sNodeCPUUsage:         MetricConfig{Enabled: true},
+			K8sNodeCPUUtilization:   MetricConfig{Enabled: false},
+			K8sPodCPUUsage:          MetricConfig{Enabled: true},
+			K8sPodCPUUtilization:    MetricConfig{Enabled: false},
+		},
 	}
 }
 

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_active.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_active.yaml
@@ -52,6 +52,19 @@ receivers:
         metric_groups:
             - container
             - pod
+        metrics:
+            container.cpu.usage:
+                enabled: true
+            container.cpu.utilization:
+                enabled: false
+            k8s.node.cpu.usage:
+                enabled: true
+            k8s.node.cpu.utilization:
+                enabled: false
+            k8s.pod.cpu.usage:
+                enabled: true
+            k8s.pod.cpu.utilization:
+                enabled: false
     prometheus/app-pods:
         config:
             scrape_configs:

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_active.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_active.yaml
@@ -52,6 +52,19 @@ receivers:
         metric_groups:
             - container
             - pod
+        metrics:
+            container.cpu.usage:
+                enabled: true
+            container.cpu.utilization:
+                enabled: false
+            k8s.node.cpu.usage:
+                enabled: true
+            k8s.node.cpu.utilization:
+                enabled: false
+            k8s.pod.cpu.usage:
+                enabled: true
+            k8s.pod.cpu.utilization:
+                enabled: false
     prometheus/app-pods:
         config:
             scrape_configs:

--- a/test/testkit/otel/kubeletstats/metrics.go
+++ b/test/testkit/otel/kubeletstats/metrics.go
@@ -3,7 +3,7 @@ package kubeletstats
 var (
 	MetricNames = []string{
 		"container.cpu.time",
-		"container.cpu.utilization",
+		"container.cpu.usage",
 		"container.filesystem.available",
 		"container.filesystem.capacity",
 		"container.filesystem.usage",
@@ -14,7 +14,7 @@ var (
 		"container.memory.usage",
 		"container.memory.working_set",
 		"k8s.pod.cpu.time",
-		"k8s.pod.cpu.utilization",
+		"k8s.pod.cpu.usage",
 		"k8s.pod.filesystem.available",
 		"k8s.pod.filesystem.capacity",
 		"k8s.pod.filesystem.usage",


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add configuration capabilities for kubeletstatreceiver to enable or disable metrics
- Disable deprecated *.cpu.utilization metrics
- Enable *.cpu.usage metrics
- Update unit and e2e test accordingly new configuration changes  

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/838

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->