### PR TITLE
feat: Reflect LogPipeline flow health status in the Telemetry status

### DIFF
--- a/internal/reconciler/telemetry/log_components_checker.go
+++ b/internal/reconciler/telemetry/log_components_checker.go
@@ -14,7 +14,8 @@ import (
 )
 
 type logComponentsChecker struct {
-	client client.Client
+	client                   client.Client
+	flowHealthProbingEnabled bool
 }
 
 func (l *logComponentsChecker) Check(ctx context.Context, telemetryInDeletion bool) (*metav1.Condition, error) {
@@ -65,6 +66,7 @@ func (l *logComponentsChecker) firstUnhealthyPipelineReason(pipelines []telemetr
 	condTypes := []string{
 		conditions.TypeAgentHealthy,
 		conditions.TypeConfigurationGenerated,
+		conditions.TypeFlowHealthy,
 	}
 	for _, condType := range condTypes {
 		for _, pipeline := range pipelines {

--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -80,7 +80,7 @@ func NewReconciler(client client.Client, scheme *runtime.Scheme, config Config, 
 		Scheme: scheme,
 		config: config,
 		healthCheckers: healthCheckers{
-			logs:    &logComponentsChecker{client: client},
+			logs:    &logComponentsChecker{client: client, flowHealthProbingEnabled: flowHealthProbingEnabled},
 			traces:  &traceComponentsChecker{client: client, flowHealthProbingEnabled: flowHealthProbingEnabled},
 			metrics: &metricComponentsChecker{client: client, flowHealthProbingEnabled: flowHealthProbingEnabled},
 		},

--- a/internal/selfmonitor/config/expr_builder.go
+++ b/internal/selfmonitor/config/expr_builder.go
@@ -20,6 +20,17 @@ func selectService(serviceName string) labelSelector {
 	}
 }
 
+func instant(metric string, selectors ...labelSelector) *exprBuilder {
+	for _, s := range selectors {
+		metric = s(metric)
+	}
+
+	eb := &exprBuilder{
+		expr: metric,
+	}
+	return eb
+}
+
 func rate(metric string, selectors ...labelSelector) *exprBuilder {
 	for _, s := range selectors {
 		metric = s(metric)

--- a/internal/selfmonitor/config/fluent_bit_rule_builder.go
+++ b/internal/selfmonitor/config/fluent_bit_rule_builder.go
@@ -1,16 +1,16 @@
 package config
 
-import (
-	"fmt"
-)
-
 const (
-	fluentBitMetricsServiceName = "telemetry-fluent-bit-metrics"
+	fluentBitMetricsServiceName        = "telemetry-fluent-bit-metrics"
+	fluentBitSidecarMetricsServiceName = "telemetry-fluent-bit-exporter-metrics"
 
 	metricFluentBitOutputProcBytesTotal      = "fluentbit_output_proc_bytes_total"
 	metricFluentBitInputBytesTotal           = "fluentbit_input_bytes_total"
 	metricFluentBitOutputDroppedRecordsTotal = "fluentbit_output_dropped_records_total"
 	metricFluentBitBufferUsageBytes          = "telemetry_fsbuffer_usage_bytes"
+
+	bufferUsage300MB = 300000000
+	bufferUsage900MB = 900000000
 )
 
 type fluentBitRuleBuilder struct {
@@ -59,14 +59,18 @@ func (rb fluentBitRuleBuilder) exporterDroppedRule() Rule {
 func (rb fluentBitRuleBuilder) bufferInUseRule() Rule {
 	return Rule{
 		Alert: rb.namePrefix() + RuleNameLogAgentBufferInUse,
-		Expr:  fmt.Sprintf("%s > 300000000", metricFluentBitBufferUsageBytes),
+		Expr: instant(metricFluentBitBufferUsageBytes).
+			greaterThan(bufferUsage300MB).
+			build(),
 	}
 }
 
 func (rb fluentBitRuleBuilder) bufferFullRule() Rule {
 	return Rule{
 		Alert: rb.namePrefix() + RuleNameLogAgentBufferFull,
-		Expr:  fmt.Sprintf("%s > 900000000", metricFluentBitBufferUsageBytes),
+		Expr: instant(metricFluentBitBufferUsageBytes).
+			greaterThan(bufferUsage900MB).
+			build(),
 	}
 }
 

--- a/internal/selfmonitor/config/fluent_bit_rule_builder.go
+++ b/internal/selfmonitor/config/fluent_bit_rule_builder.go
@@ -59,7 +59,7 @@ func (rb fluentBitRuleBuilder) exporterDroppedRule() Rule {
 func (rb fluentBitRuleBuilder) bufferInUseRule() Rule {
 	return Rule{
 		Alert: rb.namePrefix() + RuleNameLogAgentBufferInUse,
-		Expr: instant(metricFluentBitBufferUsageBytes).
+		Expr: instant(metricFluentBitBufferUsageBytes, selectService(fluentBitSidecarMetricsServiceName)).
 			greaterThan(bufferUsage300MB).
 			build(),
 	}
@@ -68,7 +68,7 @@ func (rb fluentBitRuleBuilder) bufferInUseRule() Rule {
 func (rb fluentBitRuleBuilder) bufferFullRule() Rule {
 	return Rule{
 		Alert: rb.namePrefix() + RuleNameLogAgentBufferFull,
-		Expr: instant(metricFluentBitBufferUsageBytes).
+		Expr: instant(metricFluentBitBufferUsageBytes, selectService(fluentBitSidecarMetricsServiceName)).
 			greaterThan(bufferUsage900MB).
 			build(),
 	}

--- a/internal/selfmonitor/config/rules_test.go
+++ b/internal/selfmonitor/config/rules_test.go
@@ -55,10 +55,10 @@ func TestMakeRules(t *testing.T) {
 	require.Equal(t, "sum by (pipeline_name) (rate(fluentbit_output_dropped_records_total{service=\"telemetry-fluent-bit-metrics\"}[5m])) > 0", ruleGroup.Rules[12].Expr)
 
 	require.Equal(t, "LogAgentBufferInUse", ruleGroup.Rules[13].Alert)
-	require.Equal(t, "telemetry_fsbuffer_usage_bytes > 300000000", ruleGroup.Rules[13].Expr)
+	require.Equal(t, "telemetry_fsbuffer_usage_bytes{service=\"telemetry-fluent-bit-exporter-metrics\"} > 300000000", ruleGroup.Rules[13].Expr)
 
 	require.Equal(t, "LogAgentBufferFull", ruleGroup.Rules[14].Alert)
-	require.Equal(t, "telemetry_fsbuffer_usage_bytes > 900000000", ruleGroup.Rules[14].Expr)
+	require.Equal(t, "telemetry_fsbuffer_usage_bytes{service=\"telemetry-fluent-bit-exporter-metrics\"} > 900000000", ruleGroup.Rules[14].Expr)
 }
 
 func TestMatchesLogPipelineRule(t *testing.T) {

--- a/internal/selfmonitor/prober/common.go
+++ b/internal/selfmonitor/prober/common.go
@@ -55,9 +55,9 @@ func retrieveAlerts(ctx context.Context, getter alertGetter) ([]promv1.Alert, er
 	return result.Alerts, nil
 }
 
-func evaluateRuleWithMatcher(alerts []promv1.Alert, alertName, pipelineName string, mf matcherFunc) bool {
+func isFiringWithMatcher(alerts []promv1.Alert, ruleName, pipelineName string, mf matcherFunc) bool {
 	for _, alert := range alerts {
-		if alert.State == promv1.AlertStateFiring && mf(toRawLabels(alert.Labels), alertName, pipelineName) {
+		if alert.State == promv1.AlertStateFiring && mf(toRawLabels(alert.Labels), ruleName, pipelineName) {
 			return true
 		}
 	}

--- a/internal/selfmonitor/prober/log_pipeline_prober.go
+++ b/internal/selfmonitor/prober/log_pipeline_prober.go
@@ -50,41 +50,41 @@ func (p *LogPipelineProber) Probe(ctx context.Context, pipelineName string) (Log
 }
 
 func (p *LogPipelineProber) allDataDropped(alerts []promv1.Alert, pipelineName string) bool {
-	exporterSentLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
-	exporterDroppedLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterDroppedLogs, pipelineName)
-	bufferFull := p.evaluateRule(alerts, config.RuleNameLogAgentBufferFull, pipelineName)
+	exporterSentLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
+	exporterDroppedLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterDroppedLogs, pipelineName)
+	bufferFull := p.isFiring(alerts, config.RuleNameLogAgentBufferFull, pipelineName)
 	return !exporterSentLogs && (exporterDroppedLogs || bufferFull)
 }
 
 func (p *LogPipelineProber) someDataDropped(alerts []promv1.Alert, pipelineName string) bool {
-	exporterSentLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
-	exporterDroppedLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterDroppedLogs, pipelineName)
-	bufferFull := p.evaluateRule(alerts, config.RuleNameLogAgentBufferFull, pipelineName)
+	exporterSentLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
+	exporterDroppedLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterDroppedLogs, pipelineName)
+	bufferFull := p.isFiring(alerts, config.RuleNameLogAgentBufferFull, pipelineName)
 	return exporterSentLogs && (exporterDroppedLogs || bufferFull)
 }
 
 func (p *LogPipelineProber) noLogsDelivered(alerts []promv1.Alert, pipelineName string) bool {
-	receiverReadLogs := p.evaluateRule(alerts, config.RuleNameLogAgentReceiverReadLogs, pipelineName)
-	exporterSentLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
+	receiverReadLogs := p.isFiring(alerts, config.RuleNameLogAgentReceiverReadLogs, pipelineName)
+	exporterSentLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
 	return receiverReadLogs && !exporterSentLogs
 }
 
 func (p *LogPipelineProber) bufferFillingUp(alerts []promv1.Alert, pipelineName string) bool {
-	return p.evaluateRule(alerts, config.RuleNameLogAgentBufferInUse, pipelineName)
+	return p.isFiring(alerts, config.RuleNameLogAgentBufferInUse, pipelineName)
 }
 
 func (p *LogPipelineProber) healthy(alerts []promv1.Alert, pipelineName string) bool {
 	// The pipeline is healthy if none of the following conditions are met:
-	bufferInUse := p.evaluateRule(alerts, config.RuleNameLogAgentBufferInUse, pipelineName)
-	bufferFull := p.evaluateRule(alerts, config.RuleNameLogAgentBufferFull, pipelineName)
-	exporterDroppedLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterDroppedLogs, pipelineName)
+	bufferInUse := p.isFiring(alerts, config.RuleNameLogAgentBufferInUse, pipelineName)
+	bufferFull := p.isFiring(alerts, config.RuleNameLogAgentBufferFull, pipelineName)
+	exporterDroppedLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterDroppedLogs, pipelineName)
 
 	// The pipeline is healthy if either no logs are being read or all logs are being sent
-	receiverReadLogs := p.evaluateRule(alerts, config.RuleNameLogAgentReceiverReadLogs, pipelineName)
-	exporterSentLogs := p.evaluateRule(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
+	receiverReadLogs := p.isFiring(alerts, config.RuleNameLogAgentReceiverReadLogs, pipelineName)
+	exporterSentLogs := p.isFiring(alerts, config.RuleNameLogAgentExporterSentLogs, pipelineName)
 	return !(bufferInUse || bufferFull || exporterDroppedLogs) && (!receiverReadLogs || exporterSentLogs)
 }
 
-func (p *LogPipelineProber) evaluateRule(alerts []promv1.Alert, alertName, pipelineName string) bool {
-	return evaluateRuleWithMatcher(alerts, alertName, pipelineName, config.MatchesLogPipelineRule)
+func (p *LogPipelineProber) isFiring(alerts []promv1.Alert, ruleName, pipelineName string) bool {
+	return isFiringWithMatcher(alerts, ruleName, pipelineName, config.MatchesLogPipelineRule)
 }

--- a/internal/selfmonitor/prober/otel_pipeline_prober.go
+++ b/internal/selfmonitor/prober/otel_pipeline_prober.go
@@ -61,36 +61,36 @@ func (p *OTelPipelineProber) Probe(ctx context.Context, pipelineName string) (OT
 }
 
 func (p *OTelPipelineProber) allDataDropped(alerts []promv1.Alert, pipelineName string) bool {
-	exporterSentFiring := p.evaluateRule(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
-	exporterDroppedFiring := p.evaluateRule(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
-	exporterEnqueueFailedFiring := p.evaluateRule(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
+	exporterSentFiring := p.isFiring(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
+	exporterDroppedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
+	exporterEnqueueFailedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
 
 	return !exporterSentFiring && (exporterDroppedFiring || exporterEnqueueFailedFiring)
 }
 
 func (p *OTelPipelineProber) someDataDropped(alerts []promv1.Alert, pipelineName string) bool {
-	exporterSentFiring := p.evaluateRule(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
-	exporterDroppedFiring := p.evaluateRule(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
-	exporterEnqueueFailedFiring := p.evaluateRule(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
+	exporterSentFiring := p.isFiring(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
+	exporterDroppedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
+	exporterEnqueueFailedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
 
 	return exporterSentFiring && (exporterDroppedFiring || exporterEnqueueFailedFiring)
 }
 
 func (p *OTelPipelineProber) queueAlmostFull(alerts []promv1.Alert, pipelineName string) bool {
-	return p.evaluateRule(alerts, config.RuleNameGatewayExporterQueueAlmostFull, pipelineName)
+	return p.isFiring(alerts, config.RuleNameGatewayExporterQueueAlmostFull, pipelineName)
 }
 
 func (p *OTelPipelineProber) throttling(alerts []promv1.Alert, pipelineName string) bool {
-	return p.evaluateRule(alerts, config.RuleNameGatewayReceiverRefusedData, pipelineName)
+	return p.isFiring(alerts, config.RuleNameGatewayReceiverRefusedData, pipelineName)
 }
 
 func (p *OTelPipelineProber) healthy(alerts []promv1.Alert, pipelineName string) bool {
-	return !(p.evaluateRule(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName) ||
-		p.evaluateRule(alerts, config.RuleNameGatewayExporterQueueAlmostFull, pipelineName) ||
-		p.evaluateRule(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName) ||
-		p.evaluateRule(alerts, config.RuleNameGatewayReceiverRefusedData, pipelineName))
+	return !(p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName) ||
+		p.isFiring(alerts, config.RuleNameGatewayExporterQueueAlmostFull, pipelineName) ||
+		p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName) ||
+		p.isFiring(alerts, config.RuleNameGatewayReceiverRefusedData, pipelineName))
 }
 
-func (p *OTelPipelineProber) evaluateRule(alerts []promv1.Alert, alertName, pipelineName string) bool {
-	return evaluateRuleWithMatcher(alerts, alertName, pipelineName, p.matcher)
+func (p *OTelPipelineProber) isFiring(alerts []promv1.Alert, alertName, pipelineName string) bool {
+	return isFiringWithMatcher(alerts, alertName, pipelineName, p.matcher)
 }

--- a/internal/selfmonitor/prober/otel_pipeline_prober.go
+++ b/internal/selfmonitor/prober/otel_pipeline_prober.go
@@ -61,19 +61,19 @@ func (p *OTelPipelineProber) Probe(ctx context.Context, pipelineName string) (OT
 }
 
 func (p *OTelPipelineProber) allDataDropped(alerts []promv1.Alert, pipelineName string) bool {
-	exporterSentFiring := p.isFiring(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
-	exporterDroppedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
-	exporterEnqueueFailedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
+	exporterSentData := p.isFiring(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
+	exporterDroppedData := p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
+	exporterEnqueueFailed := p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
 
-	return !exporterSentFiring && (exporterDroppedFiring || exporterEnqueueFailedFiring)
+	return !exporterSentData && (exporterDroppedData || exporterEnqueueFailed)
 }
 
 func (p *OTelPipelineProber) someDataDropped(alerts []promv1.Alert, pipelineName string) bool {
-	exporterSentFiring := p.isFiring(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
-	exporterDroppedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
-	exporterEnqueueFailedFiring := p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
+	exporterSentData := p.isFiring(alerts, config.RuleNameGatewayExporterSentData, pipelineName)
+	exporterDroppedData := p.isFiring(alerts, config.RuleNameGatewayExporterDroppedData, pipelineName)
+	exporterEnqueueFailed := p.isFiring(alerts, config.RuleNameGatewayExporterEnqueueFailed, pipelineName)
 
-	return exporterSentFiring && (exporterDroppedFiring || exporterEnqueueFailedFiring)
+	return exporterSentData && (exporterDroppedData || exporterEnqueueFailed)
 }
 
 func (p *OTelPipelineProber) queueAlmostFull(alerts []promv1.Alert, pipelineName string) bool {
@@ -91,6 +91,6 @@ func (p *OTelPipelineProber) healthy(alerts []promv1.Alert, pipelineName string)
 		p.isFiring(alerts, config.RuleNameGatewayReceiverRefusedData, pipelineName))
 }
 
-func (p *OTelPipelineProber) isFiring(alerts []promv1.Alert, alertName, pipelineName string) bool {
-	return isFiringWithMatcher(alerts, alertName, pipelineName, p.matcher)
+func (p *OTelPipelineProber) isFiring(alerts []promv1.Alert, ruleName, pipelineName string) bool {
+	return isFiringWithMatcher(alerts, ruleName, pipelineName, p.matcher)
 }

--- a/internal/selfmonitor/webhook/handler.go
+++ b/internal/selfmonitor/webhook/handler.go
@@ -92,6 +92,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer r.Body.Close()
 
 	var alerts []Alert
 	if unmarshallErr := json.Unmarshal(alertsYAML, &alerts); unmarshallErr != nil {
@@ -99,8 +100,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-
-	defer r.Body.Close()
 
 	metricPipelineEvents := h.toMetricPipelineReconcileEvents(r.Context(), alerts)
 	tracePipelineEvents := h.toTracePipelineReconcileEvents(r.Context(), alerts)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):
- Reflect LogPipeline flow health status in the Telemetry status

Also, the following improvement after a discussion with @k15r 
- Fix a potentially leaky connection in the self-monitor webhook handler
- Extend expression builder to improve FB buffer usage rules readability
- Improve variable and func names

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/917

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->