### PR TITLE
feat: Enable sidecar injection for Fluent Bit by default

### DIFF
--- a/internal/resources/fluentbit/resources.go
+++ b/internal/resources/fluentbit/resources.go
@@ -57,6 +57,9 @@ func MakeDaemonSet(name types.NamespacedName, checksum string, dsConfig DaemonSe
 	annotations[checksumAnnotationKey] = checksum
 	annotations[istioExcludeInboundPorts] = fmt.Sprintf("%v,%v", ports.HTTP, ports.ExporterMetrics)
 
+	podLabels := Labels()
+	podLabels["sidecar.istio.io/inject"] = "true"
+
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -70,7 +73,7 @@ func MakeDaemonSet(name types.NamespacedName, checksum string, dsConfig DaemonSe
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      Labels(),
+					Labels:      podLabels,
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/resources/fluentbit/resources_test.go
+++ b/internal/resources/fluentbit/resources_test.go
@@ -34,8 +34,15 @@ func TestMakeDaemonSet(t *testing.T) {
 	require.NotNil(t, daemonSet)
 	require.Equal(t, daemonSet.Name, name.Name)
 	require.Equal(t, daemonSet.Namespace, name.Namespace)
-	require.Equal(t, daemonSet.Spec.Selector.MatchLabels, Labels())
-	require.Equal(t, daemonSet.Spec.Template.ObjectMeta.Labels, Labels())
+	require.Equal(t, map[string]string{
+		"app.kubernetes.io/name":     "fluent-bit",
+		"app.kubernetes.io/instance": "telemetry",
+	}, daemonSet.Spec.Selector.MatchLabels)
+	require.Equal(t, map[string]string{
+		"app.kubernetes.io/name":     "fluent-bit",
+		"app.kubernetes.io/instance": "telemetry",
+		"sidecar.istio.io/inject":    "true",
+	}, daemonSet.Spec.Template.ObjectMeta.Labels)
 	require.NotEmpty(t, daemonSet.Spec.Template.Spec.Containers[0].EnvFrom)
 	require.NotNil(t, daemonSet.Spec.Template.Spec.Containers[0].LivenessProbe, "liveness probe must be defined")
 	require.NotNil(t, daemonSet.Spec.Template.Spec.Containers[0].ReadinessProbe, "readiness probe must be defined")


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- We already added sidecar injection labels to OTel Collector pods, but not for Fluent Bit. This PR aligns Fluent Bit with OTel Collector with regard to labeling. It's important to note that there aren't any Istio-specific features for LogPipelines yet, so it doesn't change existing functionality.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->