### PR TITLE
fix: Bug fix manager initialization error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -336,15 +336,15 @@ func main() {
 		},
 	})
 
-	overridesHandler = overrides.New(mgr.GetClient(), atomicLevel, overrides.HandlerConfig{
-		ConfigMapName: types.NamespacedName{Name: overridesConfigMapName, Namespace: telemetryNamespace},
-		ConfigMapKey:  overridesConfigMapKey,
-	})
-
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")
 		os.Exit(1)
 	}
+
+	overridesHandler = overrides.New(mgr.GetClient(), atomicLevel, overrides.HandlerConfig{
+		ConfigMapName: types.NamespacedName{Name: overridesConfigMapName, Namespace: telemetryNamespace},
+		ConfigMapKey:  overridesConfigMapKey,
+	})
 
 	enableLoggingController(mgr)
 	enableTracingController(mgr)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Manager initialization error handling happened after accessing the manager instance, in case of any initialization error the manger instance will be nil

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->