### PR TITLE
chore: Update link for golangci-lint integration

### DIFF
--- a/docs/contributor/governance.md
+++ b/docs/contributor/governance.md
@@ -125,7 +125,7 @@ issues:
 
 ### Dev Environment Configuration
 
-Read [golangci-lint integrations](https://golangci-lint.run/usage/integrations/) for information on configuring file-watchers for your IDE or code editor.
+Read [golangci-lint integrations](https://golangci-lint.run/welcome/integrations/) for information on configuring file-watchers for your IDE or code editor.
 
 ### Autofix
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The existing link https://golangci-lint.run/usage/integrations/ is now changed to https://golangci-lint.run/welcome/integrations/

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->