### PR TITLE
fix: Suppress otel-collector warning at startup by using localhost as default

### DIFF
--- a/hack/load-tests/log-fluentbit-test-setup.yaml
+++ b/hack/load-tests/log-fluentbit-test-setup.yaml
@@ -12,7 +12,7 @@ data:
   config.yaml: |-
     receivers:
       fluentforward:
-        endpoint: 0.0.0.0:8006
+        endpoint: localhost:8006
       otlp:
         protocols:
           grpc: {}

--- a/hack/load-tests/log-fluentbit-test-setup.yaml
+++ b/hack/load-tests/log-fluentbit-test-setup.yaml
@@ -12,11 +12,13 @@ data:
   config.yaml: |-
     receivers:
       fluentforward:
-        endpoint: localhost:8006
+        endpoint: ${MY_POD_IP}:8006
       otlp:
         protocols:
-          grpc: {}
-          http: {}
+          grpc:
+            endpoint: ${MY_POD_IP}:4317
+          http:
+            endpoint: ${MY_POD_IP}:4318
     exporters:
       debug:
     service:
@@ -92,6 +94,12 @@ spec:
           volumeMounts:
             - mountPath: /etc/collector
               name: config
+          env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
         - image: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluentd:v1.16-debian-1
           imagePullPolicy: IfNotPresent
           name: fluentd

--- a/hack/load-tests/log-fluentbit-test-setup.yaml
+++ b/hack/load-tests/log-fluentbit-test-setup.yaml
@@ -12,7 +12,7 @@ data:
   config.yaml: |-
     receivers:
       fluentforward:
-        endpoint: ${MY_POD_IP}:8006
+        endpoint: localhost:8006
       otlp:
         protocols:
           grpc:

--- a/hack/load-tests/metric-agent-test-setup.yaml
+++ b/hack/load-tests/metric-agent-test-setup.yaml
@@ -74,8 +74,10 @@ data:
     receivers:
       otlp:
         protocols:
-          grpc: {}
-          http: {}
+          grpc:
+            endpoint: ${MY_POD_IP}:4317
+          http:
+            endpoint: ${MY_POD_IP}:4318
     exporters:
       debug:
 
@@ -124,6 +126,12 @@ spec:
               mountPath: /etc/collector
           args:
             - --config=/etc/collector/config.yaml
+          env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
 
 ---
 apiVersion: v1

--- a/hack/load-tests/metric-load-test-setup.yaml
+++ b/hack/load-tests/metric-load-test-setup.yaml
@@ -92,8 +92,10 @@ data:
     receivers:
       otlp:
         protocols:
-          grpc: {}
-          http: {}
+          grpc:
+            endpoint: ${MY_POD_IP}:4317
+          http:
+            endpoint: ${MY_POD_IP}:4318
     exporters:
       debug:
 
@@ -142,6 +144,12 @@ spec:
               mountPath: /etc/collector
           args:
             - --config=/etc/collector/config.yaml
+          env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
 
 ---
 apiVersion: v1

--- a/hack/load-tests/run-load-test.sh
+++ b/hack/load-tests/run-load-test.sh
@@ -16,7 +16,7 @@ BACKPRESSURE_TEST="false"
 TEST_TARGET="traces"
 TEST_NAME="No Name"
 TEST_DURATION=1200
-OTEL_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-7cd3d3a3"
+OTEL_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-79b139cb"
 
 while getopts m:b:n:t:d: flag; do
     case "$flag" in

--- a/hack/load-tests/trace-load-test-setup.yaml
+++ b/hack/load-tests/trace-load-test-setup.yaml
@@ -150,8 +150,10 @@ data:
     receivers:
       otlp:
         protocols:
-          grpc: {}
-          http: {}
+          grpc:
+            endpoint: ${MY_POD_IP}:4317
+          http:
+            endpoint: ${MY_POD_IP}:4318
     exporters:
       debug:
 
@@ -201,6 +203,12 @@ spec:
               mountPath: /etc/collector
           args:
             - --config=/etc/collector/config.yaml
+          env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
 
 ---
 apiVersion: v1

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ var (
 )
 
 const (
-	otelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-7cd3d3a3"
+	otelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-79b139cb"
 	overridesConfigMapName = "telemetry-override-config"
 	overridesConfigMapKey  = "override-config"
 	fluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.2-b5220c17"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: telemetry
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-7cd3d3a3
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-79b139cb
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.2-b5220c17
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240228-d652f6a3
 whitesource:

--- a/test/testkit/mocks/backend/config_map.go
+++ b/test/testkit/mocks/backend/config_map.go
@@ -73,7 +73,7 @@ service:
 
 const LogConfigTemplate = `receivers:
   fluentforward:
-    endpoint: 0.0.0.0:8006
+    endpoint: localhost:8006
   otlp:
     protocols:
       grpc: {}

--- a/test/testkit/mocks/backend/config_map.go
+++ b/test/testkit/mocks/backend/config_map.go
@@ -32,8 +32,10 @@ func NewConfigMap(name, namespace, path string, signalType SignalType, withTLS b
 const metricsAndTracesConfigTemplate = `receivers:
   otlp:
     protocols:
-      grpc: {}
-      http: {}
+      grpc:
+        endpoint: ${MY_POD_IP}:4317
+      http:
+        endpoint: ${MY_POD_IP}:4318
 exporters:
   file:
     path: {{ FILEPATH }}
@@ -56,7 +58,9 @@ const tlsConfigTemplate = `receivers:
           cert_pem: "{{ CERT_PEM }}"
           key_pem: "{{ KEY_PEM }}"
           client_ca_file: {{ CA_FILE_PATH }}
-      http: {}
+        endpoint: ${MY_POD_IP}:4317
+      http:
+        endpoint: ${MY_POD_IP}:4318
 exporters:
   file:
     path: {{ FILEPATH }}
@@ -73,11 +77,13 @@ service:
 
 const LogConfigTemplate = `receivers:
   fluentforward:
-    endpoint: localhost:8006
+    endpoint: ${MY_POD_IP}:8006
   otlp:
     protocols:
-      grpc: {}
-      http: {}
+      grpc:
+        endpoint: ${MY_POD_IP}:4317
+      http:
+        endpoint: ${MY_POD_IP}:4318
 exporters:
   file:
     path: {{ FILEPATH }}

--- a/test/testkit/mocks/backend/config_map.go
+++ b/test/testkit/mocks/backend/config_map.go
@@ -77,7 +77,7 @@ service:
 
 const LogConfigTemplate = `receivers:
   fluentforward:
-    endpoint: ${MY_POD_IP}:8006
+    endpoint: localhost:8006
   otlp:
     protocols:
       grpc:

--- a/test/testkit/mocks/backend/deployment.go
+++ b/test/testkit/mocks/backend/deployment.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	replicas           int32 = 1
-	otelCollectorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-79b139cb"
+	otelCollectorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-7cd3d3a3"
 	nginxImage               = "europe-docker.pkg.dev/kyma-project/prod/external/nginx:1.23.3"
 	fluentDImage             = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluentd:v1.16-debian-1"
 )

--- a/test/testkit/mocks/backend/deployment.go
+++ b/test/testkit/mocks/backend/deployment.go
@@ -90,6 +90,17 @@ func (d *Deployment) containers() []corev1.Container {
 				{Name: "config", MountPath: "/etc/collector"},
 				{Name: "data", MountPath: d.dataPath},
 			},
+			Env: []corev1.EnvVar{
+				{
+					Name: "MY_POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: "v1",
+							FieldPath:  "status.podIP",
+						},
+					},
+				},
+			},
 		},
 		{
 			Name:  "web",

--- a/test/testkit/mocks/backend/deployment.go
+++ b/test/testkit/mocks/backend/deployment.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	replicas           int32 = 1
-	otelCollectorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-7cd3d3a3"
+	otelCollectorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.96.0-79b139cb"
 	nginxImage               = "europe-docker.pkg.dev/kyma-project/prod/external/nginx:1.23.3"
 	fluentDImage             = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluentd:v1.16-debian-1"
 )


### PR DESCRIPTION
## Description

Currently a warning pops up in the startup phase of each otel-collector instance:
```json
{"level":"warn","ts":1710287522.1744921,"caller":"localhostgate/featuregate.go:63","msg":"The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.","feature gate ID":"component.UseLocalHostAsDefaultHost"}
```

Changes proposed in this pull request:

- Add feature gate to the otel-collector command to switch already to the new default in order to suppress the warning
- ...
- ...

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/third-party-images/pull/422

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->