### PR TITLE
fix: Set content-security-policy header in webhook handler

### DIFF
--- a/internal/selfmonitor/webhook/handler.go
+++ b/internal/selfmonitor/webhook/handler.go
@@ -57,6 +57,8 @@ type Alert struct {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Security-Policy", "default-src 'self'")
+
 	if r.Method != http.MethodPost {
 		h.logger.Info("Invalid method", "method", r.Method)
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/selfmonitor/webhook/handler_test.go
+++ b/internal/selfmonitor/webhook/handler_test.go
@@ -154,6 +154,8 @@ func TestHandler(t *testing.T) {
 			} else {
 				require.Empty(t, tracePipelineEvents)
 			}
+
+			require.Equal(t, rr.Header().Get("Content-Security-Policy"), "default-src 'self'")
 		})
 	}
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Set content-security-policy header in webhook handler

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->