### PR TITLE
fix: Unify CRs' descriptions in Kyma dashboard

### DIFF
--- a/config/busola/logpipeline_busola_extension_cm.yaml
+++ b/config/busola/logpipeline_busola_extension_cm.yaml
@@ -414,7 +414,7 @@ data:
     urlPath: logpipelines
     scope: cluster
     description: >-
-      {{[LogPipeline](https://kyma-project.io/#/telemetry-manager/user/resources/02-logpipeline)}} configures log selection, filters, and outputs.
+      {{[LogPipeline custom resource](https://kyma-project.io/#/telemetry-manager/user/resources/02-logpipeline)}} configures a custom Log Pipeline.
   list: |-
     - source: >-
         $each(spec.output, function($v, $k) {$v.url.value or

--- a/config/busola/metricpipeline_busola_extension_cm.yaml
+++ b/config/busola/metricpipeline_busola_extension_cm.yaml
@@ -526,7 +526,7 @@ data:
     urlPath: metricpipelines
     scope: cluster
     description: >-
-      {{[MetricPipeline](https://kyma-project.io/#/telemetry-manager/user/resources/05-metricpipeline)}} configures a custom Metric Pipeline
+      {{[MetricPipeline custom resource](https://kyma-project.io/#/telemetry-manager/user/resources/05-metricpipeline)}} configures a custom Metric Pipeline.
   list: |-
     - source: >-
         $each(spec.output, function($v, $k) {$v.endpoint.value or

--- a/config/busola/telemetry_busola_extension_cm.yaml
+++ b/config/busola/telemetry_busola_extension_cm.yaml
@@ -164,7 +164,7 @@ data:
     urlPath: kymatelemetries
     scope: namespace
     description: >-
-      The {{[Telemetry](https://kyma-project.io/#/telemetry-manager/user/resources/01-telemetry)}} resource configures the telemetry module.
+      {{[Telemetry custom resource](https://kyma-project.io/#/telemetry-manager/user/resources/01-telemetry)}} configures the Telemetry module.
     features:
       actions:
         disableCreate: true

--- a/config/busola/tracepipeline_busola_extension_cm.yaml
+++ b/config/busola/tracepipeline_busola_extension_cm.yaml
@@ -358,7 +358,7 @@ data:
     urlPath: tracepipelines
     scope: cluster
     description: >-
-      {{[TracePipeline](https://kyma-project.io/#/telemetry-manager/user/resources/04-tracepipeline)}} configures a custom Trace Pipeline
+      {{[TracePipeline custom resource](https://kyma-project.io/#/telemetry-manager/user/resources/04-tracepipeline)}} configures a custom Trace Pipeline.
   list: |-
     - source: >-
         $each(spec.output, function($v, $k) {$v.endpoint.value or


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Unify Telemetry, LogPipeline, MetricPipeline, and TracePipeline CRs' descriptions to be consistent with all CR descriptions in Kyma dashboard

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/kyma/issues/18321

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->