### PR TITLE
fix: Ensure pending condition is always preserved

### DIFF
--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -127,23 +127,31 @@ func SetPendingCondition(ctx context.Context, conditions *[]metav1.Condition, ge
 	meta.SetStatusCondition(conditions, pending)
 }
 
-func SetRunningCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, reason, resourceName string, messageMap map[string]string) {
+func SetRunningCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, reason, resourceName string, messageMap map[string]string, preUpgradePendingCondition *metav1.Condition, pendingFallbackReason string) {
 	log := logf.FromContext(ctx)
 
-	existingPending := meta.FindStatusCondition(*conditions, TypePending)
-	if existingPending != nil {
-		newPending := New(
-			TypePending,
-			existingPending.Reason,
-			metav1.ConditionFalse,
-			generation,
-			messageMap,
-		)
-		newPending.Message = PendingTypeDeprecationMsg + newPending.Message
-		log.V(1).Info(fmt.Sprintf("Updating the status of %s: Setting the Pending condition to False", resourceName))
-		meta.SetStatusCondition(conditions, newPending)
+	// Set Pending condition to False
+	var pendingReason string
+	existingPendingCondition := meta.FindStatusCondition(*conditions, TypePending)
+	if existingPendingCondition != nil {
+		pendingReason = existingPendingCondition.Reason
+	} else if preUpgradePendingCondition != nil {
+		pendingReason = preUpgradePendingCondition.Reason
+	} else {
+		pendingReason = pendingFallbackReason
 	}
+	newPending := New(
+		TypePending,
+		pendingReason,
+		metav1.ConditionFalse,
+		generation,
+		messageMap,
+	)
+	newPending.Message = PendingTypeDeprecationMsg + newPending.Message
+	log.V(1).Info(fmt.Sprintf("Updating the status of %s: Setting the Pending condition to False", resourceName))
+	meta.SetStatusCondition(conditions, newPending)
 
+	// Set Running condition to True
 	running := New(
 		TypeRunning,
 		reason,
@@ -152,7 +160,6 @@ func SetRunningCondition(ctx context.Context, conditions *[]metav1.Condition, ge
 		messageMap,
 	)
 	running.Message = RunningTypeDeprecationMsg + running.Message
-
 	log.V(1).Info(fmt.Sprintf("Updating the status of %s: Setting the Running condition to True", resourceName))
 	meta.SetStatusCondition(conditions, running)
 }

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -127,7 +127,7 @@ func HandlePendingCondition(ctx context.Context, conditions *[]metav1.Condition,
 	meta.SetStatusCondition(conditions, pending)
 }
 
-func SetRunningCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, runningReason, pendingReason, resourceName string, messageMap map[string]string) {
+func HandleRunningCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, runningReason, pendingReason, resourceName string, messageMap map[string]string) {
 	log := logf.FromContext(ctx)
 
 	// Set Pending condition to False

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -127,34 +127,25 @@ func SetPendingCondition(ctx context.Context, conditions *[]metav1.Condition, ge
 	meta.SetStatusCondition(conditions, pending)
 }
 
-func SetRunningCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, reason, resourceName string, messageMap map[string]string, preUpgradePendingCondition *metav1.Condition, pendingFallbackReason string) {
+func SetRunningCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, runningReason, pendingReason, resourceName string, messageMap map[string]string) {
 	log := logf.FromContext(ctx)
 
 	// Set Pending condition to False
-	var pendingReason string
-	existingPendingCondition := meta.FindStatusCondition(*conditions, TypePending)
-	if existingPendingCondition != nil {
-		pendingReason = existingPendingCondition.Reason
-	} else if preUpgradePendingCondition != nil {
-		pendingReason = preUpgradePendingCondition.Reason
-	} else {
-		pendingReason = pendingFallbackReason
-	}
-	newPending := New(
+	pending := New(
 		TypePending,
 		pendingReason,
 		metav1.ConditionFalse,
 		generation,
 		messageMap,
 	)
-	newPending.Message = PendingTypeDeprecationMsg + newPending.Message
+	pending.Message = PendingTypeDeprecationMsg + pending.Message
 	log.V(1).Info(fmt.Sprintf("Updating the status of %s: Setting the Pending condition to False", resourceName))
-	meta.SetStatusCondition(conditions, newPending)
+	meta.SetStatusCondition(conditions, pending)
 
 	// Set Running condition to True
 	running := New(
 		TypeRunning,
-		reason,
+		runningReason,
 		metav1.ConditionTrue,
 		generation,
 		messageMap,

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -106,7 +106,7 @@ func MessageFor(reason string, messageMap map[string]string) string {
 	return ""
 }
 
-func SetPendingCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, reason, resourceName string, messageMap map[string]string) {
+func HandlePendingCondition(ctx context.Context, conditions *[]metav1.Condition, generation int64, reason, resourceName string, messageMap map[string]string) {
 	log := logf.FromContext(ctx)
 
 	pending := New(

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -38,7 +38,7 @@ func TestSetPendingCondition(t *testing.T) {
 		generation := int64(1)
 		reason := ReasonFluentBitDSNotReady
 
-		SetPendingCondition(context.Background(), &conditions, generation, reason, "pipeline", LogsMessage)
+		HandlePendingCondition(context.Background(), &conditions, generation, reason, "pipeline", LogsMessage)
 
 		pendingCond := meta.FindStatusCondition(conditions, TypePending)
 		require.Equal(t, TypePending, pendingCond.Type)
@@ -70,7 +70,7 @@ func TestSetPendingCondition(t *testing.T) {
 		generation := int64(1)
 		reason := ReasonFluentBitDSNotReady
 
-		SetPendingCondition(context.Background(), &conditions, generation, reason, "pipeline", LogsMessage)
+		HandlePendingCondition(context.Background(), &conditions, generation, reason, "pipeline", LogsMessage)
 
 		runningCond := meta.FindStatusCondition(conditions, TypeRunning)
 		require.Nil(t, runningCond)

--- a/internal/conditions/conditions_test.go
+++ b/internal/conditions/conditions_test.go
@@ -101,7 +101,7 @@ func TestSetRunningCondition(t *testing.T) {
 		generation := int64(1)
 		reason := ReasonFluentBitDSReady
 
-		SetRunningCondition(context.Background(), &conditions, generation, reason, "pipeline", LogsMessage)
+		HandleRunningCondition(context.Background(), &conditions, generation, reason, "pipeline", LogsMessage)
 
 		pendingCond := meta.FindStatusCondition(conditions, TypePending)
 		require.NotNil(t, pendingCond)

--- a/internal/reconciler/logparser/status.go
+++ b/internal/reconciler/logparser/status.go
@@ -70,7 +70,7 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, parser 
 	}
 
 	if !fluentBitReady {
-		conditions.SetPendingCondition(ctx, &parser.Status.Conditions, parser.Generation, conditions.ReasonFluentBitDSNotReady, parser.Name, conditions.LogsMessage)
+		conditions.HandlePendingCondition(ctx, &parser.Status.Conditions, parser.Generation, conditions.ReasonFluentBitDSNotReady, parser.Name, conditions.LogsMessage)
 		return
 
 	}

--- a/internal/reconciler/logparser/status.go
+++ b/internal/reconciler/logparser/status.go
@@ -75,7 +75,7 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, parser 
 
 	}
 
-	conditions.SetRunningCondition(
+	conditions.HandleRunningCondition(
 		ctx,
 		&parser.Status.Conditions,
 		parser.Generation,

--- a/internal/reconciler/logparser/status.go
+++ b/internal/reconciler/logparser/status.go
@@ -31,15 +31,12 @@ func (r *Reconciler) updateStatus(ctx context.Context, parserName string) error 
 	// If the "AgentHealthy" type doesn't exist in the conditions,
 	// then we need to reset the conditions list to ensure that the "Pending" and "Running" conditions are appended to the end of the conditions list
 	// Check step 3 in https://github.com/kyma-project/telemetry-manager/blob/main/docs/contributor/arch/004-consolidate-pipeline-statuses.md#decision
-	// At the same time, we need to store the "Pending" condition to preserve the pending reason
-	var preUpgradePendingCondition *metav1.Condition
 	if meta.FindStatusCondition(parser.Status.Conditions, conditions.TypeAgentHealthy) == nil {
-		preUpgradePendingCondition = meta.FindStatusCondition(parser.Status.Conditions, conditions.TypePending)
 		parser.Status.Conditions = []metav1.Condition{}
 	}
 
 	r.setAgentHealthyCondition(ctx, &parser)
-	r.setPendingAndRunningConditions(ctx, &parser, preUpgradePendingCondition)
+	r.setPendingAndRunningConditions(ctx, &parser)
 
 	if err := r.Status().Update(ctx, &parser); err != nil {
 		return fmt.Errorf("failed to update LogParser status: %w", err)
@@ -65,7 +62,7 @@ func (r *Reconciler) setAgentHealthyCondition(ctx context.Context, parser *telem
 	meta.SetStatusCondition(&parser.Status.Conditions, conditions.New(conditions.TypeAgentHealthy, reason, status, parser.Generation, conditions.LogsMessage))
 }
 
-func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, parser *telemetryv1alpha1.LogParser, preUpgradePendingCondition *metav1.Condition) {
+func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, parser *telemetryv1alpha1.LogParser) {
 	fluentBitReady, err := r.prober.IsReady(ctx, r.config.DaemonSet)
 	if err != nil {
 		logf.FromContext(ctx).V(1).Error(err, "Failed to probe fluent bit daemonset")
@@ -83,9 +80,8 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, parser 
 		&parser.Status.Conditions,
 		parser.Generation,
 		conditions.ReasonFluentBitDSReady,
+		conditions.ReasonFluentBitDSNotReady,
 		parser.Name,
 		conditions.LogsMessage,
-		preUpgradePendingCondition,
-		conditions.ReasonFluentBitDSNotReady,
 	)
 }

--- a/internal/reconciler/logparser/status_test.go
+++ b/internal/reconciler/logparser/status_test.go
@@ -121,6 +121,16 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotEmpty(t, agentHealthyCond.LastTransitionTime)
 
 		conditionsSize := len(updatedParser.Status.Conditions)
+
+		pendingCond := updatedParser.Status.Conditions[conditionsSize-2]
+		require.Equal(t, conditions.TypePending, pendingCond.Type)
+		require.Equal(t, metav1.ConditionFalse, pendingCond.Status)
+		require.Equal(t, conditions.ReasonFluentBitDSNotReady, pendingCond.Reason)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
+		require.Equal(t, pendingCondMsg, pendingCond.Message)
+		require.Equal(t, updatedParser.Generation, pendingCond.ObservedGeneration)
+		require.NotEmpty(t, pendingCond.LastTransitionTime)
+
 		runningCond := updatedParser.Status.Conditions[conditionsSize-1]
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -123,7 +123,7 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipelin
 		return
 	}
 
-	conditions.SetRunningCondition(
+	conditions.HandleRunningCondition(
 		ctx,
 		&pipeline.Status.Conditions,
 		pipeline.Generation,

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -102,13 +102,13 @@ func (r *Reconciler) setFluentBitConfigGeneratedCondition(ctx context.Context, p
 func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipeline *telemetryv1alpha1.LogPipeline) {
 
 	if pipeline.Spec.Output.IsLokiDefined() {
-		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonUnsupportedLokiOutput, pipeline.Name, conditions.LogsMessage)
+		conditions.HandlePendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonUnsupportedLokiOutput, pipeline.Name, conditions.LogsMessage)
 		return
 	}
 
 	referencesNonExistentSecret := secretref.ReferencesNonExistentSecret(ctx, r.Client, pipeline)
 	if referencesNonExistentSecret {
-		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonReferencedSecretMissing, pipeline.Name, conditions.LogsMessage)
+		conditions.HandlePendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonReferencedSecretMissing, pipeline.Name, conditions.LogsMessage)
 		return
 	}
 
@@ -119,7 +119,7 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipelin
 	}
 
 	if !fluentBitReady {
-		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonFluentBitDSNotReady, pipeline.Name, conditions.LogsMessage)
+		conditions.HandlePendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonFluentBitDSNotReady, pipeline.Name, conditions.LogsMessage)
 		return
 	}
 

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -38,13 +38,16 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string) erro
 	// If the "AgentHealthy" type doesn't exist in the conditions,
 	// then we need to reset the conditions list to ensure that the "Pending" and "Running" conditions are appended to the end of the conditions list
 	// Check step 3 in https://github.com/kyma-project/telemetry-manager/blob/main/docs/contributor/arch/004-consolidate-pipeline-statuses.md#decision
+	// At the same time, we need to store the "Pending" condition to preserve the pending reason
+	var preUpgradePendingCondition *metav1.Condition
 	if meta.FindStatusCondition(pipeline.Status.Conditions, conditions.TypeAgentHealthy) == nil {
+		preUpgradePendingCondition = meta.FindStatusCondition(pipeline.Status.Conditions, conditions.TypePending)
 		pipeline.Status.Conditions = []metav1.Condition{}
 	}
 
 	r.setAgentHealthyCondition(ctx, &pipeline)
 	r.setFluentBitConfigGeneratedCondition(ctx, &pipeline)
-	r.setPendingAndRunningConditions(ctx, &pipeline)
+	r.setPendingAndRunningConditions(ctx, &pipeline, preUpgradePendingCondition)
 
 	if err := r.Status().Update(ctx, &pipeline); err != nil {
 		return fmt.Errorf("failed to update LogPipeline status: %w", err)
@@ -99,7 +102,7 @@ func (r *Reconciler) setFluentBitConfigGeneratedCondition(ctx context.Context, p
 	meta.SetStatusCondition(&pipeline.Status.Conditions, conditions.New(conditions.TypeConfigurationGenerated, reason, status, pipeline.Generation, conditions.LogsMessage))
 }
 
-func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipeline *telemetryv1alpha1.LogPipeline) {
+func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipeline *telemetryv1alpha1.LogPipeline, preUpgradePendingCondition *metav1.Condition) {
 
 	if pipeline.Spec.Output.IsLokiDefined() {
 		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonUnsupportedLokiOutput, pipeline.Name, conditions.LogsMessage)
@@ -123,5 +126,14 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipelin
 		return
 	}
 
-	conditions.SetRunningCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonFluentBitDSReady, pipeline.Name, conditions.LogsMessage)
+	conditions.SetRunningCondition(
+		ctx,
+		&pipeline.Status.Conditions,
+		pipeline.Generation,
+		conditions.ReasonFluentBitDSReady,
+		pipeline.Name,
+		conditions.LogsMessage,
+		preUpgradePendingCondition,
+		conditions.ReasonFluentBitDSNotReady,
+	)
 }

--- a/internal/reconciler/logpipeline/status_test.go
+++ b/internal/reconciler/logpipeline/status_test.go
@@ -121,6 +121,16 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotEmpty(t, agentHealthyCond.LastTransitionTime)
 
 		conditionsSize := len(updatedPipeline.Status.Conditions)
+
+		pendingCond := updatedPipeline.Status.Conditions[conditionsSize-2]
+		require.Equal(t, conditions.TypePending, pendingCond.Type)
+		require.Equal(t, metav1.ConditionFalse, pendingCond.Status)
+		require.Equal(t, conditions.ReasonFluentBitDSNotReady, pendingCond.Reason)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonFluentBitDSNotReady, conditions.LogsMessage)
+		require.Equal(t, pendingCondMsg, pendingCond.Message)
+		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
+		require.NotEmpty(t, pendingCond.LastTransitionTime)
+
 		runningCond := updatedPipeline.Status.Conditions[conditionsSize-1]
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)

--- a/internal/reconciler/tracepipeline/status.go
+++ b/internal/reconciler/tracepipeline/status.go
@@ -85,13 +85,13 @@ func (r *Reconciler) setGatewayConfigGeneratedCondition(ctx context.Context, pip
 
 func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipeline *telemetryv1alpha1.TracePipeline, withinPipelineCountLimit bool) {
 	if !withinPipelineCountLimit {
-		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonMaxPipelinesExceeded, pipeline.Name, conditions.TracesMessage)
+		conditions.HandlePendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonMaxPipelinesExceeded, pipeline.Name, conditions.TracesMessage)
 		return
 	}
 
 	referencesNonExistentSecret := secretref.ReferencesNonExistentSecret(ctx, r.Client, pipeline)
 	if referencesNonExistentSecret {
-		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonReferencedSecretMissing, pipeline.Name, conditions.TracesMessage)
+		conditions.HandlePendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonReferencedSecretMissing, pipeline.Name, conditions.TracesMessage)
 		return
 	}
 
@@ -102,7 +102,7 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipelin
 	}
 
 	if !gatewayReady {
-		conditions.SetPendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonTraceGatewayDeploymentNotReady, pipeline.Name, conditions.TracesMessage)
+		conditions.HandlePendingCondition(ctx, &pipeline.Status.Conditions, pipeline.Generation, conditions.ReasonTraceGatewayDeploymentNotReady, pipeline.Name, conditions.TracesMessage)
 		return
 	}
 

--- a/internal/reconciler/tracepipeline/status.go
+++ b/internal/reconciler/tracepipeline/status.go
@@ -106,7 +106,7 @@ func (r *Reconciler) setPendingAndRunningConditions(ctx context.Context, pipelin
 		return
 	}
 
-	conditions.SetRunningCondition(
+	conditions.HandleRunningCondition(
 		ctx,
 		&pipeline.Status.Conditions,
 		pipeline.Generation,

--- a/internal/reconciler/tracepipeline/status_test.go
+++ b/internal/reconciler/tracepipeline/status_test.go
@@ -120,6 +120,16 @@ func TestUpdateStatus(t *testing.T) {
 		require.NotEmpty(t, gatewayHealthyCond.LastTransitionTime)
 
 		conditionsSize := len(updatedPipeline.Status.Conditions)
+
+		pendingCond := updatedPipeline.Status.Conditions[conditionsSize-2]
+		require.Equal(t, conditions.TypePending, pendingCond.Type)
+		require.Equal(t, metav1.ConditionFalse, pendingCond.Status)
+		require.Equal(t, conditions.ReasonTraceGatewayDeploymentNotReady, pendingCond.Reason)
+		pendingCondMsg := conditions.PendingTypeDeprecationMsg + conditions.MessageFor(conditions.ReasonTraceGatewayDeploymentNotReady, conditions.TracesMessage)
+		require.Equal(t, pendingCondMsg, pendingCond.Message)
+		require.Equal(t, updatedPipeline.Generation, pendingCond.ObservedGeneration)
+		require.NotEmpty(t, pendingCond.LastTransitionTime)
+
 		runningCond := updatedPipeline.Status.Conditions[conditionsSize-1]
 		require.Equal(t, conditions.TypeRunning, runningCond.Type)
 		require.Equal(t, metav1.ConditionTrue, runningCond.Status)

--- a/test/testkit/verifiers/logs.go
+++ b/test/testkit/verifiers/logs.go
@@ -34,8 +34,9 @@ func LogPipelineShouldBeHealthy(ctx context.Context, k8sClient client.Client, pi
 		var pipeline telemetryv1alpha1.LogPipeline
 		key := types.NamespacedName{Name: pipelineName}
 		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeRunning)).To(BeTrue())
 		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeAgentHealthy)).To(BeTrue())
 		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeConfigurationGenerated)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeRunning)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionFalse(pipeline.Status.Conditions, conditions.TypePending)).To(BeTrue())
 	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }

--- a/test/testkit/verifiers/traces.go
+++ b/test/testkit/verifiers/traces.go
@@ -26,9 +26,10 @@ func TracePipelineShouldBeHealthy(ctx context.Context, k8sClient client.Client, 
 		var pipeline telemetryv1alpha1.TracePipeline
 		key := types.NamespacedName{Name: pipelineName}
 		g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeRunning)).To(BeTrue())
 		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeGatewayHealthy)).To(BeTrue())
 		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeConfigurationGenerated)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeRunning)).To(BeTrue())
+		g.Expect(meta.IsStatusConditionFalse(pipeline.Status.Conditions, conditions.TypePending)).To(BeTrue())
 	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Ensure that the `Pending` condition always exists in the conditions list for `TracePipeline`, `LogPipeline` and `TracePipeline`
- If a pipeline was in a pending condition and then it becomes deployable, this will result in the `Trace Gateway` / `Fluent Bit` to restart. Therefore, when handling the running condition, we can always set the reason for the false pending condition to be `FluentBitDaemonSetNotReady` for `LogPipeline` and `TraceGatewayDeploymentNotReady` for `TracePipeline`
- Rename `SetRunningCondition` func to `HandleRunningCondition` to avoid giving the false impression that it only sets the `Running` condition to True
- Rename `SetPendingCondition` func to `HandlePendingCondition` to avoid giving the false impression that it only sets the `Pending` condition to True
- Updated unit tests
- Updated e2e test verifiers

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->