### PR TITLE
fix: Explicitly set previous release tag to fix the auto-generated changelogs

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,22 +25,15 @@ function prepare_release_artefacts() {
 
 get_previous_release_version() {
     TAG_LIST=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
-    if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[2-9]$ ]]
+    if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
     then
-          # get the list of tags in a reverse chronological order including patch tags
-          TAG_LIST_WITH_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[1-9]$"))
-          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH[1]}
+          # do nothing
+          echo "Skip patch previous release"
     else
           # get the list of tags in a reverse chronological order excluding patch tags
-          TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
+          TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0]$"))
           export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITHOUT_PATCH[1]}
     fi
-}
-
-get_new_release_version() {
-    # get the list of tags in a reverse chronological order
-    TAG_LIST=($(git tag --sort=-creatordate))
-    export GORELEASER_CURRENT_TAG=${TAG_LIST[0]}
 }
 
 function create_github_release() {
@@ -51,7 +44,6 @@ function create_github_release() {
 
 function main() {
     prepare_release_artefacts
-    get_new_release_version
     get_previous_release_version
     create_github_release
 }

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,8 +27,8 @@ get_previous_release_version() {
     TAG_LIST=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
     if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
     then
-          # do nothing
-          echo "Skip patch previous release"
+          TAG_LIST_WITH_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
+          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH[1]}
     else
           # get the list of tags in a reverse chronological order excluding patch tags
           TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0]$"))

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,6 +23,26 @@ function prepare_release_artefacts() {
      cp ./config/samples/operator_v1alpha1_telemetry.yaml telemetry-default-cr.yaml
 }
 
+get_previous_release_version() {
+    TAG_LIST=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
+    if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[2-9]$ ]]
+    then
+          # get the list of tags in a reverse chronological order including patch tags
+          TAG_LIST_WITH_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[1-9]$"))
+          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH[1]}
+    else
+          # get the list of tags in a reverse chronological order excluding patch tags
+          TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
+          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITHOUT_PATCH[1]}
+    fi
+}
+
+get_new_release_version() {
+    # get the list of tags in a reverse chronological order
+    TAG_LIST=($(git tag --sort=-creatordate))
+    export GORELEASER_CURRENT_TAG=${TAG_LIST[0]}
+}
+
 function create_github_release() {
     echo "Creating the Github release"
     git reset --hard
@@ -31,6 +51,8 @@ function create_github_release() {
 
 function main() {
     prepare_release_artefacts
+    get_new_release_version
+    get_previous_release_version
     create_github_release
 }
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Detect the previous release tag and set the environment variable GORELEASER_PREVIOUS_TAG

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/808

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [x] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->