### PR TITLE
chore: Enable more linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,7 +48,6 @@ linters:
     - paralleltest
     - perfsprint
     - prealloc
-    - predeclared
     - protogetter
     - tagliatelle
     - testifylint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,6 @@ linters:
     - thelper
     - tparallel
     - varnamelen
-    - wastedassign
     - whitespace
     - wrapcheck
     - wsl

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,7 +19,6 @@ linters:
     - varcheck
   # Linters to be enabled after fixing the issues
     - intrange
-    - copyloopvar
     - cyclop
     - depguard
     - errname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,6 @@ linters:
     - intrange
     - cyclop
     - depguard
-    - errorlint
     - exhaustive
     - exhaustruct
     - forcetypeassert

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,7 +21,6 @@ linters:
     - intrange
     - cyclop
     - depguard
-    - errname
     - errorlint
     - exhaustive
     - exhaustruct

--- a/apis/telemetry/v1alpha1/secret_refs_test.go
+++ b/apis/telemetry/v1alpha1/secret_refs_test.go
@@ -156,14 +156,14 @@ func TestLogPipeline_GetSecretRefs(t *testing.T) {
 func TestTracePipeline_GetSecretRefs(t *testing.T) {
 	tests := []struct {
 		name         string
-		given        OtlpOutput
+		given        *OtlpOutput
 		pipelineName string
 		expected     []SecretKeyRef
 	}{
 		{
 			name:         "only endpoint",
 			pipelineName: "test-pipeline",
-			given: OtlpOutput{
+			given: &OtlpOutput{
 				Endpoint: ValueType{
 					Value: "",
 					ValueFrom: &ValueFromSource{
@@ -181,7 +181,7 @@ func TestTracePipeline_GetSecretRefs(t *testing.T) {
 		{
 			name:         "basic auth and header",
 			pipelineName: "test-pipeline",
-			given: OtlpOutput{
+			given: &OtlpOutput{
 				Authentication: &AuthenticationOptions{
 					Basic: &BasicAuthOptions{
 						User: ValueType{
@@ -229,9 +229,8 @@ func TestTracePipeline_GetSecretRefs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			sut := TracePipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: TracePipelineSpec{Output: TracePipelineOutput{Otlp: &test.given}}}
+			sut := TracePipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: TracePipelineSpec{Output: TracePipelineOutput{Otlp: test.given}}}
 			actual := sut.GetSecretRefs()
 			require.ElementsMatch(t, test.expected, actual)
 		})
@@ -241,14 +240,14 @@ func TestTracePipeline_GetSecretRefs(t *testing.T) {
 func TestMetricPipeline_GetSecretRefs(t *testing.T) {
 	tests := []struct {
 		name         string
-		given        OtlpOutput
+		given        *OtlpOutput
 		pipelineName string
 		expected     []SecretKeyRef
 	}{
 		{
 			name:         "only endpoint",
 			pipelineName: "test-pipeline",
-			given: OtlpOutput{
+			given: &OtlpOutput{
 				Endpoint: ValueType{
 					Value: "",
 					ValueFrom: &ValueFromSource{
@@ -266,7 +265,7 @@ func TestMetricPipeline_GetSecretRefs(t *testing.T) {
 		{
 			name:         "basic auth and",
 			pipelineName: "test-pipeline",
-			given: OtlpOutput{
+			given: &OtlpOutput{
 				Authentication: &AuthenticationOptions{
 					Basic: &BasicAuthOptions{
 						User: ValueType{
@@ -314,9 +313,8 @@ func TestMetricPipeline_GetSecretRefs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			sut := MetricPipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: MetricPipelineSpec{Output: MetricPipelineOutput{Otlp: &test.given}}}
+			sut := MetricPipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: MetricPipelineSpec{Output: MetricPipelineOutput{Otlp: test.given}}}
 			actual := sut.GetSecretRefs()
 			require.ElementsMatch(t, test.expected, actual)
 		})

--- a/apis/telemetry/v1beta1/secret_refs_test.go
+++ b/apis/telemetry/v1beta1/secret_refs_test.go
@@ -156,14 +156,14 @@ func TestLogPipeline_GetSecretRefs(t *testing.T) {
 func TestTracePipeline_GetSecretRefs(t *testing.T) {
 	tests := []struct {
 		name         string
-		given        OTLPOutput
+		given        *OTLPOutput
 		pipelineName string
 		expected     []SecretKeyRef
 	}{
 		{
 			name:         "only endpoint",
 			pipelineName: "test-pipeline",
-			given: OTLPOutput{
+			given: &OTLPOutput{
 				Endpoint: ValueType{
 					Value: "",
 					ValueFrom: &ValueFromSource{
@@ -181,7 +181,7 @@ func TestTracePipeline_GetSecretRefs(t *testing.T) {
 		{
 			name:         "basic auth and header",
 			pipelineName: "test-pipeline",
-			given: OTLPOutput{
+			given: &OTLPOutput{
 				Authentication: &AuthenticationOptions{
 					Basic: &BasicAuthOptions{
 						User: ValueType{
@@ -229,9 +229,8 @@ func TestTracePipeline_GetSecretRefs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			sut := TracePipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: TracePipelineSpec{Output: TracePipelineOutput{OTLP: &test.given}}}
+			sut := TracePipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: TracePipelineSpec{Output: TracePipelineOutput{OTLP: test.given}}}
 			actual := sut.GetSecretRefs()
 			require.ElementsMatch(t, test.expected, actual)
 		})
@@ -241,14 +240,14 @@ func TestTracePipeline_GetSecretRefs(t *testing.T) {
 func TestMetricPipeline_GetSecretRefs(t *testing.T) {
 	tests := []struct {
 		name         string
-		given        OTLPOutput
+		given        *OTLPOutput
 		pipelineName string
 		expected     []SecretKeyRef
 	}{
 		{
 			name:         "only endpoint",
 			pipelineName: "test-pipeline",
-			given: OTLPOutput{
+			given: &OTLPOutput{
 				Endpoint: ValueType{
 					Value: "",
 					ValueFrom: &ValueFromSource{
@@ -266,7 +265,7 @@ func TestMetricPipeline_GetSecretRefs(t *testing.T) {
 		{
 			name:         "basic auth and",
 			pipelineName: "test-pipeline",
-			given: OTLPOutput{
+			given: &OTLPOutput{
 				Authentication: &AuthenticationOptions{
 					Basic: &BasicAuthOptions{
 						User: ValueType{
@@ -314,9 +313,8 @@ func TestMetricPipeline_GetSecretRefs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
-			sut := MetricPipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: MetricPipelineSpec{Output: MetricPipelineOutput{OTLP: &test.given}}}
+			sut := MetricPipeline{ObjectMeta: metav1.ObjectMeta{Name: test.pipelineName}, Spec: MetricPipelineSpec{Output: MetricPipelineOutput{OTLP: test.given}}}
 			actual := sut.GetSecretRefs()
 			require.ElementsMatch(t, test.expected, actual)
 		})

--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -570,7 +570,7 @@ func validateKeyExistsInFluentbitSectionsConf(ctx context.Context, key string) e
 	err := k8sClient.Get(ctx, configMapLookupKey, &fluentBitCm)
 	if err != nil {
 
-		return fmt.Errorf("could not get configmap: %s: %s", configMapLookupKey.Name, err)
+		return fmt.Errorf("could not get configmap: %s: %w", configMapLookupKey.Name, err)
 	}
 	if _, ok := fluentBitCm.Data[key]; !ok {
 		return fmt.Errorf("did not find the key: %s", key)

--- a/controllers/telemetry/logpipeline_controller_test.go
+++ b/controllers/telemetry/logpipeline_controller_test.go
@@ -466,7 +466,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
 			},
 		}
 
-		var expectedKeyNotFoundError = errors.New("did not find the key: missing-secret-ref-logpipeline.conf")
+		var errExpectedKeyNotFound = errors.New("did not find the key: missing-secret-ref-logpipeline.conf")
 
 		It("Creates a healthy LogPipeline", func() {
 			Expect(k8sClient.Create(ctx, healthyLogPipeline)).Should(Succeed())
@@ -485,7 +485,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
 		It("Should not include the LogPipeline with missing secret in fluent-bit-sections configmap", func() {
 			Consistently(func() error {
 				return validateKeyExistsInFluentbitSectionsConf(ctx, "missing-secret-ref-logpipeline.conf")
-			}, timeout, interval).Should(Equal(expectedKeyNotFoundError))
+			}, timeout, interval).Should(Equal(errExpectedKeyNotFound))
 		})
 
 		It("Should update fluent-bit-sections configmap when secret is created", func() {
@@ -499,7 +499,7 @@ var _ = Describe("LogPipeline controller", Ordered, func() {
 			Expect(k8sClient.Delete(ctx, pipelineSecret)).Should(Succeed())
 			Eventually(func() error {
 				return validateKeyExistsInFluentbitSectionsConf(ctx, "missing-secret-ref-logpipeline.conf")
-			}, timeout, interval).Should(Equal(expectedKeyNotFoundError))
+			}, timeout, interval).Should(Equal(errExpectedKeyNotFound))
 		})
 
 	})

--- a/internal/k8sutils/daemonset.go
+++ b/internal/k8sutils/daemonset.go
@@ -25,7 +25,7 @@ func (dsp *DaemonSetProber) IsReady(ctx context.Context, name types.NamespacedNa
 			log.V(1).Info("DaemonSet is not yet created")
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get %s/%s DaemonSet: %v", name.Namespace, name.Name, err)
+		return false, fmt.Errorf("failed to get %s/%s DaemonSet: %w", name.Namespace, name.Name, err)
 	}
 
 	generation := ds.Generation
@@ -44,7 +44,7 @@ type DaemonSetAnnotator struct {
 func (dsa *DaemonSetAnnotator) SetAnnotation(ctx context.Context, name types.NamespacedName, key, value string) error {
 	var ds appsv1.DaemonSet
 	if err := dsa.Get(ctx, name, &ds); err != nil {
-		return fmt.Errorf("failed to get %s/%s DaemonSet: %v", name.Namespace, name.Name, err)
+		return fmt.Errorf("failed to get %s/%s DaemonSet: %w", name.Namespace, name.Name, err)
 	}
 
 	patchedDS := *ds.DeepCopy()
@@ -57,7 +57,7 @@ func (dsa *DaemonSetAnnotator) SetAnnotation(ctx context.Context, name types.Nam
 	patchedDS.Spec.Template.ObjectMeta.Annotations[key] = value
 
 	if err := dsa.Patch(ctx, &patchedDS, client.MergeFrom(&ds)); err != nil {
-		return fmt.Errorf("failed to patch %s/%s DaemonSet: %v", name.Namespace, name.Name, err)
+		return fmt.Errorf("failed to patch %s/%s DaemonSet: %w", name.Namespace, name.Name, err)
 	}
 
 	return nil

--- a/internal/k8sutils/daemonset_test.go
+++ b/internal/k8sutils/daemonset_test.go
@@ -29,8 +29,7 @@ func TestDaemonSetProber(t *testing.T) {
 		{summary: "generation mismatch", observedGeneration: 1, desiredGeneration: 2, expected: false},
 	}
 
-	for _, test := range tests {
-		tc := test
+	for _, tc := range tests {
 		t.Run(tc.summary, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/k8sutils/deployment.go
+++ b/internal/k8sutils/deployment.go
@@ -21,7 +21,7 @@ type DeploymentProber struct {
 func (dp *DeploymentProber) IsReady(ctx context.Context, name types.NamespacedName) (bool, error) {
 	var d appsv1.Deployment
 	if err := dp.Get(ctx, name, &d); err != nil {
-		return false, fmt.Errorf("failed to get %s/%s Deployment: %v", name.Namespace, name.Name, err)
+		return false, fmt.Errorf("failed to get %s/%s Deployment: %w", name.Namespace, name.Name, err)
 	}
 
 	desiredReplicas := *d.Spec.Replicas
@@ -32,11 +32,11 @@ func (dp *DeploymentProber) IsReady(ctx context.Context, name types.NamespacedNa
 		Namespace:     d.Namespace,
 	}
 	if err := dp.List(ctx, &allReplicaSets, listOps); err != nil {
-		return false, fmt.Errorf("failed to list ReplicaSets: %v", err)
+		return false, fmt.Errorf("failed to list ReplicaSets: %w", err)
 	}
 
 	if err := dp.Get(ctx, name, &d); err != nil {
-		return false, fmt.Errorf("failed to get %s/%s ReplicaSet for deployment: %v", name.Namespace, name.Name, err)
+		return false, fmt.Errorf("failed to get %s/%s ReplicaSet for deployment: %w", name.Namespace, name.Name, err)
 	}
 
 	replicaSet := getLatestReplicaSet(&d, &allReplicaSets)

--- a/internal/k8sutils/deployment_test.go
+++ b/internal/k8sutils/deployment_test.go
@@ -8,24 +8,24 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestDeploymentProber_IsReady(t *testing.T) {
 	tests := []struct {
 		summary          string
-		desiredScheduled int32
+		desiredScheduled *int32
 		numberReady      int32
 		expected         bool
 	}{
-		{summary: "all scheduled all ready", desiredScheduled: 1, numberReady: 1, expected: true},
-		{summary: "all scheduled one ready", desiredScheduled: 2, numberReady: 1, expected: false},
-		{summary: "all scheduled zero ready", desiredScheduled: 1, numberReady: 0, expected: false},
+		{summary: "all scheduled all ready", desiredScheduled: ptr.To(int32(1)), numberReady: 1, expected: true},
+		{summary: "all scheduled one ready", desiredScheduled: ptr.To(int32(2)), numberReady: 1, expected: false},
+		{summary: "all scheduled zero ready", desiredScheduled: ptr.To(int32(1)), numberReady: 0, expected: false},
 	}
 
 	for _, test := range tests {
-		tc := test
-		t.Run(tc.summary, func(t *testing.T) {
+		t.Run(test.summary, func(t *testing.T) {
 
 			t.Parallel()
 
@@ -35,11 +35,11 @@ func TestDeploymentProber_IsReady(t *testing.T) {
 			deployment := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "telemetry-system"},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &tc.desiredScheduled,
+					Replicas: test.desiredScheduled,
 					Selector: &metav1.LabelSelector{MatchLabels: matchLabels},
 				},
 				Status: appsv1.DeploymentStatus{
-					ReadyReplicas: tc.numberReady,
+					ReadyReplicas: test.numberReady,
 				},
 			}
 
@@ -52,12 +52,12 @@ func TestDeploymentProber_IsReady(t *testing.T) {
 				},
 				Spec: appsv1.ReplicaSetSpec{
 					Selector: deployment.Spec.Selector,
-					Replicas: &tc.desiredScheduled,
+					Replicas: test.desiredScheduled,
 					Template: deployment.Spec.Template,
 				},
 				Status: appsv1.ReplicaSetStatus{
-					ReadyReplicas: tc.numberReady,
-					Replicas:      tc.numberReady,
+					ReadyReplicas: test.numberReady,
+					Replicas:      test.numberReady,
 				},
 			}
 
@@ -74,7 +74,7 @@ func TestDeploymentProber_IsReady(t *testing.T) {
 			ready, err := sut.IsReady(context.Background(), types.NamespacedName{Name: "foo", Namespace: "telemetry-system"})
 
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, ready)
+			require.Equal(t, test.expected, ready)
 
 		})
 	}

--- a/internal/k8sutils/utils.go
+++ b/internal/k8sutils/utils.go
@@ -255,12 +255,12 @@ func CreateOrUpdateValidatingWebhookConfiguration(ctx context.Context, c client.
 	return c.Update(ctx, desired)
 }
 
-func mergeMetadata(new *metav1.ObjectMeta, old metav1.ObjectMeta) {
-	new.ResourceVersion = old.ResourceVersion
+func mergeMetadata(newMeta *metav1.ObjectMeta, oldMeta metav1.ObjectMeta) {
+	newMeta.ResourceVersion = oldMeta.ResourceVersion
 
-	new.SetLabels(mergeMaps(new.Labels, old.Labels))
-	new.SetAnnotations(mergeMaps(new.Annotations, old.Annotations))
-	new.SetOwnerReferences(mergeOwnerReferences(new.OwnerReferences, old.OwnerReferences))
+	newMeta.SetLabels(mergeMaps(newMeta.Labels, oldMeta.Labels))
+	newMeta.SetAnnotations(mergeMaps(newMeta.Annotations, oldMeta.Annotations))
+	newMeta.SetOwnerReferences(mergeOwnerReferences(newMeta.OwnerReferences, oldMeta.OwnerReferences))
 }
 
 func ownerSliceContains(owners []metav1.OwnerReference, owner metav1.OwnerReference) bool {
@@ -286,14 +286,14 @@ func mergeOwnerReferences(newOwners []metav1.OwnerReference, oldOwners []metav1.
 	return merged
 }
 
-func mergeMaps(new map[string]string, old map[string]string) map[string]string {
-	return mergeMapsByPrefix(new, old, "")
+func mergeMaps(newMap map[string]string, oldMap map[string]string) map[string]string {
+	return mergeMapsByPrefix(newMap, oldMap, "")
 }
 
-func mergePodAnnotations(new *metav1.ObjectMeta, old metav1.ObjectMeta) {
-	new.SetAnnotations(mergeMapsByPrefix(new.Annotations, old.Annotations, "kubectl.kubernetes.io/"))
-	new.SetAnnotations(mergeMapsByPrefix(new.Annotations, old.Annotations, "checksum/"))
-	new.SetAnnotations(mergeMapsByPrefix(new.Annotations, old.Annotations, "istio-operator.kyma-project.io/restartedAt"))
+func mergePodAnnotations(newMeta *metav1.ObjectMeta, oldMeta metav1.ObjectMeta) {
+	newMeta.SetAnnotations(mergeMapsByPrefix(newMeta.Annotations, oldMeta.Annotations, "kubectl.kubernetes.io/"))
+	newMeta.SetAnnotations(mergeMapsByPrefix(newMeta.Annotations, oldMeta.Annotations, "checksum/"))
+	newMeta.SetAnnotations(mergeMapsByPrefix(newMeta.Annotations, oldMeta.Annotations, "istio-operator.kyma-project.io/restartedAt"))
 }
 
 func mergeMapsByPrefix(newMap map[string]string, oldMap map[string]string, prefix string) map[string]string {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -13,7 +13,7 @@ type Logger struct {
 	zapLogger *zap.SugaredLogger
 }
 
-// New returns a newLogger logger with the given format and level.
+// New returns a logger with the given format and level.
 func New(atomicLevel zap.AtomicLevel) (*Logger, error) {
 	log := newWithAtomicLevel(atomicLevel)
 	level := atomicLevel.Level()

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -13,7 +13,7 @@ type Logger struct {
 	zapLogger *zap.SugaredLogger
 }
 
-// New returns a new logger with the given format and level.
+// New returns a newLogger logger with the given format and level.
 func New(atomicLevel zap.AtomicLevel) (*Logger, error) {
 	log := newWithAtomicLevel(atomicLevel)
 	level := atomicLevel.Level()
@@ -35,10 +35,10 @@ This function creates logger structure based on given format, atomicLevel and ad
 AtomicLevel structure allows to change level dynamically
 */
 func newWithAtomicLevel(atomicLevel zap.AtomicLevel, additionalCores ...zapcore.Core) *Logger {
-	return new(atomicLevel, additionalCores...)
+	return newLogger(atomicLevel, additionalCores...)
 }
 
-func new(levelEnabler zapcore.LevelEnabler, additionalCores ...zapcore.Core) *Logger {
+func newLogger(levelEnabler zapcore.LevelEnabler, additionalCores ...zapcore.Core) *Logger {
 	encoder := getZapEncoder()
 
 	defaultCore := zapcore.NewCore(
@@ -47,6 +47,7 @@ func new(levelEnabler zapcore.LevelEnabler, additionalCores ...zapcore.Core) *Lo
 		levelEnabler,
 	)
 	cores := append(additionalCores, defaultCore)
+
 	return &Logger{zap.New(zapcore.NewTee(cores...), zap.AddCaller()).Sugar()}
 }
 

--- a/internal/otelcollector/config/otlpexporter/config_builder.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder.go
@@ -39,7 +39,7 @@ func NewConfigBuilder(reader client.Reader, otlpOutput *telemetryv1alpha1.OtlpOu
 func (cb *ConfigBuilder) MakeConfig(ctx context.Context) (*config.OTLPExporter, EnvVars, error) {
 	envVars, err := makeEnvVars(ctx, cb.reader, cb.otlpOutput, cb.pipelineName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to make env vars: %v", err)
+		return nil, nil, fmt.Errorf("failed to make env vars: %w", err)
 	}
 
 	exportersConfig := makeExportersConfig(cb.otlpOutput, cb.pipelineName, envVars, cb.queueSize, cb.signalType)

--- a/internal/reconciler/logparser/reconciler.go
+++ b/internal/reconciler/logparser/reconciler.go
@@ -96,9 +96,9 @@ func (r *Reconciler) doReconcile(ctx context.Context, parser *telemetryv1alpha1.
 	defer func() {
 		if statusErr := r.updateStatus(ctx, parser.Name); statusErr != nil {
 			if err != nil {
-				err = fmt.Errorf("failed while updating status: %v: %v", statusErr, err)
+				err = fmt.Errorf("failed while updating status: %w: %w", statusErr, err)
 			} else {
-				err = fmt.Errorf("failed to update status: %v", statusErr)
+				err = fmt.Errorf("failed to update status: %w", statusErr)
 			}
 		}
 	}()
@@ -130,7 +130,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, parser *telemetryv1alpha1.
 func (r *Reconciler) calculateConfigChecksum(ctx context.Context) (string, error) {
 	var cm corev1.ConfigMap
 	if err := r.Get(ctx, r.config.ParsersConfigMap, &cm); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.ParsersConfigMap.Namespace, r.config.ParsersConfigMap.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", r.config.ParsersConfigMap.Namespace, r.config.ParsersConfigMap.Name, err)
 	}
 	return configchecksum.Calculate([]corev1.ConfigMap{cm}, nil), nil
 }

--- a/internal/reconciler/logparser/status.go
+++ b/internal/reconciler/logparser/status.go
@@ -21,7 +21,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, parserName string) error 
 			return nil
 		}
 
-		return fmt.Errorf("failed to get LogParser: %v", err)
+		return fmt.Errorf("failed to get LogParser: %w", err)
 	}
 
 	if parser.DeletionTimestamp != nil {

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -146,9 +146,9 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	defer func() {
 		if statusErr := r.updateStatus(ctx, pipeline.Name); statusErr != nil {
 			if err != nil {
-				err = fmt.Errorf("failed while updating status: %v: %v", statusErr, err)
+				err = fmt.Errorf("failed while updating status: %w: %w", statusErr, err)
 			} else {
-				err = fmt.Errorf("failed to update status: %v", statusErr)
+				err = fmt.Errorf("failed to update status: %w", statusErr)
 			}
 		}
 	}()
@@ -283,37 +283,37 @@ func isUnsupported(pipeline *telemetryv1alpha1.LogPipeline) bool {
 func (r *Reconciler) calculateChecksum(ctx context.Context) (string, error) {
 	var baseCm corev1.ConfigMap
 	if err := r.Get(ctx, r.config.DaemonSet, &baseCm); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.DaemonSet.Namespace, r.config.DaemonSet.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", r.config.DaemonSet.Namespace, r.config.DaemonSet.Name, err)
 	}
 
 	var parsersCm corev1.ConfigMap
 	if err := r.Get(ctx, r.config.ParsersConfigMap, &parsersCm); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.ParsersConfigMap.Namespace, r.config.ParsersConfigMap.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", r.config.ParsersConfigMap.Namespace, r.config.ParsersConfigMap.Name, err)
 	}
 
 	var luaCm corev1.ConfigMap
 	if err := r.Get(ctx, r.config.LuaConfigMap, &luaCm); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.LuaConfigMap.Namespace, r.config.LuaConfigMap.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", r.config.LuaConfigMap.Namespace, r.config.LuaConfigMap.Name, err)
 	}
 
 	var sectionsCm corev1.ConfigMap
 	if err := r.Get(ctx, r.config.SectionsConfigMap, &sectionsCm); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.SectionsConfigMap.Namespace, r.config.SectionsConfigMap.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", r.config.SectionsConfigMap.Namespace, r.config.SectionsConfigMap.Name, err)
 	}
 
 	var filesCm corev1.ConfigMap
 	if err := r.Get(ctx, r.config.FilesConfigMap, &filesCm); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %v", r.config.FilesConfigMap.Namespace, r.config.FilesConfigMap.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s ConfigMap: %w", r.config.FilesConfigMap.Namespace, r.config.FilesConfigMap.Name, err)
 	}
 
 	var envSecret corev1.Secret
 	if err := r.Get(ctx, r.config.EnvSecret, &envSecret); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s Secret: %v", r.config.EnvSecret.Namespace, r.config.EnvSecret.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s Secret: %w", r.config.EnvSecret.Namespace, r.config.EnvSecret.Name, err)
 	}
 
 	var tlsSecret corev1.Secret
 	if err := r.Get(ctx, r.config.OutputTLSConfigSecret, &tlsSecret); err != nil {
-		return "", fmt.Errorf("failed to get %s/%s Secret: %v", r.config.OutputTLSConfigSecret.Namespace, r.config.OutputTLSConfigSecret.Name, err)
+		return "", fmt.Errorf("failed to get %s/%s Secret: %w", r.config.OutputTLSConfigSecret.Namespace, r.config.OutputTLSConfigSecret.Name, err)
 	}
 
 	return configchecksum.Calculate([]corev1.ConfigMap{baseCm, parsersCm, luaCm, sectionsCm, filesCm}, []corev1.Secret{envSecret, tlsSecret}), nil

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -27,7 +27,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string) erro
 			return nil
 		}
 
-		return fmt.Errorf("failed to get LogPipeline: %v", err)
+		return fmt.Errorf("failed to get LogPipeline: %w", err)
 	}
 
 	if pipeline.DeletionTimestamp != nil {
@@ -67,7 +67,7 @@ func (r *Reconciler) updateStatusUnsupportedMode(ctx context.Context, pipeline *
 	if pipeline.Status.UnsupportedMode != desiredUnsupportedMode {
 		pipeline.Status.UnsupportedMode = desiredUnsupportedMode
 		if err := r.Status().Update(ctx, pipeline); err != nil {
-			return fmt.Errorf("failed to update LogPipeline unsupported mode status: %v", err)
+			return fmt.Errorf("failed to update LogPipeline unsupported mode status: %w", err)
 		}
 	}
 
@@ -126,7 +126,7 @@ func (r *Reconciler) setFluentBitConfigGeneratedCondition(ctx context.Context, p
 		message = fmt.Sprintf(conditions.MessageForLogPipeline(reason), certValidationResult.Validity.Format(time.DateOnly))
 	}
 
-	//ensure not expired and about to expire
+	// ensure not expired and about to expire
 	validUntil := time.Until(certValidationResult.Validity)
 	if validUntil > 0 && validUntil <= twoWeeks {
 		status = metav1.ConditionTrue

--- a/internal/reconciler/logpipeline/sync.go
+++ b/internal/reconciler/logpipeline/sync.go
@@ -26,11 +26,11 @@ func (s *syncer) syncFluentBitConfig(ctx context.Context, pipeline *telemetryv1a
 	log := logf.FromContext(ctx)
 
 	if err := s.syncSectionsConfigMap(ctx, pipeline, deployableLogPipelines); err != nil {
-		return fmt.Errorf("failed to sync sections: %v", err)
+		return fmt.Errorf("failed to sync sections: %w", err)
 	}
 
 	if err := s.syncFilesConfigMap(ctx, pipeline); err != nil {
-		return fmt.Errorf("failed to sync mounted files: %v", err)
+		return fmt.Errorf("failed to sync mounted files: %w", err)
 	}
 
 	if err := s.syncEnvSecret(ctx, deployableLogPipelines); err != nil {

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -105,9 +105,9 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	defer func() {
 		if statusErr := r.updateStatus(ctx, pipeline.Name, lockAcquired); statusErr != nil {
 			if err != nil {
-				err = fmt.Errorf("failed while updating status: %v: %v", statusErr, err)
+				err = fmt.Errorf("failed while updating status: %w: %w", statusErr, err)
 			} else {
-				err = fmt.Errorf("failed to update status: %v", statusErr)
+				err = fmt.Errorf("failed to update status: %w", statusErr)
 			}
 		}
 	}()

--- a/internal/reconciler/telemetry/status.go
+++ b/internal/reconciler/telemetry/status.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -72,7 +73,7 @@ func (r *Reconciler) updateOverallState(ctx context.Context, telemetry *operator
 
 	// Since LogPipeline, MetricPipeline, and TracePipeline have status conditions with positive polarity,
 	// we can assume that the Telemetry Module is in the 'Ready' state if all conditions of dependent resources have the status 'True',
-	//with the exception being the imminent expiration of the configured TLS certificate.
+	// with the exception being the imminent expiration of the configured TLS certificate.
 	if slices.ContainsFunc(telemetry.Status.Conditions, func(cond metav1.Condition) bool {
 		return cond.Status == metav1.ConditionFalse || cond.Reason == conditions.ReasonTLSCertificateAboutToExpire
 	}) {
@@ -142,10 +143,7 @@ func (r *Reconciler) dependentCRsFound(ctx context.Context) bool {
 func (r *Reconciler) resourcesExist(ctx context.Context, list client.ObjectList) bool {
 	if err := r.List(ctx, list); err != nil {
 		// no kind found
-		if _, ok := err.(*meta.NoKindMatchError); ok {
-			return false
-		}
-		return true
+		return errors.Is(err, &meta.NoKindMatchError{})
 	}
 	return meta.LenList(list) > 0
 }

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -111,9 +111,9 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 	defer func() {
 		if statusErr := r.updateStatus(ctx, pipeline.Name, lockAcquired); statusErr != nil {
 			if err != nil {
-				err = fmt.Errorf("failed while updating status: %v: %v", statusErr, err)
+				err = fmt.Errorf("failed while updating status: %w: %w", statusErr, err)
 			} else {
-				err = fmt.Errorf("failed to update status: %v", statusErr)
+				err = fmt.Errorf("failed to update status: %w", statusErr)
 			}
 		}
 	}()

--- a/internal/reconciler/tracepipeline/status.go
+++ b/internal/reconciler/tracepipeline/status.go
@@ -24,7 +24,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, with
 			return nil
 		}
 
-		return fmt.Errorf("failed to get TracePipeline: %v", err)
+		return fmt.Errorf("failed to get TracePipeline: %w", err)
 	}
 
 	if pipeline.DeletionTimestamp != nil {

--- a/internal/resources/otelcollector/config.go
+++ b/internal/resources/otelcollector/config.go
@@ -90,9 +90,9 @@ type AgentConfig struct {
 }
 
 func (cfg *AgentConfig) WithCollectorConfig(collectorCfgYAML string) *AgentConfig {
-	copy := *cfg
-	copy.CollectorConfig = collectorCfgYAML
-	return &copy
+	cp := *cfg
+	cp.CollectorConfig = collectorCfgYAML
+	return &cp
 }
 
 type DaemonSetConfig struct {

--- a/internal/selfmonitor/config/config_builder.go
+++ b/internal/selfmonitor/config/config_builder.go
@@ -94,7 +94,7 @@ func makeScrapeConfig(scrapeNamespace string) []ScrapeConfig {
 				{
 					SourceLabels: []string{"__name__"},
 					Action:       Keep,
-					Regex:        srapableMetricsRegex(),
+					Regex:        scrapableMetricsRegex(),
 				},
 				// The following relabel configs add an artificial pipeline_name label to the Fluent Bit and OTel Collector metrics to simplify pipeline matching
 				// For Fluent Bit metrics, the pipeline_name is based on the name label. Note that a regex group matching Kubernetes resource names (alphanumerical chars and hyphens) is used to extract the pipeline name.
@@ -121,7 +121,7 @@ func makeScrapeConfig(scrapeNamespace string) []ScrapeConfig {
 	}
 }
 
-func srapableMetricsRegex() string {
+func scrapableMetricsRegex() string {
 	fluentBitMetrics := []string{
 		metricFluentBitOutputProcBytesTotal,
 		metricFluentBitOutputDroppedRecordsTotal,

--- a/internal/webhookcert/ca_cert_provider.go
+++ b/internal/webhookcert/ca_cert_provider.go
@@ -44,7 +44,7 @@ func newCACertProvider(client client.Client) *caCertProviderImpl {
 
 func (p *caCertProviderImpl) provideCert(ctx context.Context, caSecretName types.NamespacedName) ([]byte, []byte, error) {
 	var caSecret corev1.Secret
-	shouldCreateNew := false
+	var shouldCreateNew bool
 	if err := p.client.Get(ctx, caSecretName, &caSecret); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, nil, fmt.Errorf("failed to find ca cert caSecretName: %w", err)

--- a/internal/webhookcert/server_cert_provider.go
+++ b/internal/webhookcert/server_cert_provider.go
@@ -47,7 +47,7 @@ func (p *serverCertProviderImpl) provideCert(ctx context.Context, config serverC
 	var err error
 	var serverCertPEM, serverKeyPEM []byte
 	serverCertPEM, serverKeyPEM, err = p.storage.load()
-	shouldCreateNew := false
+	var shouldCreateNew bool
 	if err != nil || len(serverCertPEM) == 0 || len(serverKeyPEM) == 0 {
 		shouldCreateNew = true
 	} else {
@@ -71,10 +71,7 @@ func (p *serverCertProviderImpl) provideCert(ctx context.Context, config serverC
 }
 
 func (p *serverCertProviderImpl) checkServerCert(ctx context.Context, serverCertPEM, caCertPEM []byte) bool {
-	var err error
-	certValid := false
-
-	certValid, err = p.expiryChecker.checkExpiry(ctx, serverCertPEM)
+	certValid, err := p.expiryChecker.checkExpiry(ctx, serverCertPEM)
 	if err != nil || !certValid {
 		return false
 	}

--- a/test/testkit/k8s/objects.go
+++ b/test/testkit/k8s/objects.go
@@ -73,9 +73,9 @@ func labelMatches(labels Labels, label, value string) bool {
 	return l == value
 }
 
-func versionsMatch(new, existing client.Object) bool {
-	newVersion := new.GetLabels()[VersionLabelName]
-	existingVersion, ok := existing.GetLabels()[VersionLabelName]
+func versionsMatch(newObj, existingObj client.Object) bool {
+	newVersion := newObj.GetLabels()[VersionLabelName]
+	existingVersion, ok := existingObj.GetLabels()[VersionLabelName]
 	if !ok {
 		return true
 	}

--- a/test/testkit/matchers/log/log_matchers.go
+++ b/test/testkit/matchers/log/log_matchers.go
@@ -18,7 +18,7 @@ func WithLds(matcher types.GomegaMatcher) types.GomegaMatcher {
 
 		lds, err := unmarshalLogs(jsonlLogs)
 		if err != nil {
-			return nil, fmt.Errorf("WithLds requires a valid OTLP JSON document: %v", err)
+			return nil, fmt.Errorf("WithLds requires a valid OTLP JSON document: %w", err)
 		}
 
 		return lds, nil

--- a/test/testkit/matchers/metric/metric_matchers.go
+++ b/test/testkit/matchers/metric/metric_matchers.go
@@ -12,7 +12,7 @@ func WithMds(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return gomega.WithTransform(func(jsonlMetrics []byte) ([]pmetric.Metrics, error) {
 		mds, err := unmarshalMetrics(jsonlMetrics)
 		if err != nil {
-			return nil, fmt.Errorf("WithMds requires a valid OTLP JSON document: %v", err)
+			return nil, fmt.Errorf("WithMds requires a valid OTLP JSON document: %w", err)
 		}
 
 		return mds, nil

--- a/test/testkit/matchers/trace/trace_matchers.go
+++ b/test/testkit/matchers/trace/trace_matchers.go
@@ -13,7 +13,7 @@ func WithTds(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return gomega.WithTransform(func(jsonlTraces []byte) ([]ptrace.Traces, error) {
 		tds, err := unmarshalTraces(jsonlTraces)
 		if err != nil {
-			return nil, fmt.Errorf("WithTds requires a valid OTLP JSON document: %v", err)
+			return nil, fmt.Errorf("WithTds requires a valid OTLP JSON document: %w", err)
 		}
 
 		return tds, nil

--- a/test/testkit/matchers/unmarshal.go
+++ b/test/testkit/matchers/unmarshal.go
@@ -19,18 +19,18 @@ func UnmarshalSignals[T plog.Logs | pmetric.Metrics | ptrace.Traces](jsonlSignal
 	for {
 		line, readerErr := reader.ReadBytes('\n')
 		if readerErr != nil && readerErr != io.EOF {
-			return nil, fmt.Errorf("failed to read line: %v", readerErr)
+			return nil, fmt.Errorf("failed to read line: %w", readerErr)
 		}
 
 		if len(line) > 0 {
 			signals, err := unmarshal(line)
 			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal logs: %v", readerErr)
+				return nil, fmt.Errorf("failed to unmarshal logs: %w", readerErr)
 			}
 			allSignals = append(allSignals, signals)
 		}
 
-		//check the io.EOF error after checking the line since both can be returned simultaneously
+		// check the io.EOF error after checking the line since both can be returned simultaneously
 		if readerErr == io.EOF {
 			break
 		}

--- a/test/testkit/mocks/backend/backend.go
+++ b/test/testkit/mocks/backend/backend.go
@@ -78,7 +78,7 @@ func (b *Backend) buildResources() {
 		backendDNSName := fmt.Sprintf("%s.%s.svc.cluster.local", b.name, b.namespace)
 		certs, err := tls.GenerateTLSCerts(backendDNSName)
 		if err != nil {
-			panic(fmt.Errorf("could not generate TLS certs: %v", err))
+			panic(fmt.Errorf("could not generate TLS certs: %w", err))
 		}
 		b.TLSCerts = certs
 	}


### PR DESCRIPTION

## Description

Changes proposed in this pull request (what was done and why):

- enable predeclared linter
- enable copyloopvar linter
- enable wastedassign linter
- enable errname linter
- enable errorlint linter

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/114

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
