### PR TITLE
feat: Ensure that auto-generated CRDs for development variant are always up-to-date

### DIFF
--- a/hack/lint-manifests.sh
+++ b/hack/lint-manifests.sh
@@ -11,14 +11,28 @@ echo "Check that the CRDs manifests and their documentation are up-to-date"
 make manifests
 
 DIFF=$(git diff)
-if [ -n "${DIFF}" ]; then 
-    echo "ERROR: detected CRDs manifests and/or documentation that need to be updated"
+if [ -n "${DIFF}" ]; then
+    echo "ERROR: detected CRDs manifests (default variant) and/or documentation that need to be updated"
     echo "
-    To update the CRDs manifests and their documentation run:
+    To update the CRDs manifests (default variant) and their documentation run:
         make manifests
     in the root of the repository and commit changes.
     "
     exit 1
 fi
+
+make manifests-dev
+
+DIFF=$(git diff)
+if [ -n "${DIFF}" ]; then
+    echo "ERROR: detected CRDs manifests (development variant) that need to be updated"
+    echo "
+    To update the CRDs manifests (development variant) run:
+        make manifests-dev
+    in the root of the repository and commit changes.
+    "
+    exit 1
+fi
+
 
 echo "CRDs manifests and their documentation are up-to-date"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Update the lint-manifests script to ensure that the auto-generated CRDs for development variant are always up-to-date

Changes refer to particular issues, PRs or documents:

- #848 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->