### PR TITLE
fix: Invocation order for setting the status

### DIFF
--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -350,7 +350,7 @@ func getTLSCertValidationResult(ctx context.Context, pipeline *telemetryv1alpha1
 
 	if err != nil {
 		return cert.TLSCertValidationResult{
-			CertPresent: false,
+			CertValid: false,
 		}
 	}
 
@@ -358,7 +358,7 @@ func getTLSCertValidationResult(ctx context.Context, pipeline *telemetryv1alpha1
 
 	if err != nil {
 		return cert.TLSCertValidationResult{
-			CertPresent: false,
+			CertValid: false,
 		}
 	}
 

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -308,8 +308,6 @@ func (r *Reconciler) calculateChecksum(ctx context.Context) (string, error) {
 func getDeployableLogPipelines(ctx context.Context, allPipelines []telemetryv1alpha1.LogPipeline, client client.Client, certValidator TLSCertValidator) []telemetryv1alpha1.LogPipeline {
 	var deployablePipelines []telemetryv1alpha1.LogPipeline
 	for i := range allPipelines {
-		certValidationResult := getTLSCertValidationResult(ctx, &allPipelines[i], certValidator, client)
-
 		if !allPipelines[i].GetDeletionTimestamp().IsZero() {
 			continue
 		}
@@ -319,7 +317,7 @@ func getDeployableLogPipelines(ctx context.Context, allPipelines []telemetryv1al
 		if allPipelines[i].Spec.Output.IsLokiDefined() {
 			continue
 		}
-
+		certValidationResult := getTLSCertValidationResult(ctx, &allPipelines[i], certValidator, client)
 		if !certValidationResult.CertValid || !certValidationResult.PrivateKeyValid || time.Now().After(certValidationResult.Validity) {
 			continue
 		}

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -350,7 +350,7 @@ func getTLSCertValidationResult(ctx context.Context, pipeline *telemetryv1alpha1
 
 	if err != nil {
 		return cert.TLSCertValidationResult{
-			CertValid: false,
+			CertPresent: false,
 		}
 	}
 
@@ -358,7 +358,7 @@ func getTLSCertValidationResult(ctx context.Context, pipeline *telemetryv1alpha1
 
 	if err != nil {
 		return cert.TLSCertValidationResult{
-			PrivateKeyValid: false,
+			CertPresent: false,
 		}
 	}
 

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -358,7 +358,7 @@ func getTLSCertValidationResult(ctx context.Context, pipeline *telemetryv1alpha1
 
 	if err != nil {
 		return cert.TLSCertValidationResult{
-			CertValid: false,
+			PrivateKeyValid: false,
 		}
 	}
 

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -99,7 +99,9 @@ func (r *Reconciler) setFluentBitConfigGeneratedCondition(ctx context.Context, p
 	certValidationResult := getTLSCertValidationResult(ctx, pipeline, r.tlsCertValidator, r.Client)
 	message := conditions.MessageForLogPipeline(reason)
 
-	// The order with checking TLS and the checking ReferenceSecretExists needs to be maintained. As if the TLS Cert does not exist then checking TLS Cert will
+	// The order with checking TLS and the checking ReferenceSecretExists needs to be maintained. If the TLS Cert
+	// does not exist then checking TLS Cert will set a message saying CertIsInvalid which would be overridden by
+	// ReferenceSecretNot found.
 	if !certValidationResult.CertValid {
 		status = metav1.ConditionFalse
 		reason = conditions.ReasonTLSCertificateInvalid

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -96,7 +96,6 @@ func (r *Reconciler) setAgentHealthyCondition(ctx context.Context, pipeline *tel
 func (r *Reconciler) setFluentBitConfigGeneratedCondition(ctx context.Context, pipeline *telemetryv1alpha1.LogPipeline) {
 	status := metav1.ConditionTrue
 	reason := conditions.ReasonConfigurationGenerated
-	certValidationResult := getTLSCertValidationResult(ctx, pipeline, r.tlsCertValidator, r.Client)
 	if secretref.ReferencesNonExistentSecret(ctx, r.Client, pipeline) {
 		status = metav1.ConditionFalse
 		reason = conditions.ReasonReferencedSecretMissing
@@ -108,6 +107,7 @@ func (r *Reconciler) setFluentBitConfigGeneratedCondition(ctx context.Context, p
 	}
 
 	message := conditions.MessageForLogPipeline(reason)
+	certValidationResult := getTLSCertValidationResult(ctx, pipeline, r.tlsCertValidator, r.Client)
 
 	if !certValidationResult.CertValid {
 		status = metav1.ConditionFalse

--- a/internal/tls/cert/tls_cert_validator.go
+++ b/internal/tls/cert/tls_cert_validator.go
@@ -19,14 +19,12 @@ type TLSCertValidationResult struct {
 	PrivateKeyValid             bool
 	PrivateKeyValidationMessage string
 	Validity                    time.Time
-	CertPresent                 bool
 }
 
 func (tcv *TLSCertValidator) ValidateCertificate(certPEM []byte, keyPEM []byte) TLSCertValidationResult {
 	result := TLSCertValidationResult{
 		CertValid:       true,
 		PrivateKeyValid: true,
-		CertPresent:     false,
 		Validity:        time.Now().Add(time.Hour * 24 * 365),
 	}
 

--- a/internal/tls/cert/tls_cert_validator.go
+++ b/internal/tls/cert/tls_cert_validator.go
@@ -19,12 +19,14 @@ type TLSCertValidationResult struct {
 	PrivateKeyValid             bool
 	PrivateKeyValidationMessage string
 	Validity                    time.Time
+	CertPresent                 bool
 }
 
 func (tcv *TLSCertValidator) ValidateCertificate(certPEM []byte, keyPEM []byte) TLSCertValidationResult {
 	result := TLSCertValidationResult{
 		CertValid:       true,
 		PrivateKeyValid: true,
+		CertPresent:     false,
 		Validity:        time.Now().Add(time.Hour * 24 * 365),
 	}
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Currently if the secret is missing for TLS Cert, we still check if cert is valid or not. Thus overriding the status `ReferenceSecretMissing`. 


Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->