### PR TITLE
chore: Adapt .golangci.yaml for v1.58.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,8 @@ linters:
     - scopelint
     - structcheck
     - varcheck
+    - gomnd
+    - execinquery
   # Linters to be enabled after fixing the issues
     - intrange
     - cyclop
@@ -30,9 +32,9 @@ linters:
     - gocritic
     - godot
     - godox
-    - goerr113
+    - err113
     - gofumpt
-    - gomnd
+    - mnd
     - ireturn
     - lll
     - maintidx

--- a/apis/operator/v1alpha1/telemetry_types.go
+++ b/apis/operator/v1alpha1/telemetry_types.go
@@ -142,7 +142,7 @@ type TelemetryList struct {
 	Items           []Telemetry `json:"items"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&Telemetry{}, &TelemetryList{})
 }

--- a/apis/telemetry/v1alpha1/logparser_types.go
+++ b/apis/telemetry/v1alpha1/logparser_types.go
@@ -61,7 +61,7 @@ type LogParserStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&LogParser{}, &LogParserList{})
 }

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -227,7 +227,7 @@ type LogPipelineList struct {
 	Items           []LogPipeline `json:"items"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&LogPipeline{}, &LogPipelineList{})
 }

--- a/apis/telemetry/v1alpha1/metricpipeline_types.go
+++ b/apis/telemetry/v1alpha1/metricpipeline_types.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&MetricPipeline{}, &MetricPipelineList{})
 }

--- a/apis/telemetry/v1alpha1/tracepipeline_types.go
+++ b/apis/telemetry/v1alpha1/tracepipeline_types.go
@@ -64,7 +64,7 @@ type TracePipelineList struct {
 	Items           []TracePipeline `json:"items"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&TracePipeline{}, &TracePipelineList{})
 }

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -181,7 +181,7 @@ type LogPipelineList struct {
 	Items           []LogPipeline `json:"items"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&LogPipeline{}, &LogPipelineList{})
 }

--- a/apis/telemetry/v1beta1/metricpipeline_types.go
+++ b/apis/telemetry/v1beta1/metricpipeline_types.go
@@ -146,7 +146,7 @@ type MetricPipelineList struct {
 	Items           []MetricPipeline `json:"items"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&MetricPipeline{}, &MetricPipelineList{})
 }

--- a/apis/telemetry/v1beta1/tracepipeline_types.go
+++ b/apis/telemetry/v1beta1/tracepipeline_types.go
@@ -66,7 +66,7 @@ type TracePipelineList struct {
 	Items           []TracePipeline `json:"items"`
 }
 
-//nolint:gochecknoinits // SchemeBuilder's registration is required.
+//nolint:init // SchemeBuilder's registration is required.
 func init() {
 	SchemeBuilder.Register(&TracePipeline{}, &TracePipelineList{})
 }

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ const (
 	selfMonitorName = "telemetry-self-monitor"
 )
 
-//nolint:gochecknoinits // Runtime's scheme addition is required.
+//nolint:init // Runtime's scheme addition is required.
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Adapted linter config to deprecated and renamed linters in golangci-lint v1.58.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->