### PR TITLE
fix: Self-monitor alert matching

### DIFF
--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -70,6 +70,11 @@ type OtlpTLS struct {
 	Key *ValueType `json:"key,omitempty"`
 }
 
+const (
+	OtlpProtocolHTTP string = "http"
+	OtlpProtocolGRPC string = "grpc"
+)
+
 // OtlpOutput OTLP output configuration
 // +kubebuilder:validation:XValidation:rule="((!has(self.path) || size(self.path) <= 0) && (has(self.protocol) && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol == 'http')", message="Path is only available with HTTP protocol"
 type OtlpOutput struct {

--- a/apis/telemetry/v1beta1/shared_types.go
+++ b/apis/telemetry/v1beta1/shared_types.go
@@ -70,6 +70,13 @@ type OTLPTLS struct {
 	Key *ValueType `json:"key,omitempty"`
 }
 
+type OTLPProtocol string
+
+const (
+	OTLPProtocolHTTP OTLPProtocol = "http"
+	OTLPProtocolGRPC OTLPProtocol = "grpc"
+)
+
 // OTLPOutput OTLP output configuration
 // +kubebuilder:validation:XValidation:rule="((!has(self.path) || size(self.path) <= 0) && (has(self.protocol) && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol == 'http')", message="Path is only available with HTTP protocol"
 type OTLPOutput struct {
@@ -77,7 +84,7 @@ type OTLPOutput struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:default:=grpc
 	// +kubebuilder:validation:Enum=grpc;http
-	Protocol string `json:"protocol,omitempty"`
+	Protocol OTLPProtocol `json:"protocol,omitempty"`
 	// Defines the host and port (<host>:<port>) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`

--- a/apis/telemetry/v1beta1/shared_types.go
+++ b/apis/telemetry/v1beta1/shared_types.go
@@ -81,7 +81,6 @@ const (
 // +kubebuilder:validation:XValidation:rule="((!has(self.path) || size(self.path) <= 0) && (has(self.protocol) && self.protocol == 'grpc')) || (has(self.protocol) && self.protocol == 'http')", message="Path is only available with HTTP protocol"
 type OTLPOutput struct {
 	// Defines the OTLP protocol (http or grpc). Default is grpc.
-	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:default:=grpc
 	// +kubebuilder:validation:Enum=grpc;http
 	Protocol OTLPProtocol `json:"protocol,omitempty"`

--- a/config/development/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_metricpipelines.yaml
@@ -933,7 +933,6 @@ spec:
                         enum:
                         - grpc
                         - http
-                        minLength: 1
                         type: string
                       tls:
                         description: Defines TLS options for the OTLP output.

--- a/config/development/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -619,7 +619,6 @@ spec:
                         enum:
                         - grpc
                         - http
-                        minLength: 1
                         type: string
                       tls:
                         description: Defines TLS options for the OTLP output.

--- a/internal/otelcollector/config/metric/gateway/config_builder.go
+++ b/internal/otelcollector/config/metric/gateway/config_builder.go
@@ -156,7 +156,7 @@ func declareOTLPExporter(ctx context.Context, otlpExporterBuilder *otlpexporter.
 
 	maps.Copy(envVars, otlpExporterEnvVars)
 
-	exporterID := otlpexporter.ExporterID(pipeline.Spec.Output.Otlp, pipeline.Name)
+	exporterID := otlpexporter.ExporterID(pipeline.Spec.Output.Otlp.Protocol, pipeline.Name)
 	cfg.Exporters[exporterID] = Exporter{OTLP: otlpExporterConfig}
 
 	return nil
@@ -224,7 +224,7 @@ func makeNamespaceFilterID(pipelineName string, inputSourceType metric.InputSour
 }
 
 func makeOTLPExporterID(pipeline *telemetryv1alpha1.MetricPipeline) string {
-	return otlpexporter.ExporterID(pipeline.Spec.Output.Otlp, pipeline.Name)
+	return otlpexporter.ExporterID(pipeline.Spec.Output.Otlp.Protocol, pipeline.Name)
 }
 
 func isPrometheusInputEnabled(input telemetryv1alpha1.MetricPipelineInput) bool {

--- a/internal/otelcollector/config/otlpexporter/config_builder.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder.go
@@ -79,9 +79,9 @@ func makeExportersConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName 
 	return &otlpExporterConfig
 }
 
-func ExporterID(output *telemetryv1alpha1.OtlpOutput, pipelineName string) string {
+func ExporterID(protocol string, pipelineName string) string {
 	var outputType string
-	if output.Protocol == "http" {
+	if protocol == "http" {
 		outputType = "otlphttp"
 	} else {
 		outputType = "otlp"

--- a/internal/otelcollector/config/otlpexporter/config_builder.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder.go
@@ -81,7 +81,7 @@ func makeExportersConfig(otlpOutput *telemetryv1alpha1.OtlpOutput, pipelineName 
 
 func ExporterID(protocol string, pipelineName string) string {
 	var outputType string
-	if protocol == "http" {
+	if protocol == telemetryv1alpha1.OtlpProtocolHTTP {
 		outputType = "otlphttp"
 	} else {
 		outputType = "otlp"

--- a/internal/otelcollector/config/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder_test.go
@@ -11,29 +11,15 @@ import (
 )
 
 func TestExporterIDHTTP(t *testing.T) {
-	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
-		Protocol: "http",
-	}
-
-	require.Equal(t, "otlphttp/test", ExporterID(output, "test"))
+	require.Equal(t, "otlphttp/test", ExporterID("http", "test"))
 }
 
 func TestExporterIDGRPC(t *testing.T) {
-	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
-		Protocol: "grpc",
-	}
-
-	require.Equal(t, "otlp/test", ExporterID(output, "test"))
+	require.Equal(t, "otlp/test", ExporterID("grpc", "test"))
 }
 
 func TestExorterIDDefault(t *testing.T) {
-	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
-	}
-
-	require.Equal(t, "otlp/test", ExporterID(output, "test"))
+	require.Equal(t, "otlp/test", ExporterID("", "test"))
 }
 
 func TestMakeConfig(t *testing.T) {

--- a/internal/otelcollector/config/trace/gateway/config_builder.go
+++ b/internal/otelcollector/config/trace/gateway/config_builder.go
@@ -97,7 +97,7 @@ func addComponentsForTracePipeline(ctx context.Context, otlpExporterBuilder *otl
 
 	maps.Copy(envVars, otlpExporterEnvVars)
 
-	otlpExporterID := otlpexporter.ExporterID(pipeline.Spec.Output.Otlp, pipeline.Name)
+	otlpExporterID := otlpexporter.ExporterID(pipeline.Spec.Output.Otlp.Protocol, pipeline.Name)
 	cfg.Exporters[otlpExporterID] = Exporter{OTLP: otlpExporterConfig}
 
 	pipelineID := fmt.Sprintf("traces/%s", pipeline.Name)

--- a/internal/selfmonitor/flowhealth/prober_test.go
+++ b/internal/selfmonitor/flowhealth/prober_test.go
@@ -84,6 +84,22 @@ func TestProber(t *testing.T) {
 			expected: ProbeResult{Healthy: true},
 		},
 		{
+			name:         "overlapping pipeline names",
+			pipelineName: "cls",
+			alerts: promv1.AlertsResult{
+				Alerts: []promv1.Alert{
+					{
+						Labels: model.LabelSet{
+							"alertname": "TraceGatewayExporterDroppedData",
+							"exporter":  "otlp/cls-2",
+						},
+						State: promv1.AlertStateFiring,
+					},
+				},
+			},
+			expected: ProbeResult{Healthy: true},
+		},
+		{
 			name:         "flow type mismatch",
 			pipelineName: "cls",
 			alerts: promv1.AlertsResult{
@@ -107,7 +123,7 @@ func TestProber(t *testing.T) {
 					{
 						Labels: model.LabelSet{
 							"alertname": "TraceGatewayExporterDroppedData",
-							"exporter":  "otlp/cls",
+							"exporter":  "otlphttp/cls",
 						},
 						State: promv1.AlertStateFiring,
 					},

--- a/test/testkit/k8s/metric_pipeline_v1beta1.go
+++ b/test/testkit/k8s/metric_pipeline_v1beta1.go
@@ -25,7 +25,7 @@ type metricPipelineV1Beta1 struct {
 	istio           *telemetryv1beta1.MetricPipelineIstioInput
 	otlp            *telemetryv1beta1.MetricPipelineOTLPInput
 	tls             *telemetryv1beta1.OTLPTLS
-	protocol        string
+	protocol        telemetryv1beta1.OTLPProtocol
 	endpointPath    string
 }
 
@@ -169,7 +169,7 @@ func (p *metricPipelineV1Beta1) WithTLS(certs tls.Certs) *metricPipelineV1Beta1 
 	return p
 }
 
-func (p *metricPipelineV1Beta1) WithProtocol(protocol string) *metricPipelineV1Beta1 {
+func (p *metricPipelineV1Beta1) WithProtocol(protocol telemetryv1beta1.OTLPProtocol) *metricPipelineV1Beta1 {
 	p.protocol = protocol
 	return p
 }

--- a/test/testkit/k8s/trace_pipeline_v1beta1.go
+++ b/test/testkit/k8s/trace_pipeline_v1beta1.go
@@ -19,7 +19,7 @@ type tracePipelineV1Beta1 struct {
 	otlpEndpointRef *telemetryv1beta1.SecretKeyRef
 	otlpEndpoint    string
 	tls             *telemetryv1beta1.OTLPTLS
-	protocol        string
+	protocol        telemetryv1beta1.OTLPProtocol
 	endpointPath    string
 }
 
@@ -73,7 +73,7 @@ func (p *tracePipelineV1Beta1) Persistent(persistent bool) *tracePipelineV1Beta1
 	return p
 }
 
-func (p *tracePipelineV1Beta1) WithProtocol(protocol string) *tracePipelineV1Beta1 {
+func (p *tracePipelineV1Beta1) WithProtocol(protocol telemetryv1beta1.OTLPProtocol) *tracePipelineV1Beta1 {
 	p.protocol = protocol
 	return p
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Refactor the otlpexporter.ExporterID helper method
- Fix a bug resulting in reflecting a problem for one pipeline in the status of another pipeline, if their names overlap
- Match otlp/ and otlphttp/ prefixes

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/822

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->