### PR TITLE
chore: Ignore dependabot updates for fluent-bit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       prefix: "chore(dependabot)"
     labels:
       - "area/dependency"
+    ignore:
+      - dependency-name: "kyma-project/prod/tpi/fluent-bit"
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- ignore fluent-bit docker file versions

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->