### PR TITLE
feat: Update to prometheus 2.45.5 in self-monitor

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ const (
 	defaultOtelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.99.0-41265c69"
 	defaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.2-b5220c17"
 	defaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240404-fd3588ce"
-	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.45.4-6627fb45"
+	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.45.5-4f1be411"
 
 	overridesConfigMapName = "telemetry-override-config"
 	overridesConfigMapKey  = "override-config"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -4,7 +4,7 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.99.0-41265c69
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:2.2.2-b5220c17
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240404-fd3588ce
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.45.4-6627fb45
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.45.5-4f1be411
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Updated prometheus to latest patch version. Patch does not contain relevant fixes, however uses a newer golang version

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/third-party-images/pull/431

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->