### PR TITLE
feat: Adjusted the FlowHealthy status condition messages

### DIFF
--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -143,7 +143,7 @@ Reflecting the trace data flow in the status condition is currently under develo
 | Condition Status | Condition Reason  | Condition Message                                                                       |
 |------------------|-------------------|-----------------------------------------------------------------------------------------|
 | True             | FlowHealthy       | No problems detected in the trace flow                                                  |
-| False            | GatewayThrottling | Trace gateway experiencing high influx: unable to receive traces at the current rate |
+| False            | GatewayThrottling | Trace gateway experiencing high influx: unable to receive traces at the current rate    |
 | False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                    |
 | False            | SomeDataDropped   | Some traces dropped: backend unreachable or rejecting                                   |
 | False            | AllDataDropped    | All traces dropped: backend unreachable or rejecting                                    |
@@ -167,7 +167,7 @@ Reflecting the metric data flow in the status condition is currently under devel
 | Condition Status | Condition Reason  | Condition Message                                                                        |
 |------------------|-------------------|------------------------------------------------------------------------------------------|
 | True             | FlowHealthy       | No problems detected in the metric flow                                                  |
-| False            | GatewayThrottling | Metric gateway experiencing high influx: unable to receive metrics at the current rate |
+| False            | GatewayThrottling | Metric gateway experiencing high influx: unable to receive metrics at the current rate   |
 | False            | BufferFillingUp   | Buffer nearing capacity: incoming metric rate exceeds the export rate                    |
 | False            | SomeDataDropped   | Some metrics dropped: backend unreachable or rejecting                                   |
 | False            | AllDataDropped    | All metrics dropped: backend unreachable or rejecting                                    |

--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -143,7 +143,7 @@ Reflecting the trace data flow in the status condition is currently under develo
 | Condition Status | Condition Reason  | Condition Message                                                                       |
 |------------------|-------------------|-----------------------------------------------------------------------------------------|
 | True             | FlowHealthy       | No problems detected in the trace flow                                                  |
-| False            | GatewayThrottling | Trace collector experiencing high influx: Unable to receive metrics at the current rate |
+| False            | GatewayThrottling | Trace gateway experiencing high influx: unable to receive metrics at the current rate |
 | False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                    |
 | False            | SomeDataDropped   | Some traces dropped: backend unreachable or rejecting                                   |
 | False            | AllDataDropped    | All traces dropped: backend unreachable or rejecting                                    |
@@ -167,7 +167,7 @@ Reflecting the metric data flow in the status condition is currently under devel
 | Condition Status | Condition Reason  | Condition Message                                                                        |
 |------------------|-------------------|------------------------------------------------------------------------------------------|
 | True             | FlowHealthy       | No problems detected in the metric flow                                                  |
-| False            | GatewayThrottling | Metric collector experiencing high influx: Unable to receive metrics at the current rate |
+| False            | GatewayThrottling | Metric gateway experiencing high influx: unable to receive metrics at the current rate |
 | False            | BufferFillingUp   | Buffer nearing capacity: incoming metric rate exceeds the export rate                    |
 | False            | SomeDataDropped   | Some metrics dropped: backend unreachable or rejecting                                   |
 | False            | AllDataDropped    | All metrics dropped: backend unreachable or rejecting                                    |

--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -115,6 +115,16 @@ The state of the log components is determined by the status condition of type `L
 | False            | ResourceBlocksDeletion             | The deletion of the module is blocked. To unblock the deletion, delete the following resources: LogPipelines (resource-1, resource-2,...), LogParsers (resource-1, resource-2,...)                                                                        |
 | False            | UnsupportedLokiOutput              | The grafana-loki output is not supported anymore. For integration with a custom Loki installation, use the `custom` output and follow [Installing a custom Loki stack in Kyma](https://kyma-project.io/#/telemetry-manager/user/integration/loki/README). |
 
+Reflecting the log data flow in the status condition is currently under development and determined by the following reasons:
+
+| Condition Status | Condition Reason | Condition Message                                                  |
+|------------------|------------------|--------------------------------------------------------------------|
+| True             | FlowHealthy      | No problems detected in the log flow                               |
+| False            | BufferFillingUp  | Buffer nearing capacity: incoming log rate exceeds the export rate |
+| False            | NoLogsDelivered  | No logs delivered to backend                                       |
+| False            | SomeDataDropped  | Some logs dropped: backend unreachable or rejecting                |
+| False            | AllDataDropped   | All logs dropped: backend unreachable or rejecting                 |
+
 ### Trace Components State
 
 The state of the trace components is determined by the status condition of type `TraceComponentsHealthy`:
@@ -128,6 +138,16 @@ The state of the trace components is determined by the status condition of type 
 | False            | ResourceBlocksDeletion               | The deletion of the module is blocked. To unblock the deletion, delete the following resources: TracePipelines (resource-1, resource-2,...) |
 | False            | MaxPipelinesExceeded                 | Maximum pipeline count exceeded                                                                                                             |
 
+Reflecting the trace data flow in the status condition is currently under development and determined by the following reasons:
+
+| Condition Status | Condition Reason  | Condition Message                                                                       |
+|------------------|-------------------|-----------------------------------------------------------------------------------------|
+| True             | FlowHealthy       | No problems detected in the trace flow                                                  |
+| False            | GatewayThrottling | Trace collector experiencing high influx: Unable to receive metrics at the current rate |
+| False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                    |
+| False            | SomeDataDropped   | Some traces dropped: backend unreachable or rejecting                                   |
+| False            | AllDataDropped    | All traces dropped: backend unreachable or rejecting                                    |
+
 ### Metric Components State
 
 The state of the metric components is determined by the status condition of type `MetricComponentsHealthy`:
@@ -140,7 +160,17 @@ The state of the metric components is determined by the status condition of type
 | False            | MetricGatewayDeploymentNotReady       | Metric gateway Deployment is not ready                                                                                                       |
 | False            | MetricAgentDaemonSetNotReady          | Metric agent DaemonSet is not ready                                                                                                          |
 | False            | ResourceBlocksDeletion                | The deletion of the module is blocked. To unblock the deletion, delete the following resources: MetricPipelines (resource-1, resource-2,...) |
-| False            | MaxPipelinesExceeded                 | Maximum pipeline count exceeded                                                                                                             |
+| False            | MaxPipelinesExceeded                  | Maximum pipeline count exceeded                                                                                                              |
+
+Reflecting the metric data flow in the status condition is currently under development and determined by the following reasons:
+
+| Condition Status | Condition Reason  | Condition Message                                                                        |
+|------------------|-------------------|------------------------------------------------------------------------------------------|
+| True             | FlowHealthy       | No problems detected in the metric flow                                                  |
+| False            | GatewayThrottling | Metric collector experiencing high influx: Unable to receive metrics at the current rate |
+| False            | BufferFillingUp   | Buffer nearing capacity: incoming metric rate exceeds the export rate                    |
+| False            | SomeDataDropped   | Some metrics dropped: backend unreachable or rejecting                                   |
+| False            | AllDataDropped    | All metrics dropped: backend unreachable or rejecting                                    |
 
 ### Telemetry CR State
 

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -215,7 +215,7 @@ Reflecting the LogPipeline's data flow in `TelemetryFlowHealthy` condition type 
 
 | Condition Type       | Condition Status | Condition Reason | Condition Message                                                  |
 |----------------------|------------------|------------------|--------------------------------------------------------------------|
-| TelemetryFlowHealthy | True             | FlowHealthy      | Logs are flowing normally to backend                               |
+| TelemetryFlowHealthy | True             | FlowHealthy      | No problems detected in the log flow                               |
 | TelemetryFlowHealthy | False            | BufferFillingUp  | Buffer nearing capacity: incoming log rate exceeds the export rate |
 | TelemetryFlowHealthy | False            | NoLogsDelivered  | No logs delivered to backend                                       |
 | TelemetryFlowHealthy | False            | SomeDataDropped  | Some logs dropped: backend unreachable or rejecting                |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -163,7 +163,7 @@ Reflecting the TracePipeline's data flow in `TelemetryFlowHealthy` condition typ
 
 | Condition Type       | Condition Status | Condition Reason  | Condition Message                                                                       |
 |----------------------|------------------|-------------------|-----------------------------------------------------------------------------------------|
-| TelemetryFlowHealthy | True             | FlowHealthy       | Traces are flowing normally to backend                                                  |
+| TelemetryFlowHealthy | True             | FlowHealthy       | No problems detected in the trace flow                                                  |
 | TelemetryFlowHealthy | False            | GatewayThrottling | Trace collector experiencing high influx: Unable to receive metrics at the current rate |
 | TelemetryFlowHealthy | False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                    |
 | TelemetryFlowHealthy | False            | SomeDataDropped   | Some traces dropped: backend unreachable or rejecting                                   |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -164,7 +164,7 @@ Reflecting the TracePipeline's data flow in `TelemetryFlowHealthy` condition typ
 | Condition Type       | Condition Status | Condition Reason  | Condition Message                                                                       |
 |----------------------|------------------|-------------------|-----------------------------------------------------------------------------------------|
 | TelemetryFlowHealthy | True             | FlowHealthy       | No problems detected in the trace flow                                                  |
-| TelemetryFlowHealthy | False            | GatewayThrottling | Trace collector experiencing high influx: Unable to receive metrics at the current rate |
+| TelemetryFlowHealthy | False            | GatewayThrottling | Trace gateway experiencing high influx: unable to receive metrics at the current rate |
 | TelemetryFlowHealthy | False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                    |
 | TelemetryFlowHealthy | False            | SomeDataDropped   | Some traces dropped: backend unreachable or rejecting                                   |
 | TelemetryFlowHealthy | False            | AllDataDropped    | All traces dropped: backend unreachable or rejecting                                    |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -191,7 +191,7 @@ Reflecting the MetricPipeline's data flow in `TelemetryFlowHealthy` condition ty
 | Condition Type       | Condition Status | Condition Reason  | Condition Message                                                                      |
 |----------------------|------------------|-------------------|----------------------------------------------------------------------------------------|
 | TelemetryFlowHealthy | True             | FlowHealthy       | No problems detected in the metric flow                                                |
-| TelemetryFlowHealthy | False            | GatewayThrottling | Metric gateway experiencing high influx: Unable to receive metrics at the current rate |
+| TelemetryFlowHealthy | False            | GatewayThrottling | Metric gateway experiencing high influx: unable to receive metrics at the current rate |
 | TelemetryFlowHealthy | False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                   |
 | TelemetryFlowHealthy | False            | SomeDataDropped   | Some metrics dropped: backend unreachable or rejecting                                 |
 | TelemetryFlowHealthy | False            | AllDataDropped    | All metrics dropped: backend unreachable or rejecting                                  |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -190,7 +190,7 @@ Reflecting the MetricPipeline's data flow in `TelemetryFlowHealthy` condition ty
 
 | Condition Type       | Condition Status | Condition Reason  | Condition Message                                                                      |
 |----------------------|------------------|-------------------|----------------------------------------------------------------------------------------|
-| TelemetryFlowHealthy | True             | FlowHealthy       | Metrics are flowing normally to backend                                                |
+| TelemetryFlowHealthy | True             | FlowHealthy       | No problems detected in the metric flow                                                |
 | TelemetryFlowHealthy | False            | GatewayThrottling | Metric gateway experiencing high influx: Unable to receive metrics at the current rate |
 | TelemetryFlowHealthy | False            | BufferFillingUp   | Buffer nearing capacity: incoming trace rate exceeds the export rate                   |
 | TelemetryFlowHealthy | False            | SomeDataDropped   | Some metrics dropped: backend unreachable or rejecting                                 |

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -74,7 +74,7 @@ var metricPipelineMessages = map[string]string{
 	ReasonAllDataDropped:          "All metrics dropped: backend unreachable or rejecting",
 	ReasonSomeDataDropped:         "Some metrics dropped: backend unreachable or rejecting",
 	ReasonBufferFillingUp:         "Buffer nearing capacity: incoming metric rate exceeds export rate",
-	ReasonGatewayThrottling:       "Metric gateway experiencing high influx: Unable to receive metrics at current rate",
+	ReasonGatewayThrottling:       "Metric gateway experiencing high influx: unable to receive metrics at current rate",
 	ReasonFlowHealthy:             "No problems detected in the metric flow",
 }
 
@@ -87,7 +87,7 @@ var tracePipelineMessages = map[string]string{
 	ReasonAllDataDropped:                 "All traces dropped: backend unreachable or rejecting",
 	ReasonSomeDataDropped:                "Some traces dropped: backend unreachable or rejecting",
 	ReasonBufferFillingUp:                "Buffer nearing capacity: incoming trace rate exceeds export rate",
-	ReasonGatewayThrottling:              "Trace collector experiencing high influx: Unable to receive metrics at current rate",
+	ReasonGatewayThrottling:              "Trace gateway experiencing high influx: unable to receive traces at current rate",
 	ReasonFlowHealthy:                    "No problems detected in the trace flow",
 }
 

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -87,11 +87,7 @@ var tracePipelineMessages = map[string]string{
 	ReasonAllDataDropped:                 "All traces dropped: backend unreachable or rejecting",
 	ReasonSomeDataDropped:                "Some traces dropped: backend unreachable or rejecting",
 	ReasonBufferFillingUp:                "Buffer nearing capacity: incoming trace rate exceeds export rate",
-<<<<<<< HEAD
 	ReasonGatewayThrottling:              "Trace gateway experiencing high influx: unable to receive traces at current rate",
-=======
-	ReasonGatewayThrottling:              "Trace collector experiencing high influx: Unable to receive traces at current rate",
->>>>>>> 0c98abb7bdb43adb6d8cd016f3a61536dd82dd11
 	ReasonFlowHealthy:                    "No problems detected in the trace flow",
 }
 

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -75,7 +75,7 @@ var metricPipelineMessages = map[string]string{
 	ReasonSomeDataDropped:         "Some metrics dropped: backend unreachable or rejecting",
 	ReasonBufferFillingUp:         "Buffer nearing capacity: incoming metric rate exceeds export rate",
 	ReasonGatewayThrottling:       "Metric gateway experiencing high influx: Unable to receive metrics at current rate",
-	ReasonFlowHealthy:             "Metrics are flowing normally to backend",
+	ReasonFlowHealthy:             "No problems detected in the metric flow",
 }
 
 var tracePipelineMessages = map[string]string{
@@ -88,7 +88,7 @@ var tracePipelineMessages = map[string]string{
 	ReasonSomeDataDropped:                "Some traces dropped: backend unreachable or rejecting",
 	ReasonBufferFillingUp:                "Buffer nearing capacity: incoming trace rate exceeds export rate",
 	ReasonGatewayThrottling:              "Trace collector experiencing high influx: Unable to receive metrics at current rate",
-	ReasonFlowHealthy:                    "Traces are flowing normally to backend",
+	ReasonFlowHealthy:                    "No problems detected in the trace flow",
 }
 
 var logPipelineMessages = map[string]string{
@@ -102,7 +102,7 @@ var logPipelineMessages = map[string]string{
 	ReasonSomeDataDropped:       "Some logs dropped: backend unreachable or rejecting",
 	ReasonBufferFillingUp:       "Buffer nearing capacity: incoming log rate exceeds export rate",
 	ReasonNoLogsDelivered:       "No logs delivered to backend",
-	ReasonFlowHealthy:           "Logs are flowing normally to backend",
+	ReasonFlowHealthy:           "No problems detected in the log flow",
 }
 
 func MessageForLogPipeline(reason string) string {

--- a/internal/reconciler/telemetry/metric_components_checker_test.go
+++ b/internal/reconciler/telemetry/metric_components_checker_test.go
@@ -197,7 +197,7 @@ func TestMetricComponentsCheck(t *testing.T) {
 				Type:    "MetricComponentsHealthy",
 				Status:  "False",
 				Reason:  "GatewayThrottling",
-				Message: "Metric gateway experiencing high influx: Unable to receive metrics at current rate",
+				Message: "Metric gateway experiencing high influx: unable to receive metrics at current rate",
 			},
 		},
 		{
@@ -214,7 +214,7 @@ func TestMetricComponentsCheck(t *testing.T) {
 				Type:    "MetricComponentsHealthy",
 				Status:  "False",
 				Reason:  "GatewayThrottling",
-				Message: "Metric gateway experiencing high influx: Unable to receive metrics at current rate",
+				Message: "Metric gateway experiencing high influx: unable to receive metrics at current rate",
 			},
 		},
 		{

--- a/internal/reconciler/telemetry/trace_components_checker_test.go
+++ b/internal/reconciler/telemetry/trace_components_checker_test.go
@@ -195,7 +195,7 @@ func TestTraceComponentsCheck(t *testing.T) {
 				Type:    "TraceComponentsHealthy",
 				Status:  "False",
 				Reason:  "GatewayThrottling",
-				Message: "Trace collector experiencing high influx: Unable to receive metrics at current rate",
+				Message: "Trace gateway experiencing high influx: unable to receive traces at current rate",
 			},
 		},
 		{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The idea of linking TelemetryFlowHealth to other conditions didn't work well and caused more problems than it solved. So, this PR now adjusts the status messages to better match the telemetry flow, even when there's no flow but no issues exist either.
- Unify existing messages (gateway vs controller, unable vs Unable, etc.)

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/917

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->