### PR TITLE
chore: Bump images for 1.13.1 release

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ### Default Environment Variables
 ## General
 ENV_ENVTEST_K8S_VERSION=1.27.1 # ENVTEST_K8S_VERSION refers to the version of Kubebuilder assets to be downloaded by envtest binary.
-ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.13.0 # Image URL to use all building/pushing image targets
+ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.13.1 # Image URL to use all building/pushing image targets
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.27

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: 1.13.0
+  newTag: 1.13.1

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: telemetry
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.13.0
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.13.1
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.97.0-cccde9ac
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.2-b5220c17
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240404-fd3588ce


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump the manager image according to https://github.com/kyma-project/telemetry-manager/blob/main/docs/contributor/releasing.md

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->