### PR TITLE
fix: Flakiness in the logppipeline tests

### DIFF
--- a/test/e2e/logs_basic_v1alpha1_test.go
+++ b/test/e2e/logs_basic_v1alpha1_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Logs Basic v1alpha1", Label("logs"), Ordered, func() {
 		mockBackendName = "log-receiver"
 		mockNs          = "log-http-output"
 		logProducerName = "log-producer-http-output" //#nosec G101 -- This is a false positive
-		pipelineName    = "http-output-pipeline"
+		pipelineName    = "http-output-pipeline-alpha1"
 	)
 	var telemetryExportURL string
 

--- a/test/e2e/logs_basic_v1beta1_test.go
+++ b/test/e2e/logs_basic_v1beta1_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Logs Basic v1beta1", Label("logs", "v1beta1"), Ordered, func()
 		mockBackendName = "log-receiver"
 		mockNs          = "logs-basic-v1beta1-test"
 		logProducerName = "log-producer-http-output" //#nosec G101 -- This is a false positive
-		pipelineName    = "http-output-pipeline"
+		pipelineName    = "http-output-pipeline-beta1"
 	)
 	var telemetryExportURL string
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Sometimes the logpipeline test fails with error that "object is being deleted: logpipelines.telemetry.kyma-project.io "http-output-pipeline" already exists". The pipeline name is same for alpha1 and beta1 tests so use different pipeline names.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->