### PR TITLE
fix: Use different UI path for telemetry module view to not clash with Istio resources

### DIFF
--- a/config/busola/telemetry_busola_extension_cm.yaml
+++ b/config/busola/telemetry_busola_extension_cm.yaml
@@ -161,7 +161,7 @@ data:
       version: v1alpha1
     name: Telemetry
     category: Kyma
-    urlPath: telemetries
+    urlPath: kymatelemetries
     scope: namespace
     description: >-
       The {{[Telemetry](https://kyma-project.io/#/telemetry-manager/user/resources/01-telemetry)}} resource configures the telemetry module.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The telemetry module view in the Kyma dashboard is not getting displayed at the moment as it get overruled by the new Istio telemetry view. Fixed it by using a custom UI path for the telemetry view

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/istio/issues/579

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->