### PR TITLE
feat: Add scrape config for self-monitor

### DIFF
--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -146,12 +146,12 @@ func (r *Reconciler) reconcileSelfMonitor(ctx context.Context, telemetry operato
 	}
 
 	scrapeNamespace := r.config.SelfMonitor.Config.Namespace
-	selfMonConfig := config.MakeConfig(scrapeNamespace)
-	selfMonitorConfigYaml, err := yaml.Marshal(selfMonConfig)
+	selfMonitorConfig := config.MakeConfig(scrapeNamespace)
+	selfMonitorConfigYAML, err := yaml.Marshal(selfMonitorConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal selfmonitor config: %w", err)
 	}
-	r.config.SelfMonitor.Config.SelfMonitorConfig = string(selfMonitorConfigYaml)
+	r.config.SelfMonitor.Config.SelfMonitorConfig = string(selfMonitorConfigYAML)
 
 	if err := selfmonitor.ApplyResources(ctx,
 		k8sutils.NewOwnerReferenceSetter(r.Client, &telemetry),

--- a/internal/resources/otelcollector/agent.go
+++ b/internal/resources/otelcollector/agent.go
@@ -27,7 +27,7 @@ const istioCertVolumeName = "istio-certs"
 func ApplyAgentResources(ctx context.Context, c client.Client, cfg *AgentConfig) error {
 	name := types.NamespacedName{Namespace: cfg.Namespace, Name: cfg.BaseName}
 
-	if err := applyCommonResources(ctx, c, name, makeAgentClusterRole(name), cfg.allowedPorts); err != nil {
+	if err := applyCommonResources(ctx, c, name, makeAgentClusterRole(name), cfg.allowedPorts, cfg.SelfMonitorLabel); err != nil {
 		return fmt.Errorf("failed to create common resource: %w", err)
 	}
 

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -232,3 +232,56 @@ func TestApplyAgentResources(t *testing.T) {
 		}, svc.Spec.Ports[0])
 	})
 }
+
+func TestApplyAgentResources_WithSelfMonEnabled(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientBuilder().Build()
+	namespace := "my-namespace"
+	name := "my-agent"
+	cfg := "dummy otel collector config"
+
+	agentConfig := &AgentConfig{
+		allowedPorts: []int32{5555, 6666},
+		Config: Config{
+			BaseName:         name,
+			Namespace:        namespace,
+			CollectorConfig:  cfg,
+			SelfMonitorLabel: true,
+		},
+	}
+
+	err := ApplyAgentResources(ctx, client, agentConfig)
+	require.NoError(t, err)
+
+	t.Run("should create metrics service", func(t *testing.T) {
+		var svcs corev1.ServiceList
+		require.NoError(t, client.List(ctx, &svcs))
+		require.Len(t, svcs.Items, 1)
+
+		svc := svcs.Items[0]
+		require.NotNil(t, svc)
+		require.Equal(t, name+"-metrics", svc.Name)
+		require.Equal(t, namespace, svc.Namespace)
+		require.Equal(t, map[string]string{
+			"app.kubernetes.io/name":                 name,
+			"telemetry.kyma-project.io/self-monitor": "enabled",
+		}, svc.Labels)
+		require.Equal(t, map[string]string{
+			"app.kubernetes.io/name":                 name,
+			"telemetry.kyma-project.io/self-monitor": "enabled",
+		}, svc.Spec.Selector)
+		require.Equal(t, map[string]string{
+			"prometheus.io/port":   "8888",
+			"prometheus.io/scheme": "http",
+			"prometheus.io/scrape": "true",
+		}, svc.Annotations)
+		require.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+		require.Len(t, svc.Spec.Ports, 1)
+		require.Equal(t, corev1.ServicePort{
+			Name:       "http-metrics",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       8888,
+			TargetPort: intstr.FromInt32(8888),
+		}, svc.Spec.Ports[0])
+	})
+}

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -267,8 +267,7 @@ func TestApplyAgentResources_WithSelfMonEnabled(t *testing.T) {
 			"telemetry.kyma-project.io/self-monitor": "enabled",
 		}, svc.Labels)
 		require.Equal(t, map[string]string{
-			"app.kubernetes.io/name":                 name,
-			"telemetry.kyma-project.io/self-monitor": "enabled",
+			"app.kubernetes.io/name": name,
 		}, svc.Spec.Selector)
 		require.Equal(t, map[string]string{
 			"prometheus.io/port":   "8888",

--- a/internal/resources/otelcollector/config.go
+++ b/internal/resources/otelcollector/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	Namespace        string
 	CollectorConfig  string
 	CollectorEnvVars map[string][]byte
+	SelfMonitorLabel bool
 }
 
 type GatewayConfig struct {

--- a/internal/resources/otelcollector/core.go
+++ b/internal/resources/otelcollector/core.go
@@ -3,6 +3,7 @@ package otelcollector
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -103,6 +104,8 @@ func makeSecret(name types.NamespacedName, secretData map[string][]byte) *corev1
 
 func makeMetricsService(name types.NamespacedName, addSelfMonLabel bool) *corev1.Service {
 	labels := defaultLabels(name.Name)
+	selectorLabels := make(map[string]string)
+	maps.Copy(selectorLabels, labels)
 
 	if addSelfMonLabel {
 		labels["telemetry.kyma-project.io/self-monitor"] = "enabled"
@@ -128,7 +131,7 @@ func makeMetricsService(name types.NamespacedName, addSelfMonLabel bool) *corev1
 					TargetPort: intstr.FromInt32(ports.Metrics),
 				},
 			},
-			Selector: labels,
+			Selector: selectorLabels,
 			Type:     corev1.ServiceTypeClusterIP,
 		},
 	}

--- a/internal/resources/otelcollector/gateway.go
+++ b/internal/resources/otelcollector/gateway.go
@@ -28,7 +28,7 @@ import (
 func ApplyGatewayResources(ctx context.Context, c client.Client, cfg *GatewayConfig) error {
 	name := types.NamespacedName{Namespace: cfg.Namespace, Name: cfg.BaseName}
 
-	if err := applyCommonResources(ctx, c, name, makeGatewayClusterRole(name), cfg.allowedPorts); err != nil {
+	if err := applyCommonResources(ctx, c, name, makeGatewayClusterRole(name), cfg.allowedPorts, cfg.SelfMonitorLabel); err != nil {
 		return fmt.Errorf("failed to create common resource: %w", err)
 	}
 

--- a/internal/resources/otelcollector/gateway_test.go
+++ b/internal/resources/otelcollector/gateway_test.go
@@ -371,8 +371,7 @@ func TestApplyGatewayResourcesWithSelfMonEnabled(t *testing.T) {
 			"telemetry.kyma-project.io/self-monitor": "enabled",
 		}, svc.Labels)
 		require.Equal(t, map[string]string{
-			"app.kubernetes.io/name":                 name,
-			"telemetry.kyma-project.io/self-monitor": "enabled",
+			"app.kubernetes.io/name": name,
 		}, svc.Spec.Selector)
 		require.Equal(t, map[string]string{
 			"prometheus.io/port":   "8888",

--- a/internal/resources/otelcollector/gateway_test.go
+++ b/internal/resources/otelcollector/gateway_test.go
@@ -39,7 +39,7 @@ func TestApplyGatewayResources(t *testing.T) {
 	ctx := context.Background()
 	client := fake.NewClientBuilder().Build()
 
-	err := ApplyGatewayResources(ctx, client, createGatewayConfig(false))
+	err := ApplyGatewayResources(ctx, client, createGatewayConfig(false, false))
 	require.NoError(t, err)
 
 	t.Run("should create collector config configmap", func(t *testing.T) {
@@ -316,7 +316,7 @@ func TestApplyGatewayResourcesWithIstioEnabled(t *testing.T) {
 	require.NoError(t, clientgoscheme.AddToScheme(scheme))
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	err := ApplyGatewayResources(ctx, client, createGatewayConfig(true))
+	err := ApplyGatewayResources(ctx, client, createGatewayConfig(true, false))
 	require.NoError(t, err)
 
 	t.Run("It should have permissive peer authentication created", func(t *testing.T) {
@@ -349,13 +349,55 @@ func TestApplyGatewayResourcesWithIstioEnabled(t *testing.T) {
 	})
 }
 
-func createGatewayConfig(istioEnabled bool) *GatewayConfig {
+func TestApplyGatewayResourcesWithSelfMonEnabled(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, istiosecurityclientv1beta.AddToScheme(scheme))
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	err := ApplyGatewayResources(ctx, client, createGatewayConfig(false, true))
+	require.NoError(t, err)
+
+	t.Run("should create metrics service", func(t *testing.T) {
+		var svc corev1.Service
+		require.NoError(t, client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name + "-metrics"}, &svc))
+
+		require.NotNil(t, svc)
+		require.Equal(t, name+"-metrics", svc.Name)
+		require.Equal(t, namespace, svc.Namespace)
+		require.Equal(t, map[string]string{
+			"app.kubernetes.io/name":                 name,
+			"telemetry.kyma-project.io/self-monitor": "enabled",
+		}, svc.Labels)
+		require.Equal(t, map[string]string{
+			"app.kubernetes.io/name":                 name,
+			"telemetry.kyma-project.io/self-monitor": "enabled",
+		}, svc.Spec.Selector)
+		require.Equal(t, map[string]string{
+			"prometheus.io/port":   "8888",
+			"prometheus.io/scheme": "http",
+			"prometheus.io/scrape": "true",
+		}, svc.Annotations)
+		require.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+		require.Len(t, svc.Spec.Ports, 1)
+		require.Equal(t, corev1.ServicePort{
+			Name:       "http-metrics",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       8888,
+			TargetPort: intstr.FromInt32(8888),
+		}, svc.Spec.Ports[0])
+	})
+}
+
+func createGatewayConfig(istioEnabled, selfMonEnabled bool) *GatewayConfig {
 	return &GatewayConfig{
 		Config: Config{
 			BaseName:         name,
 			Namespace:        namespace,
 			CollectorConfig:  cfg,
 			CollectorEnvVars: envVars,
+			SelfMonitorLabel: selfMonEnabled,
 		},
 		OTLPServiceName:      otlpServiceName,
 		CanReceiveOpenCensus: true,

--- a/internal/resources/selfmonitor/config.go
+++ b/internal/resources/selfmonitor/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	BaseName          string
 	Namespace         string
 	SelfMonitorConfig string
+	AlertRules        string
 
 	Deployment DeploymentConfig
 }

--- a/internal/resources/selfmonitor/resources.go
+++ b/internal/resources/selfmonitor/resources.go
@@ -30,46 +30,44 @@ func RemoveResources(ctx context.Context, c client.Client, config *Config) error
 		Name:      config.BaseName,
 		Namespace: config.Namespace,
 	}
-	// Delete Deployment
-	deployment := &appsv1.Deployment{ObjectMeta: objectMeta}
-	if err := c.Delete(ctx, deployment); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	// Delete Configmap
-	configMap := &corev1.ConfigMap{ObjectMeta: objectMeta}
-	if err := c.Delete(ctx, configMap); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	// Delete Network policy
-	networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: objectMeta}
-	if err := c.Delete(ctx, networkPolicy); err != nil {
+
+	if err := c.Delete(ctx, &appsv1.Deployment{ObjectMeta: objectMeta}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
 
-	// Delete RoleBinding
-	roleBinding := &rbacv1.RoleBinding{ObjectMeta: objectMeta}
-	if err := c.Delete(ctx, roleBinding); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-	// Delete Role
-	role := &rbacv1.Role{ObjectMeta: objectMeta}
-	if err := c.Delete(ctx, role); err != nil {
+	if err := c.Delete(ctx, &corev1.ConfigMap{ObjectMeta: objectMeta}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
 
-	// Delete service account
-	serviceAccount := &corev1.ServiceAccount{ObjectMeta: objectMeta}
-	if err := c.Delete(ctx, serviceAccount); err != nil {
+	if err := c.Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: objectMeta}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err := c.Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: objectMeta}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err := c.Delete(ctx, &rbacv1.Role{ObjectMeta: objectMeta}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err := c.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: objectMeta}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if err := c.Delete(ctx, &corev1.Service{ObjectMeta: objectMeta}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -98,7 +96,7 @@ func ApplyResources(ctx context.Context, c client.Client, config *Config) error 
 		return fmt.Errorf("failed to create self-monitor network policy: %w", err)
 	}
 
-	configMap := makeConfigMap(name, config.SelfMonitorConfig)
+	configMap := makeConfigMap(name, config)
 	if err := k8sutils.CreateOrUpdateConfigMap(ctx, c, configMap); err != nil {
 		return fmt.Errorf("failed to create self-monitor configmap: %w", err)
 	}
@@ -106,6 +104,10 @@ func ApplyResources(ctx context.Context, c client.Client, config *Config) error 
 	checksum := configchecksum.Calculate([]corev1.ConfigMap{*configMap}, nil)
 	if err := k8sutils.CreateOrUpdateDeployment(ctx, c, makeSelfMonitorDeployment(config, checksum)); err != nil {
 		return fmt.Errorf("failed to create sel-monitor deployment: %w", err)
+	}
+
+	if err := k8sutils.CreateOrUpdateService(ctx, c, makeService(name, ports.PrometheusPort)); err != nil {
+		return fmt.Errorf("failed to create self-monitor service: %w", err)
 	}
 
 	return nil
@@ -120,6 +122,24 @@ func makeServiceAccount(name types.NamespacedName) *corev1.ServiceAccount {
 		},
 	}
 	return &serviceAccount
+}
+
+func makeRole(name types.NamespacedName) *rbacv1.Role {
+	role := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Labels:    defaultLabels(name.Name),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "endpoints", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+	return &role
 }
 
 func makeRoleBinding(name types.NamespacedName) *rbacv1.RoleBinding {
@@ -200,7 +220,7 @@ func makeNetworkPolicyPorts(ports []int32) []networkingv1.NetworkPolicyPort {
 	return networkPolicyPorts
 }
 
-func makeConfigMap(name types.NamespacedName, selfmonitorConfig string) *corev1.ConfigMap {
+func makeConfigMap(name types.NamespacedName, config *Config) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.Name,
@@ -208,7 +228,8 @@ func makeConfigMap(name types.NamespacedName, selfmonitorConfig string) *corev1.
 			Labels:    defaultLabels(name.Name),
 		},
 		Data: map[string]string{
-			"prometheus.yml": selfmonitorConfig,
+			"prometheus.yml":     config.SelfMonitorConfig,
+			"alerting_rules.yml": config.AlertRules,
 		},
 	}
 }
@@ -245,24 +266,6 @@ func makeSelfMonitorDeployment(cfg *Config, configChecksum string) *appsv1.Deplo
 			},
 		},
 	}
-}
-
-func makeRole(name types.NamespacedName) *rbacv1.Role {
-	role := rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-			Labels:    defaultLabels(name.Name),
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		},
-	}
-	return &role
 }
 
 func defaultLabels(baseName string) map[string]string {
@@ -365,6 +368,27 @@ func makeResourceRequirements(cfg *Config) corev1.ResourceRequirements {
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			corev1.ResourceCPU:    cfg.Deployment.CPURequest,
 			corev1.ResourceMemory: cfg.Deployment.MemoryRequest,
+		},
+	}
+}
+
+func makeService(name types.NamespacedName, port int) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Labels:    defaultLabels(name.Name),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     int32(port),
+				},
+			},
+			Selector: defaultLabels(name.Name),
+			Type:     corev1.ServiceTypeClusterIP,
 		},
 	}
 }

--- a/internal/resources/selfmonitor/resources.go
+++ b/internal/resources/selfmonitor/resources.go
@@ -31,48 +31,43 @@ func RemoveResources(ctx context.Context, c client.Client, config *Config) error
 		Namespace: config.Namespace,
 	}
 
-	if err := c.Delete(ctx, &appsv1.Deployment{ObjectMeta: objectMeta}); err != nil {
+	if err := deleteObj(ctx, c, &appsv1.Deployment{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	if err := deleteObj(ctx, c, &corev1.ConfigMap{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	if err := deleteObj(ctx, c, &networkingv1.NetworkPolicy{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	if err := deleteObj(ctx, c, &rbacv1.RoleBinding{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	if err := deleteObj(ctx, c, &rbacv1.Role{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	if err := deleteObj(ctx, c, &corev1.ServiceAccount{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	if err := deleteObj(ctx, c, &corev1.Service{ObjectMeta: objectMeta}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deleteObj(ctx context.Context, c client.Client, object client.Object) error {
+	if err := c.Delete(ctx, object); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
-
-	if err := c.Delete(ctx, &corev1.ConfigMap{ObjectMeta: objectMeta}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := c.Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: objectMeta}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := c.Delete(ctx, &rbacv1.RoleBinding{ObjectMeta: objectMeta}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := c.Delete(ctx, &rbacv1.Role{ObjectMeta: objectMeta}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := c.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: objectMeta}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := c.Delete(ctx, &corev1.Service{ObjectMeta: objectMeta}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -382,9 +377,10 @@ func makeService(name types.NamespacedName, port int) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name:     "http",
-					Protocol: corev1.ProtocolTCP,
-					Port:     int32(port),
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       int32(port),
+					TargetPort: intstr.FromInt32(int32(port)),
 				},
 			},
 			Selector: defaultLabels(name.Name),

--- a/internal/selfmonitor/config/config.go
+++ b/internal/selfmonitor/config/config.go
@@ -67,5 +67,6 @@ type RelabelConfig struct {
 type RelabelAction string
 
 const (
-	Keep RelabelAction = "keep"
+	Keep    RelabelAction = "keep"
+	Replace RelabelAction = "replace"
 )

--- a/internal/selfmonitor/config/config_builder.go
+++ b/internal/selfmonitor/config/config_builder.go
@@ -50,9 +50,9 @@ func makeScrapeConfig(scrapeNamespace string) []ScrapeConfig {
 					Regex:        "true",
 				},
 				{
-					SourceLabels: []string{"__meta_kubernetes_service_label_app_kubernetes_io_name"},
+					SourceLabels: []string{"__meta_kubernetes_service_label_telemetry_kyma_project_io_self_monitor"},
 					Action:       Keep,
-					Regex:        "telemetry-.+",
+					Regex:        "enabled",
 				},
 				{
 					SourceLabels: []string{"__meta_kubernetes_service_annotation_prometheus_io_path"},

--- a/internal/selfmonitor/config/config_builder.go
+++ b/internal/selfmonitor/config/config_builder.go
@@ -50,7 +50,7 @@ func makeScrapeConfig(scrapeNamespace string) []ScrapeConfig {
 					Regex:        "true",
 				},
 				{
-					SourceLabels: []string{"__meta_kubernetes_service_label_telemetry_kyma_project_io_self_monitor"},
+					SourceLabels: []string{"__meta_kubernetes_endpoints_label_telemetry_kyma_project_io_self_monitor"},
 					Action:       Keep,
 					Regex:        "enabled",
 				},

--- a/internal/selfmonitor/config/config_builder.go
+++ b/internal/selfmonitor/config/config_builder.go
@@ -11,7 +11,7 @@ func MakeConfig(scrapeNamespace string) Config {
 	promConfig := Config{}
 	promConfig.GlobalConfig = makeGlobalConfig()
 	promConfig.AlertingConfig = makeAlertConfig()
-	promConfig.RuleFiles = []string{"/etc/prometheus/prometheus.rules"}
+	promConfig.RuleFiles = []string{"/etc/prometheus/alerting_rules.yml"}
 	promConfig.ScrapeConfigs = makeScrapeConfig(scrapeNamespace)
 	return promConfig
 }
@@ -38,11 +38,58 @@ func makeScrapeConfig(scrapeNamespace string) []ScrapeConfig {
 		{
 			JobName: "kubernetes-service-endpoints",
 
-			RelabelConfigs: []RelabelConfig{{
-				SourceLabels: []string{"__meta_kubernetes_service_annotation_prometheus_io_scrape"},
-				Regex:        "true",
-				Action:       Keep,
-			}},
+			RelabelConfigs: []RelabelConfig{
+				{
+					SourceLabels: []string{"__meta_kubernetes_namespace"},
+					Action:       Keep,
+					Regex:        scrapeNamespace,
+				},
+				{
+					SourceLabels: []string{"__meta_kubernetes_service_annotation_prometheus_io_scrape"},
+					Action:       Keep,
+					Regex:        "true",
+				},
+				{
+					SourceLabels: []string{"__meta_kubernetes_service_label_app_kubernetes_io_name"},
+					Action:       Keep,
+					Regex:        "telemetry-.+",
+				},
+				{
+					SourceLabels: []string{"__meta_kubernetes_service_annotation_prometheus_io_path"},
+					Action:       Replace,
+					TargetLabel:  "__metrics_path__",
+					Regex:        "true",
+				},
+				{
+					SourceLabels: []string{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
+					Action:       Replace,
+					TargetLabel:  "__address__",
+					Regex:        "(.+?)(?::\\d+)?;(\\d+)",
+					Replacement:  "$1:$2",
+				},
+				{
+					SourceLabels: []string{"__meta_kubernetes_namespace"},
+					Action:       Replace,
+					TargetLabel:  "namespace",
+				},
+				{
+					SourceLabels: []string{"__meta_kubernetes_service_name"},
+					Action:       Replace,
+					TargetLabel:  "service",
+				},
+				{
+					SourceLabels: []string{"__meta_kubernetes_pod_node_name"},
+					Action:       Replace,
+					TargetLabel:  "node",
+				},
+			},
+			MetricRelabelConfigs: []RelabelConfig{
+				{
+					SourceLabels: []string{"__name__"},
+					Action:       Keep,
+					Regex:        "(otelcol_.*)",
+				},
+			},
 			KubernetesDiscoveryConfigs: []KubernetesDiscoveryConfig{{
 				Role:       RoleEndpoints,
 				Namespaces: Names{Name: []string{scrapeNamespace}},

--- a/internal/selfmonitor/config/testdata/config.yaml
+++ b/internal/selfmonitor/config/testdata/config.yaml
@@ -17,8 +17,8 @@ scrape_configs:
         - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           regex: "true"
           action: keep
-        - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-          regex: telemetry-.+
+        - source_labels: [__meta_kubernetes_endpoints_label_telemetry_kyma_project_io_self_monitor]
+          regex: enabled
           action: keep
         - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
           regex: "true"

--- a/internal/selfmonitor/config/testdata/config.yaml
+++ b/internal/selfmonitor/config/testdata/config.yaml
@@ -7,12 +7,40 @@ alerting:
             - targets:
                 - localhost:9093
 rule_files:
-    - /etc/prometheus/prometheus.rules
+    - /etc/prometheus/alerting_rules.yml
 scrape_configs:
     - job_name: kubernetes-service-endpoints
       relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: kyma-system
+          action: keep
         - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
           regex: "true"
+          action: keep
+        - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+          regex: telemetry-.+
+          action: keep
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+          regex: "true"
+          target_label: __metrics_path__
+          action: replace
+        - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+          regex: (.+?)(?::\d+)?;(\d+)
+          target_label: __address__
+          replacement: $1:$2
+          action: replace
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+          action: replace
+        - source_labels: [__meta_kubernetes_service_name]
+          target_label: service
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+          action: replace
+      metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: (otelcol_.*)
           action: keep
       kubernetes_sd_configs:
         - role: endpoints

--- a/main.go
+++ b/main.go
@@ -518,8 +518,9 @@ func createTracePipelineReconciler(client client.Client) *telemetrycontrollers.T
 	config := tracepipeline.Config{
 		Gateway: otelcollector.GatewayConfig{
 			Config: otelcollector.Config{
-				Namespace: telemetryNamespace,
-				BaseName:  "telemetry-trace-collector",
+				Namespace:        telemetryNamespace,
+				BaseName:         "telemetry-trace-collector",
+				SelfMonitorLabel: enableSelfMonitor,
 			},
 			Deployment: otelcollector.DeploymentConfig{
 				Image:                traceGatewayImage,
@@ -550,8 +551,9 @@ func createMetricPipelineReconciler(client client.Client) *telemetrycontrollers.
 	config := metricpipeline.Config{
 		Agent: otelcollector.AgentConfig{
 			Config: otelcollector.Config{
-				Namespace: telemetryNamespace,
-				BaseName:  "telemetry-metric-agent",
+				Namespace:        telemetryNamespace,
+				BaseName:         "telemetry-metric-agent",
+				SelfMonitorLabel: enableSelfMonitor,
 			},
 			DaemonSet: otelcollector.DaemonSetConfig{
 				Image:             metricGatewayImage,
@@ -564,8 +566,9 @@ func createMetricPipelineReconciler(client client.Client) *telemetrycontrollers.
 		},
 		Gateway: otelcollector.GatewayConfig{
 			Config: otelcollector.Config{
-				Namespace: telemetryNamespace,
-				BaseName:  "telemetry-metric-gateway",
+				Namespace:        telemetryNamespace,
+				BaseName:         "telemetry-metric-gateway",
+				SelfMonitorLabel: enableSelfMonitor,
 			},
 			Deployment: otelcollector.DeploymentConfig{
 				Image:                metricGatewayImage,


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add scrape-config for self-monitor
- Add the missing servicer for self-monitor

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/822

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->