### PR TITLE
test: Add e2e test for LogPipeline health condition

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -261,3 +261,23 @@ jobs:
         if: success() || failure()
         with:
           failure: failure()
+
+  e2e-self-monitor-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Prepare Test
+        uses: "./.github/template/prepare-test"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests
+        run: bin/ginkgo run --tags e2e --label-filter="self-mon-logs" test/e2e
+
+      - name: Finalize Test
+        uses: "./.github/template/finalize-test"
+        if: success() || failure()
+        with:
+          failure: failure()

--- a/test/e2e/logs_self_monitor_basic_test.go
+++ b/test/e2e/logs_self_monitor_basic_test.go
@@ -1,0 +1,94 @@
+//go:build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/conditions"
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
+)
+
+var _ = Describe("Logs Self Monitor", Label("logs"), Ordered, func() {
+	const (
+		mockBackendName = "log-receiver-selfmon"
+		mockNs          = "log-http-output-selfmon-test"
+		logProducerName = "log-producer-http-output-selfmon" //#nosec G101 -- This is a false positive
+		pipelineName    = "http-output-pipeline-selfmon"
+	)
+	var telemetryExportURL string
+
+	makeResources := func() []client.Object {
+		var objs []client.Object
+		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
+
+		mockBackend := backend.New(mockBackendName, mockNs, backend.SignalTypeLogs, backend.WithPersistentHostSecret(isOperational()))
+		mockLogProducer := loggen.New(logProducerName, mockNs)
+		objs = append(objs, mockBackend.K8sObjects()...)
+		objs = append(objs, mockLogProducer.K8sObject(kitk8s.WithLabel("app", "logging-test")))
+		telemetryExportURL = mockBackend.TelemetryExportURL(proxyClient)
+
+		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
+			WithSecretKeyRef(mockBackend.HostSecretRefV1Alpha1()).
+			WithHTTPOutput().
+			Persistent(isOperational())
+		objs = append(objs, logPipeline.K8sObject())
+
+		return objs
+	}
+
+	Context("Before deploying a logpipeline", func() {
+		It("Should have a healthy webhook", func() {
+			verifiers.WebhookShouldBeHealthy(ctx, k8sClient)
+		})
+	})
+
+	Context("When a logpipeline exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeResources()
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+		})
+
+		It("Should have a running logpipeline", Label(operationalTest), func() {
+			verifiers.LogPipelineShouldBeHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have a running self-monitor", func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, kitkyma.SelfMonitorName)
+		})
+
+		It("Should have a log backend running", Label(operationalTest), func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: mockBackendName})
+		})
+
+		It("Should have a log producer running", Label(operationalTest), func() {
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+		})
+
+		It("Should have produced logs in the backend", Label(operationalTest), func() {
+			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, telemetryExportURL)
+		})
+
+		It("Should have TypeFlowHealthy condition set to True", func() {
+			Eventually(func(g Gomega) {
+				var pipeline telemetryv1alpha1.LogPipeline
+				key := types.NamespacedName{Name: pipelineName}
+				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeFlowHealthy)).To(BeTrue())
+			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/logs_self_monitor_basic_test.go
+++ b/test/e2e/logs_self_monitor_basic_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/verifiers"
 )
 
-var _ = Describe("Logs Self Monitor", Label("logs"), Ordered, func() {
+var _ = Describe("Logs Self Monitor", Label("self-mon-logs"), Ordered, func() {
 	const (
 		mockBackendName = "log-receiver-selfmon"
 		mockNs          = "log-http-output-selfmon-test"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add e2e test for LogPipeline health condition

Changes refer to particular issues, PRs or documents:

- #917

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->