### PR TITLE
chore: Unify Controller/Reconciler type names

### DIFF
--- a/controllers/operator/suite_test.go
+++ b/controllers/operator/suite_test.go
@@ -133,10 +133,10 @@ var _ = BeforeSuite(func() {
 	var handlerConfig overrides.HandlerConfig
 	overridesHandler := overrides.New(client, atomicLogLevel, handlerConfig)
 
-	telemetryReconciler := NewTelemetryController(client,
+	telemetryController := NewTelemetryController(client,
 		telemetry.NewReconciler(client, mgr.GetScheme(), config, overridesHandler, false),
 		config)
-	err = telemetryReconciler.SetupWithManager(mgr)
+	err = telemetryController.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/controllers/operator/suite_test.go
+++ b/controllers/operator/suite_test.go
@@ -133,7 +133,7 @@ var _ = BeforeSuite(func() {
 	var handlerConfig overrides.HandlerConfig
 	overridesHandler := overrides.New(client, atomicLogLevel, handlerConfig)
 
-	telemetryReconciler := NewTelemetryReconciler(client,
+	telemetryReconciler := NewTelemetryController(client,
 		telemetry.NewReconciler(client, mgr.GetScheme(), config, overridesHandler, false),
 		config)
 	err = telemetryReconciler.SetupWithManager(mgr)

--- a/controllers/operator/telemetry_controller.go
+++ b/controllers/operator/telemetry_controller.go
@@ -34,26 +34,26 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/telemetry"
 )
 
-type TelemetryReconciler struct {
+type TelemetryController struct {
 	client.Client
 
 	reconciler *telemetry.Reconciler
 	config     telemetry.Config
 }
 
-func NewTelemetryReconciler(client client.Client, reconciler *telemetry.Reconciler, config telemetry.Config) *TelemetryReconciler {
-	return &TelemetryReconciler{
+func NewTelemetryController(client client.Client, reconciler *telemetry.Reconciler, config telemetry.Config) *TelemetryController {
+	return &TelemetryController{
 		Client:     client,
 		reconciler: reconciler,
 		config:     config,
 	}
 }
 
-func (r *TelemetryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *TelemetryController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconciler.Reconcile(ctx, req)
 }
 
-func (r *TelemetryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *TelemetryController) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1alpha1.Telemetry{}).
 		Watches(
@@ -80,7 +80,7 @@ func (r *TelemetryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-func (r *TelemetryReconciler) mapWebhook(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *TelemetryController) mapWebhook(ctx context.Context, object client.Object) []reconcile.Request {
 	webhook, ok := object.(*admissionregistrationv1.ValidatingWebhookConfiguration)
 	if !ok {
 		logf.FromContext(ctx).Error(nil, "Unable to cast object to ValidatingWebhookConfiguration")
@@ -93,7 +93,7 @@ func (r *TelemetryReconciler) mapWebhook(ctx context.Context, object client.Obje
 	return r.createTelemetryRequests(ctx)
 }
 
-func (r *TelemetryReconciler) mapLogPipeline(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *TelemetryController) mapLogPipeline(ctx context.Context, object client.Object) []reconcile.Request {
 	logPipeline, ok := object.(*telemetryv1alpha1.LogPipeline)
 	if !ok {
 		logf.FromContext(ctx).Error(nil, "Unable to cast object to LogPipeline")
@@ -106,7 +106,7 @@ func (r *TelemetryReconciler) mapLogPipeline(ctx context.Context, object client.
 	return r.createTelemetryRequests(ctx)
 }
 
-func (r *TelemetryReconciler) mapTracePipeline(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *TelemetryController) mapTracePipeline(ctx context.Context, object client.Object) []reconcile.Request {
 	tracePipeline, ok := object.(*telemetryv1alpha1.TracePipeline)
 	if !ok {
 		logf.FromContext(ctx).Error(nil, "Unable to cast object to TracePipeline")
@@ -119,7 +119,7 @@ func (r *TelemetryReconciler) mapTracePipeline(ctx context.Context, object clien
 	return r.createTelemetryRequests(ctx)
 }
 
-func (r *TelemetryReconciler) mapMetricPipeline(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *TelemetryController) mapMetricPipeline(ctx context.Context, object client.Object) []reconcile.Request {
 	tracePipeline, ok := object.(*telemetryv1alpha1.MetricPipeline)
 	if !ok {
 		logf.FromContext(ctx).Error(nil, "Unable to cast object to MetricPipeline")
@@ -132,7 +132,7 @@ func (r *TelemetryReconciler) mapMetricPipeline(ctx context.Context, object clie
 	return r.createTelemetryRequests(ctx)
 }
 
-func (r *TelemetryReconciler) createTelemetryRequests(ctx context.Context) []reconcile.Request {
+func (r *TelemetryController) createTelemetryRequests(ctx context.Context) []reconcile.Request {
 	var telemetries operatorv1alpha1.TelemetryList
 	err := r.List(ctx, &telemetries)
 	if err != nil {

--- a/controllers/telemetry/logparser_controller.go
+++ b/controllers/telemetry/logparser_controller.go
@@ -30,27 +30,27 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/logparser"
 )
 
-// LogParserReconciler reconciles a Logparser object
-type LogParserReconciler struct {
+// LogParserController reconciles a Logparser object
+type LogParserController struct {
 	client.Client
 
 	config     logparser.Config
 	reconciler *logparser.Reconciler
 }
 
-func NewLogParserReconciler(client client.Client, reconciler *logparser.Reconciler, config logparser.Config) *LogParserReconciler {
-	return &LogParserReconciler{
+func NewLogParserController(client client.Client, reconciler *logparser.Reconciler, config logparser.Config) *LogParserController {
+	return &LogParserController{
 		Client:     client,
 		reconciler: reconciler,
 		config:     config,
 	}
 }
 
-func (r *LogParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LogParserController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconciler.Reconcile(ctx, req)
 }
 
-func (r *LogParserReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *LogParserController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1alpha1.LogParser{}).
 		Watches(

--- a/controllers/telemetry/logpipeline_controller.go
+++ b/controllers/telemetry/logpipeline_controller.go
@@ -32,28 +32,27 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/logpipeline"
 )
 
-// LogPipelineReconciler reconciles a LogPipeline object
-type LogPipelineReconciler struct {
+// LogPipelineController reconciles a LogPipeline object
+type LogPipelineController struct {
 	client.Client
 
 	reconciler *logpipeline.Reconciler
-
-	config logpipeline.Config
+	config     logpipeline.Config
 }
 
-func NewLogPipelineReconciler(client client.Client, reconciler *logpipeline.Reconciler, config logpipeline.Config) *LogPipelineReconciler {
-	return &LogPipelineReconciler{
+func NewLogPipelineController(client client.Client, reconciler *logpipeline.Reconciler, config logpipeline.Config) *LogPipelineController {
+	return &LogPipelineController{
 		Client:     client,
 		reconciler: reconciler,
 		config:     config,
 	}
 }
 
-func (r *LogPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LogPipelineController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconciler.Reconcile(ctx, req)
 }
 
-func (r *LogPipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *LogPipelineController) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr).For(&telemetryv1alpha1.LogPipeline{})
 
 	ownedResourceTypesToWatch := []client.Object{

--- a/controllers/telemetry/metricpipeline_controller.go
+++ b/controllers/telemetry/metricpipeline_controller.go
@@ -39,26 +39,26 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/metricpipeline"
 )
 
-// MetricPipelineReconciler reconciles a MetricPipeline object
-type MetricPipelineReconciler struct {
+// MetricPipelineController reconciles a MetricPipeline object
+type MetricPipelineController struct {
 	client.Client
 
 	reconciler *metricpipeline.Reconciler
 }
 
-func NewMetricPipelineReconciler(client client.Client, reconciler *metricpipeline.Reconciler) *MetricPipelineReconciler {
-	return &MetricPipelineReconciler{
+func NewMetricPipelineController(client client.Client, reconciler *metricpipeline.Reconciler) *MetricPipelineController {
+	return &MetricPipelineController{
 		Client:     client,
 		reconciler: reconciler,
 	}
 }
 
-func (r *MetricPipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MetricPipelineController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconciler.Reconcile(ctx, req)
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MetricPipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MetricPipelineController) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr).For(&telemetryv1alpha1.MetricPipeline{})
 
 	ownedResourceTypesToWatch := []client.Object{
@@ -95,7 +95,7 @@ func (r *MetricPipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	).Complete(r)
 }
 
-func (r *MetricPipelineReconciler) mapCRDChanges(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *MetricPipelineController) mapCRDChanges(ctx context.Context, object client.Object) []reconcile.Request {
 	_, ok := object.(*apiextensionsv1.CustomResourceDefinition)
 	if !ok {
 		logf.FromContext(ctx).V(1).Error(nil, "Unexpected type: expected CRD")
@@ -109,7 +109,7 @@ func (r *MetricPipelineReconciler) mapCRDChanges(ctx context.Context, object cli
 	return requests
 }
 
-func (r *MetricPipelineReconciler) mapTelemetryChanges(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *MetricPipelineController) mapTelemetryChanges(ctx context.Context, object client.Object) []reconcile.Request {
 	_, ok := object.(*operatorv1alpha1.Telemetry)
 	if !ok {
 		logf.FromContext(ctx).V(1).Error(nil, "Unexpected type: expected Telemetry")
@@ -123,7 +123,7 @@ func (r *MetricPipelineReconciler) mapTelemetryChanges(ctx context.Context, obje
 	return requests
 }
 
-func (r *MetricPipelineReconciler) createRequestsForAllPipelines(ctx context.Context) ([]reconcile.Request, error) {
+func (r *MetricPipelineController) createRequestsForAllPipelines(ctx context.Context) ([]reconcile.Request, error) {
 	var pipelines telemetryv1alpha1.MetricPipelineList
 	var requests []reconcile.Request
 	err := r.List(ctx, &pipelines)

--- a/controllers/telemetry/suite_test.go
+++ b/controllers/telemetry/suite_test.go
@@ -126,14 +126,14 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(ctx, kymaSystemNamespace)).Should(Succeed())
 
-	logpipelineController := NewLogPipelineController(
+	logPipelineController := NewLogPipelineController(
 		client,
 		logpipeline.NewReconciler(client, testLogPipelineConfig, &k8sutils.DaemonSetProber{Client: client}, overridesHandler),
 		testLogPipelineConfig)
-	err = logpipelineController.SetupWithManager(mgr)
+	err = logPipelineController.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
-	logparserReconciler := NewLogParserController(
+	logParserController := NewLogParserController(
 		client,
 		logparser.NewReconciler(
 			client,
@@ -144,20 +144,20 @@ var _ = BeforeSuite(func() {
 		),
 		testLogParserConfig,
 	)
-	err = logparserReconciler.SetupWithManager(mgr)
+	err = logParserController.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
-	tracepipelineReconciler := NewTracePipelineReconciler(
+	tracePipelineController := NewTracePipelineController(
 		client,
 		tracepipeline.NewReconciler(client, testTracePipelineReconcilerConfig, &k8sutils.DeploymentProber{Client: client}, false, nil, overridesHandler),
 	)
-	err = tracepipelineReconciler.SetupWithManager(mgr)
+	err = tracePipelineController.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
-	metricPipelineReconciler := NewMetricPipelineController(
+	metricPipelineController := NewMetricPipelineController(
 		client,
 		metricpipeline.NewReconciler(client, testMetricPipelineReconcilerConfig, &k8sutils.DeploymentProber{Client: client}, &k8sutils.DaemonSetProber{Client: client}, false, nil, overridesHandler))
-	err = metricPipelineReconciler.SetupWithManager(mgr)
+	err = metricPipelineController.SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/controllers/telemetry/suite_test.go
+++ b/controllers/telemetry/suite_test.go
@@ -126,14 +126,14 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(ctx, kymaSystemNamespace)).Should(Succeed())
 
-	logpipelineController := NewLogPipelineReconciler(
+	logpipelineController := NewLogPipelineController(
 		client,
 		logpipeline.NewReconciler(client, testLogPipelineConfig, &k8sutils.DaemonSetProber{Client: client}, overridesHandler),
 		testLogPipelineConfig)
 	err = logpipelineController.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
-	logparserReconciler := NewLogParserReconciler(
+	logparserReconciler := NewLogParserController(
 		client,
 		logparser.NewReconciler(
 			client,
@@ -154,7 +154,7 @@ var _ = BeforeSuite(func() {
 	err = tracepipelineReconciler.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
-	metricPipelineReconciler := NewMetricPipelineReconciler(
+	metricPipelineReconciler := NewMetricPipelineController(
 		client,
 		metricpipeline.NewReconciler(client, testMetricPipelineReconcilerConfig, &k8sutils.DeploymentProber{Client: client}, &k8sutils.DaemonSetProber{Client: client}, false, nil, overridesHandler))
 	err = metricPipelineReconciler.SetupWithManager(mgr)

--- a/controllers/telemetry/tracepipeline_controller.go
+++ b/controllers/telemetry/tracepipeline_controller.go
@@ -45,7 +45,7 @@ type TracePipelineController struct {
 	reconciler *tracepipeline.Reconciler
 }
 
-func NewTracePipelineReconciler(client client.Client, reconciler *tracepipeline.Reconciler) *TracePipelineController {
+func NewTracePipelineController(client client.Client, reconciler *tracepipeline.Reconciler) *TracePipelineController {
 	return &TracePipelineController{
 		Client:     client,
 		reconciler: reconciler,

--- a/controllers/telemetry/tracepipeline_controller.go
+++ b/controllers/telemetry/tracepipeline_controller.go
@@ -38,25 +38,25 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/tracepipeline"
 )
 
-// TracePipelineReconciler reconciles a TracePipeline object
-type TracePipelineReconciler struct {
+// TracePipelineController reconciles a TracePipeline object
+type TracePipelineController struct {
 	client.Client
 
 	reconciler *tracepipeline.Reconciler
 }
 
-func NewTracePipelineReconciler(client client.Client, reconciler *tracepipeline.Reconciler) *TracePipelineReconciler {
-	return &TracePipelineReconciler{
+func NewTracePipelineReconciler(client client.Client, reconciler *tracepipeline.Reconciler) *TracePipelineController {
+	return &TracePipelineController{
 		Client:     client,
 		reconciler: reconciler,
 	}
 }
 
-func (r *TracePipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *TracePipelineController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.reconciler.Reconcile(ctx, req)
 }
 
-func (r *TracePipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *TracePipelineController) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr).For(&telemetryv1alpha1.TracePipeline{})
 
 	ownedResourceTypesToWatch := []client.Object{
@@ -88,7 +88,7 @@ func (r *TracePipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	).Complete(r)
 }
 
-func (r *TracePipelineReconciler) mapTelemetryChanges(ctx context.Context, object client.Object) []reconcile.Request {
+func (r *TracePipelineController) mapTelemetryChanges(ctx context.Context, object client.Object) []reconcile.Request {
 	_, ok := object.(*operatorv1alpha1.Telemetry)
 	if !ok {
 		logf.FromContext(ctx).V(1).Error(nil, "Unexpected type: expected Telemetry")
@@ -102,7 +102,7 @@ func (r *TracePipelineReconciler) mapTelemetryChanges(ctx context.Context, objec
 	return requests
 }
 
-func (r *TracePipelineReconciler) createRequestsForAllPipelines(ctx context.Context) ([]reconcile.Request, error) {
+func (r *TracePipelineController) createRequestsForAllPipelines(ctx context.Context) ([]reconcile.Request, error) {
 	var pipelines telemetryv1alpha1.TracePipelineList
 	var requests []reconcile.Request
 	err := r.List(ctx, &pipelines)

--- a/main.go
+++ b/main.go
@@ -382,7 +382,7 @@ func main() {
 func enableTelemetryModuleController(mgr manager.Manager, webhookConfig telemetry.WebhookConfig, selfMonitorConfig telemetry.SelfMonitorConfig) {
 	setupLog.Info("Starting with telemetry manager controller")
 
-	if err := createTelemetryReconciler(mgr.GetClient(), mgr.GetScheme(), webhookConfig, selfMonitorConfig).SetupWithManager(mgr); err != nil {
+	if err := createTelemetryController(mgr.GetClient(), mgr.GetScheme(), webhookConfig, selfMonitorConfig).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Telemetry")
 		os.Exit(1)
 	}
@@ -394,12 +394,12 @@ func enableLoggingController(mgr manager.Manager) {
 	mgr.GetWebhookServer().Register("/validate-logpipeline", &webhook.Admission{Handler: createLogPipelineValidator(mgr.GetClient())})
 	mgr.GetWebhookServer().Register("/validate-logparser", &webhook.Admission{Handler: createLogParserValidator(mgr.GetClient())})
 
-	if err := createLogPipelineReconciler(mgr.GetClient()).SetupWithManager(mgr); err != nil {
+	if err := createLogPipelineController(mgr.GetClient()).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "LogPipeline")
 		os.Exit(1)
 	}
 
-	if err := createLogParserReconciler(mgr.GetClient()).SetupWithManager(mgr); err != nil {
+	if err := createLogParserController(mgr.GetClient()).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "LogParser")
 		os.Exit(1)
 	}
@@ -415,7 +415,7 @@ func enableTracingController(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
-	if err := createTracePipelineReconciler(mgr.GetClient(), flowHealthProber).SetupWithManager(mgr); err != nil {
+	if err := createTracePipelineController(mgr.GetClient(), flowHealthProber).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "TracePipeline")
 		os.Exit(1)
 	}
@@ -431,7 +431,7 @@ func enableMetricsController(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
-	if err := createMetricPipelineReconciler(mgr.GetClient(), flowHealthProber).SetupWithManager(mgr); err != nil {
+	if err := createMetricPipelineController(mgr.GetClient(), flowHealthProber).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "MetricPipeline")
 		os.Exit(1)
 	}
@@ -467,7 +467,7 @@ func validateFlags() error {
 	return nil
 }
 
-func createLogPipelineReconciler(client client.Client) *telemetrycontrollers.LogPipelineReconciler {
+func createLogPipelineController(client client.Client) *telemetrycontrollers.LogPipelineController {
 	config := logpipeline.Config{
 		SectionsConfigMap:     types.NamespacedName{Name: "telemetry-fluent-bit-sections", Namespace: telemetryNamespace},
 		FilesConfigMap:        types.NamespacedName{Name: "telemetry-fluent-bit-files", Namespace: telemetryNamespace},
@@ -490,19 +490,19 @@ func createLogPipelineReconciler(client client.Client) *telemetrycontrollers.Log
 		},
 	}
 
-	return telemetrycontrollers.NewLogPipelineReconciler(
+	return telemetrycontrollers.NewLogPipelineController(
 		client,
 		logpipeline.NewReconciler(client, config, &k8sutils.DaemonSetProber{Client: client}, overridesHandler),
 		config)
 }
 
-func createLogParserReconciler(client client.Client) *telemetrycontrollers.LogParserReconciler {
+func createLogParserController(client client.Client) *telemetrycontrollers.LogParserController {
 	config := logparser.Config{
 		ParsersConfigMap: types.NamespacedName{Name: "telemetry-fluent-bit-parsers", Namespace: telemetryNamespace},
 		DaemonSet:        types.NamespacedName{Name: fluentBitDaemonSet, Namespace: telemetryNamespace},
 	}
 
-	return telemetrycontrollers.NewLogParserReconciler(
+	return telemetrycontrollers.NewLogParserController(
 		client,
 		logparser.NewReconciler(
 			client,
@@ -533,7 +533,7 @@ func createLogParserValidator(client client.Client) *logparserwebhook.Validating
 		admission.NewDecoder(scheme))
 }
 
-func createTracePipelineReconciler(client client.Client, flowHealthProber *flowhealth.Prober) *telemetrycontrollers.TracePipelineReconciler {
+func createTracePipelineController(client client.Client, flowHealthProber *flowhealth.Prober) *telemetrycontrollers.TracePipelineController {
 	config := tracepipeline.Config{
 		Gateway: otelcollector.GatewayConfig{
 			Config: otelcollector.Config{
@@ -572,7 +572,7 @@ func createTracePipelineReconciler(client client.Client, flowHealthProber *flowh
 	)
 }
 
-func createMetricPipelineReconciler(client client.Client, flowHealthProber *flowhealth.Prober) *telemetrycontrollers.MetricPipelineReconciler {
+func createMetricPipelineController(client client.Client, flowHealthProber *flowhealth.Prober) *telemetrycontrollers.MetricPipelineController {
 	config := metricpipeline.Config{
 		Agent: otelcollector.AgentConfig{
 			Config: otelcollector.Config{
@@ -613,7 +613,7 @@ func createMetricPipelineReconciler(client client.Client, flowHealthProber *flow
 		MaxPipelines:           maxMetricPipelines,
 	}
 
-	return telemetrycontrollers.NewMetricPipelineReconciler(
+	return telemetrycontrollers.NewMetricPipelineController(
 		client,
 		metricpipeline.NewReconciler(
 			client,
@@ -664,7 +664,7 @@ func parsePlugins(s string) []string {
 	return strings.SplitN(strings.ReplaceAll(s, " ", ""), ",", len(s))
 }
 
-func createTelemetryReconciler(client client.Client, scheme *runtime.Scheme, webhookConfig telemetry.WebhookConfig, selfMonitorConfig telemetry.SelfMonitorConfig) *operator.TelemetryReconciler {
+func createTelemetryController(client client.Client, scheme *runtime.Scheme, webhookConfig telemetry.WebhookConfig, selfMonitorConfig telemetry.SelfMonitorConfig) *operator.TelemetryController {
 	config := telemetry.Config{
 		Traces: telemetry.TracesConfig{
 			OTLPServiceName: traceOTLPServiceName,
@@ -679,7 +679,7 @@ func createTelemetryReconciler(client client.Client, scheme *runtime.Scheme, web
 		SelfMonitor:            selfMonitorConfig,
 	}
 
-	return operator.NewTelemetryReconciler(client, telemetry.NewReconciler(client, scheme, config, overridesHandler, enableSelfMonitor), config)
+	return operator.NewTelemetryController(client, telemetry.NewReconciler(client, scheme, config, overridesHandler, enableSelfMonitor), config)
 }
 
 func createWebhookConfig() telemetry.WebhookConfig {

--- a/main.go
+++ b/main.go
@@ -560,7 +560,7 @@ func createTracePipelineController(client client.Client, flowHealthProber *flowh
 		MaxPipelines:           maxTracePipelines,
 	}
 
-	return telemetrycontrollers.NewTracePipelineReconciler(
+	return telemetrycontrollers.NewTracePipelineController(
 		client,
 		tracepipeline.NewReconciler(
 			client,


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

In the early stage of the project, we made a clear distinction between Controllers and Reconcilers. The Controllers were designed to establish reconciliation triggers (SetupWithManager) and to call upon Reconcilers to perform the actual reconciliation of a custom resource. Importantly, the Controllers and Reconcilers are located in separate packages.


However, a slight inconsistency arose with the use of terminology. While we applied the term 'Controller' in the context of package names, variables, and file names, the actual types were termed 'Reconcilers'. This understandably led to some confusion. To solve this issue and improve clarity, this PR is aimed at unifying the terminology.

Changes refer to particular issues, PRs or documents:

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->