### PR TITLE
fix: Always set OwnerReference for telemetry-fluent-bit-sections ConfigMap

### DIFF
--- a/internal/reconciler/logpipeline/sync.go
+++ b/internal/reconciler/logpipeline/sync.go
@@ -75,10 +75,10 @@ func (s *syncer) syncSectionsConfigMap(ctx context.Context, pipeline *telemetryv
 		} else if oldConfig, hasKey := cm.Data[cmKey]; !hasKey || oldConfig != newConfig {
 			cm.Data[cmKey] = newConfig
 		}
+	}
 
-		if err = controllerutil.SetOwnerReference(pipeline, &cm, s.Scheme()); err != nil {
-			return fmt.Errorf("unable to set owner reference for section configmap: %w", err)
-		}
+	if err = controllerutil.SetOwnerReference(pipeline, &cm, s.Scheme()); err != nil {
+		return fmt.Errorf("unable to set owner reference for section configmap: %w", err)
 	}
 
 	if err = s.Update(ctx, &cm); err != nil {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- In case of a non-deployable LogPipeline, the `OwnerReference` was not set in the `telemetry-fluent-bit-sections` ConfigMap. Therefore, if this non-deployable LogPipeline is deleted, the `telemetry-fluent-bit-sections` ConfigMap will not be cleaned up and it will remain orphaned in the cluster. This is fixed in this PR by setting the `OwnerReference` in the `telemetry-fluent-bit-sections` ConfigMap regardless of whether the LogPipeline is deployable or not.

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->