### PR TITLE
test: Simplify log producer builder

### DIFF
--- a/test/e2e/logs_annotation_test.go
+++ b/test/e2e/logs_annotation_test.go
@@ -22,7 +22,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -32,10 +31,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs).
-			WithAnnotations(map[string]string{"release": "v1.0.0"})
+		logProducer := loggen.New(mockNs).WithAnnotations(map[string]string{"release": "v1.0.0"})
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -72,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have logs with annotations in the backend", func() {

--- a/test/e2e/logs_basic_v1alpha1_test.go
+++ b/test/e2e/logs_basic_v1alpha1_test.go
@@ -18,7 +18,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -28,9 +27,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs, backend.WithPersistentHostSecret(suite.IsOperational()))
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -70,11 +69,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", Label(suite.LabelOperational), func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have produced logs in the backend", Label(suite.LabelOperational), func() {
-			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, backendExportURL)
+			verifiers.LogsShouldBeDelivered(proxyClient, loggen.DefaultName, backendExportURL)
 		})
 	})
 })

--- a/test/e2e/logs_basic_v1beta1_test.go
+++ b/test/e2e/logs_basic_v1beta1_test.go
@@ -18,7 +18,6 @@ import (
 var _ = Describe("Logs Basic v1beta1", Label("logs", "v1beta1"), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -28,9 +27,9 @@ var _ = Describe("Logs Basic v1beta1", Label("logs", "v1beta1"), Ordered, func()
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Beta1(pipelineName).
@@ -69,11 +68,11 @@ var _ = Describe("Logs Basic v1beta1", Label("logs", "v1beta1"), Ordered, func()
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have produced logs in the backend", func() {
-			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, backendExportURL)
+			verifiers.LogsShouldBeDelivered(proxyClient, loggen.DefaultName, backendExportURL)
 		})
 	})
 })

--- a/test/e2e/logs_custom_output_test.go
+++ b/test/e2e/logs_custom_output_test.go
@@ -18,7 +18,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -28,9 +27,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		mockLogProducer := loggen.New(logProducerName, mockNs)
+		mockLogProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, mockLogProducer.K8sObject(kitk8s.WithLabel("app", "logging-test")))
+		objs = append(objs, mockLogProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).WithCustomOutput(backend.ExternalService.Host())
@@ -63,11 +62,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have log-producer logs in the backend", func() {
-			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, backendExportURL)
+			verifiers.LogsShouldBeDelivered(proxyClient, loggen.DefaultName, backendExportURL)
 		})
 	})
 })

--- a/test/e2e/logs_exclude_container_test.go
+++ b/test/e2e/logs_exclude_container_test.go
@@ -22,7 +22,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -32,15 +31,15 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
 			WithSecretKeyRef(backend.HostSecretRefV1Alpha1()).
 			WithHTTPOutput().
-			WithExcludeContainers([]string{logProducerName})
+			WithExcludeContainers([]string{loggen.DefaultName})
 		objs = append(objs, logPipeline.K8sObject())
 
 		return objs
@@ -70,7 +69,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have any logs in the backend", func() {
@@ -88,7 +87,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(Not(ContainLd(ContainLogRecord(
-					WithContainerName(ContainSubstring(logProducerName))))),
+					WithContainerName(ContainSubstring(loggen.DefaultName))))),
 				))
 			}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})

--- a/test/e2e/logs_exclude_namespaces_test.go
+++ b/test/e2e/logs_exclude_namespaces_test.go
@@ -23,7 +23,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -33,9 +32,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -71,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have any logs in the backend", func() {

--- a/test/e2e/logs_include_namespaces_test.go
+++ b/test/e2e/logs_include_namespaces_test.go
@@ -23,7 +23,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -33,9 +32,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -71,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have logs from expected namespaces", func() {

--- a/test/e2e/logs_label_test.go
+++ b/test/e2e/logs_label_test.go
@@ -22,7 +22,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -32,10 +31,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs).
+		logProducer := loggen.New(mockNs).
+			WithLabels(map[string]string{"env": "dev"}).
 			WithAnnotations(map[string]string{"release": "v1.0.0"})
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -72,7 +72,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have logs with labels in the backend", func() {
@@ -81,7 +81,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(ContainLd(ContainLogRecord(
-					WithKubernetesLabels(HaveKeyWithValue("app", logProducerName)))),
+					WithKubernetesLabels(HaveKeyWithValue("env", "dev")))),
 				))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})

--- a/test/e2e/logs_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/logs_mtls_about_to_expire_cert_test.go
@@ -20,7 +20,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -43,8 +42,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 			WithHTTPOutput().
 			WithTLS(*clientCerts)
 
-		logProducer := loggen.New(logProducerName, mockNs)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		logProducer := loggen.New(mockNs)
+		objs = append(objs, logProducer.K8sObject())
 
 		objs = append(objs,
 			logPipeline.K8sObject(),
@@ -80,11 +79,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", Label(suite.LabelOperational), func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have produced logs in the backend", Label(suite.LabelOperational), func() {
-			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, backendExportURL)
+			verifiers.LogsShouldBeDelivered(proxyClient, loggen.DefaultName, backendExportURL)
 		})
 	})
 })

--- a/test/e2e/logs_mtls_expired_cert_test.go
+++ b/test/e2e/logs_mtls_expired_cert_test.go
@@ -18,9 +18,8 @@ import (
 
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
-		mockNs          = suite.ID()
-		logProducerName = suite.ID()
-		pipelineName    = suite.ID()
+		mockNs       = suite.ID()
+		pipelineName = suite.ID()
 	)
 
 	makeResources := func() []client.Object {
@@ -35,17 +34,17 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		backend := backend.New(mockNs, backend.SignalTypeLogs, backend.WithTLS(*serverCerts))
 		objs = append(objs, backend.K8sObjects()...)
 
-		LogPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
+		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
 			WithSecretKeyRef(backend.HostSecretRefV1Alpha1()).
 			WithHTTPOutput().
 			WithTLS(*clientCerts)
-		pipelineName = LogPipeline.Name()
+		pipelineName = logPipeline.Name()
 
-		logProducer := loggen.New(logProducerName, mockNs)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		logProducer := loggen.New(mockNs)
+		objs = append(objs, logProducer.K8sObject())
 
 		objs = append(objs,
-			LogPipeline.K8sObject(),
+			logPipeline.K8sObject(),
 		)
 
 		return objs

--- a/test/e2e/logs_mtls_invalid_cert_test.go
+++ b/test/e2e/logs_mtls_invalid_cert_test.go
@@ -18,9 +18,8 @@ import (
 
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
-		mockNs          = suite.ID()
-		logProducerName = suite.ID()
-		pipelineName    = suite.ID()
+		mockNs       = suite.ID()
+		pipelineName = suite.ID()
 	)
 
 	makeResources := func() []client.Object {
@@ -41,8 +40,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 			WithTLS(*clientCerts)
 		pipelineName = logPipeline.Name()
 
-		logProducer := loggen.New(logProducerName, mockNs)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		logProducer := loggen.New(mockNs)
+		objs = append(objs, logProducer.K8sObject())
 		objs = append(objs,
 			logPipeline.K8sObject(),
 		)

--- a/test/e2e/logs_mtls_test.go
+++ b/test/e2e/logs_mtls_test.go
@@ -19,7 +19,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -32,9 +31,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs, backend.WithTLS(*serverCerts))
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		pipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -71,11 +70,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have log-producer logs in the backend", func() {
-			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, backendExportURL)
+			verifiers.LogsShouldBeDelivered(proxyClient, loggen.DefaultName, backendExportURL)
 		})
 	})
 })

--- a/test/e2e/logs_parser_test.go
+++ b/test/e2e/logs_parser_test.go
@@ -23,7 +23,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -33,10 +32,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(logProducerName, mockNs).
+		logProducer := loggen.New(mockNs).
 			WithAnnotations(map[string]string{"fluentbit.io/parser": "my-regex-parser"})
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", "regex-parser-testing-service")))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logHTTPPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -79,7 +78,7 @@ Types user:string pass:string`
 		})
 
 		It("Should have a log producer running", func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have parsed logs in the backend", func() {

--- a/test/e2e/logs_self_monitor_basic_test.go
+++ b/test/e2e/logs_self_monitor_basic_test.go
@@ -23,7 +23,6 @@ import (
 var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogs), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
-		logProducerName  = suite.ID()
 		pipelineName     = suite.ID()
 		backendExportURL string
 	)
@@ -33,9 +32,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogs), Ordered, func
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		backend := backend.New(mockNs, backend.SignalTypeLogs, backend.WithPersistentHostSecret(suite.IsOperational()))
-		logProducer := loggen.New(logProducerName, mockNs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject(kitk8s.WithLabel("app", logProducerName)))
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
 		logPipeline := kitk8s.NewLogPipelineV1Alpha1(pipelineName).
@@ -75,11 +74,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogs), Ordered, func
 		})
 
 		It("Should have a log producer running", Label(suite.LabelOperational), func() {
-			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: logProducerName})
+			verifiers.DeploymentShouldBeReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have produced logs in the backend", Label(suite.LabelOperational), func() {
-			verifiers.LogsShouldBeDelivered(proxyClient, logProducerName, backendExportURL)
+			verifiers.LogsShouldBeDelivered(proxyClient, loggen.DefaultName, backendExportURL)
 		})
 
 		It("Should have TypeFlowHealthy condition set to True", func() {

--- a/test/testkit/mocks/loggen/log_producer.go
+++ b/test/testkit/mocks/loggen/log_producer.go
@@ -1,24 +1,28 @@
 package loggen
 
 import (
+	"maps"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+)
 
-	"github.com/kyma-project/telemetry-manager/test/testkit"
-	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+const (
+	DefaultName = "log-producer"
 )
 
 type LogProducer struct {
 	name        string
 	namespace   string
 	annotations map[string]string
+	labels      map[string]string
 }
 
-func New(name, namespace string) *LogProducer {
+func New(namespace string) *LogProducer {
 	return &LogProducer{
-		name:      name,
+		name:      DefaultName,
 		namespace: namespace,
 	}
 }
@@ -26,11 +30,18 @@ func New(name, namespace string) *LogProducer {
 func (lp *LogProducer) WithAnnotations(annotations map[string]string) *LogProducer {
 	lp.annotations = annotations
 	return lp
-
 }
 
-func (lp *LogProducer) K8sObject(labelOpts ...testkit.OptFunc) *appsv1.Deployment {
-	labels := kitk8s.ProcessLabelOptions(labelOpts...)
+func (lp *LogProducer) WithLabels(labels map[string]string) *LogProducer {
+	lp.labels = labels
+	return lp
+}
+
+func (lp *LogProducer) K8sObject() *appsv1.Deployment {
+	labels := map[string]string{"app": lp.name}
+	if lp.labels != nil {
+		maps.Copy(labels, lp.labels)
+	}
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- When reviewing the e2e tests I realized that we always have to pass the name and the label (to be used by the label selector) to the log producer builder. It does not make much sense since it's namespace scoped and can always have the same name. Moreover, the builder can configure the label selector itlsef, no need to pass it from the outside.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->