### PR TITLE
fix: Get the Ginkgo path properly

### DIFF
--- a/hack/gardener-integration-test.sh
+++ b/hack/gardener-integration-test.sh
@@ -15,6 +15,7 @@ IMG="europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE
 function run-tests-with-git-image () {
     kubectl create namespace kyma-system
     make ginkgo
+    make deploy
     hack/deploy-istio.sh
     ${GINKGO} run --tags istio test/integration/istio
 }

--- a/hack/gardener-integration-test.sh
+++ b/hack/gardener-integration-test.sh
@@ -10,7 +10,7 @@ readonly LOCALBIN=${LOCALBIN:-$(pwd)/bin}
 readonly GINKGO=${GINKGO:-$LOCALBIN/ginkgo}
 GIT_COMMIT_SHA=$(git rev-parse --short=8 HEAD)
 GIT_COMMIT_DATE=$(git show -s --format=%cd --date=format:'v%Y%m%d' ${GIT_COMMIT_SHA})
-IMG="europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} make deploy-dev"
+IMG="europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA}"
 
 function run-tests-with-git-image () {
     kubectl create namespace kyma-system

--- a/hack/gardener-integration-test.sh
+++ b/hack/gardener-integration-test.sh
@@ -7,7 +7,7 @@ set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being masked
 
 readonly LOCALBIN=${LOCALBIN:-$(pwd)/bin}
-readonly GINKGO=${GINKGO:-$(LOCALBIN)/ginkgo}
+readonly GINKGO=${GINKGO:-$LOCALBIN/ginkgo}
 GIT_COMMIT_SHA=$(git rev-parse --short=8 HEAD)
 GIT_COMMIT_DATE=$(git show -s --format=%cd --date=format:'v%Y%m%d' ${GIT_COMMIT_SHA})
 IMG="europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} make deploy-dev"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The ginkgo path is not set so branch integration job fails
```
hack/gardener-integration-test.sh: line 19: /ginkgo: No such file or directory
```

- Also fix the image name

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->