### PR TITLE
fix: Introduce endpoint validation 

### DIFF
--- a/internal/otelcollector/config/metric/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/metric/gateway/config_builder_test.go
@@ -23,7 +23,7 @@ func TestMakeConfig(t *testing.T) {
 
 	t.Run("otlp exporter endpoint", func(t *testing.T) {
 		collectorConfig, envVars, err := MakeConfig(ctx, fakeClient, []telemetryv1alpha1.MetricPipeline{
-			testutils.NewMetricPipelineBuilder().WithName("test").WithOTLPOutput(testutils.OTLPEndpoint("http://localhost")).Build(),
+			testutils.NewMetricPipelineBuilder().WithName("test").WithOTLPOutput(testutils.OTLPEndpoint(testutils.ValidInsecureEndpoint)).Build(),
 		})
 		require.NoError(t, err)
 
@@ -34,12 +34,12 @@ func TestMakeConfig(t *testing.T) {
 		require.Equal(t, expectedEndpoint, actualExporterConfig.OTLP.Endpoint)
 
 		require.Contains(t, envVars, "OTLP_ENDPOINT_TEST")
-		require.Equal(t, "http://localhost", string(envVars["OTLP_ENDPOINT_TEST"]))
+		require.Equal(t, testutils.ValidInsecureEndpoint, string(envVars["OTLP_ENDPOINT_TEST"]))
 	})
 
 	t.Run("secure", func(t *testing.T) {
 		collectorConfig, _, err := MakeConfig(ctx, fakeClient, []telemetryv1alpha1.MetricPipeline{testutils.NewMetricPipelineBuilder().
-			WithName("test").WithOTLPOutput(testutils.OTLPEndpoint("https://localhost")).Build()})
+			WithName("test").WithOTLPOutput(testutils.OTLPEndpoint(testutils.ValidSecureEndpoint)).Build()})
 		require.NoError(t, err)
 		require.Contains(t, collectorConfig.Exporters, "otlp/test")
 
@@ -49,7 +49,7 @@ func TestMakeConfig(t *testing.T) {
 
 	t.Run("insecure", func(t *testing.T) {
 		collectorConfig, _, err := MakeConfig(ctx, fakeClient, []telemetryv1alpha1.MetricPipeline{
-			testutils.NewMetricPipelineBuilder().WithName("test-insecure").WithOTLPOutput(testutils.OTLPEndpoint("http://localhost")).Build()},
+			testutils.NewMetricPipelineBuilder().WithName("test-insecure").WithOTLPOutput(testutils.OTLPEndpoint(testutils.ValidInsecureEndpoint)).Build()},
 		)
 		require.NoError(t, err)
 		require.Contains(t, collectorConfig.Exporters, "otlp/test-insecure")
@@ -446,7 +446,7 @@ func TestMakeConfig(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 
 				config, _, err := MakeConfig(context.Background(), fakeClient, []telemetryv1alpha1.MetricPipeline{
-					testutils.NewMetricPipelineBuilder().WithName("test").WithOTLPInput(tt.withOtlpInput).WithOTLPOutput(testutils.OTLPEndpoint("https://localhost")).Build(),
+					testutils.NewMetricPipelineBuilder().WithName("test").WithOTLPInput(tt.withOtlpInput).WithOTLPOutput(testutils.OTLPEndpoint(testutils.ValidSecureEndpoint)).Build(),
 				})
 				require.NoError(t, err)
 
@@ -457,7 +457,6 @@ func TestMakeConfig(t *testing.T) {
 				goldenFile, err := os.ReadFile(goldenFilePath)
 				require.NoError(t, err, "failed to load golden file")
 
-				require.NoError(t, err)
 				require.Equal(t, string(goldenFile), string(configYAML))
 			})
 		}

--- a/internal/otelcollector/config/otlpexporter/config_builder_test.go
+++ b/internal/otelcollector/config/otlpexporter/config_builder_test.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/testutils"
 )
 
 func TestExporterIDHTTP(t *testing.T) {
@@ -24,7 +25,7 @@ func TestExorterIDDefault(t *testing.T) {
 
 func TestMakeConfig(t *testing.T) {
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidInsecureEndpoint},
 	}
 
 	cb := NewConfigBuilder(fake.NewClientBuilder().Build(), output, "test", 512, SignalTypeTrace)
@@ -33,7 +34,7 @@ func TestMakeConfig(t *testing.T) {
 	require.NotNil(t, envVars)
 
 	require.NotNil(t, envVars["OTLP_ENDPOINT_TEST"])
-	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte("otlp-endpoint"))
+	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte(testutils.ValidInsecureEndpoint))
 
 	require.Equal(t, "${OTLP_ENDPOINT_TEST}", otlpExporterConfig.Endpoint)
 	require.True(t, otlpExporterConfig.SendingQueue.Enabled)
@@ -47,7 +48,7 @@ func TestMakeConfig(t *testing.T) {
 
 func TestMakeConfigTraceWithPath(t *testing.T) {
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidSecureEndpoint},
 		Path:     "/v1/test",
 		Protocol: "http",
 	}
@@ -58,7 +59,7 @@ func TestMakeConfigTraceWithPath(t *testing.T) {
 	require.NotNil(t, envVars)
 
 	require.NotNil(t, envVars["OTLP_ENDPOINT_TEST"])
-	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte("otlp-endpoint/v1/test"))
+	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte(testutils.ValidSecureEndpoint+"/v1/test"))
 
 	require.Equal(t, "${OTLP_ENDPOINT_TEST}", otlpExporterConfig.TracesEndpoint)
 	require.Empty(t, otlpExporterConfig.Endpoint)
@@ -66,7 +67,7 @@ func TestMakeConfigTraceWithPath(t *testing.T) {
 
 func TestMakeConfigMetricWithPath(t *testing.T) {
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidInsecureEndpoint},
 		Path:     "/v1/test",
 		Protocol: "http",
 	}
@@ -77,7 +78,7 @@ func TestMakeConfigMetricWithPath(t *testing.T) {
 	require.NotNil(t, envVars)
 
 	require.NotNil(t, envVars["OTLP_ENDPOINT_TEST"])
-	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte("otlp-endpoint/v1/test"))
+	require.Equal(t, envVars["OTLP_ENDPOINT_TEST"], []byte(testutils.ValidInsecureEndpoint+"/v1/test"))
 
 	require.Equal(t, "${OTLP_ENDPOINT_TEST}", otlpExporterConfig.MetricsEndpoint)
 	require.Empty(t, otlpExporterConfig.Endpoint)
@@ -93,7 +94,7 @@ func TestMakeExporterConfigWithCustomHeaders(t *testing.T) {
 		},
 	}
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidSecureEndpoint},
 		Headers:  headers,
 	}
 
@@ -111,7 +112,7 @@ func TestMakeExporterConfigWithTLSInsecure(t *testing.T) {
 		Insecure: true,
 	}
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidInsecureEndpoint},
 		TLS:      tls,
 	}
 
@@ -129,7 +130,7 @@ func TestMakeExporterConfigWithTLSInsecureSkipVerify(t *testing.T) {
 		InsecureSkipVerify: true,
 	}
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidSecureEndpoint},
 		TLS:      tls,
 	}
 
@@ -158,7 +159,7 @@ func TestMakeExporterConfigWithmTLS(t *testing.T) {
 		},
 	}
 	output := &telemetryv1alpha1.OtlpOutput{
-		Endpoint: telemetryv1alpha1.ValueType{Value: "otlp-endpoint"},
+		Endpoint: telemetryv1alpha1.ValueType{Value: testutils.ValidSecureEndpoint},
 		TLS:      tls,
 	}
 

--- a/internal/otelcollector/config/trace/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/trace/gateway/config_builder_test.go
@@ -22,7 +22,7 @@ func TestMakeConfig(t *testing.T) {
 
 	t.Run("otlp exporter endpoint", func(t *testing.T) {
 		collectorConfig, envVars, err := MakeConfig(ctx, fakeClient, []telemetryv1alpha1.TracePipeline{
-			testutils.NewTracePipelineBuilder().WithName("test").WithOTLPOutput(testutils.OTLPEndpoint("http://localhost")).Build(),
+			testutils.NewTracePipelineBuilder().WithName("test").WithOTLPOutput(testutils.OTLPEndpoint(testutils.ValidSecureEndpoint)).Build(),
 		})
 		require.NoError(t, err)
 
@@ -33,7 +33,7 @@ func TestMakeConfig(t *testing.T) {
 		require.Equal(t, expectedEndpoint, otlpExporterConfig.OTLP.Endpoint)
 
 		require.Contains(t, envVars, "OTLP_ENDPOINT_TEST")
-		require.Equal(t, "http://localhost", string(envVars["OTLP_ENDPOINT_TEST"]))
+		require.Equal(t, testutils.ValidSecureEndpoint, string(envVars["OTLP_ENDPOINT_TEST"]))
 	})
 
 	t.Run("secure", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMakeConfig(t *testing.T) {
 
 	t.Run("insecure", func(t *testing.T) {
 		collectorConfig, _, err := MakeConfig(ctx, fakeClient, []telemetryv1alpha1.TracePipeline{
-			testutils.NewTracePipelineBuilder().WithName("test-insecure").WithOTLPOutput(testutils.OTLPEndpoint("http://localhost")).Build()},
+			testutils.NewTracePipelineBuilder().WithName("test-insecure").WithOTLPOutput(testutils.OTLPEndpoint(testutils.ValidInsecureEndpoint)).Build()},
 		)
 		require.NoError(t, err)
 		require.Contains(t, collectorConfig.Exporters, "otlp/test-insecure")

--- a/internal/testutils/pipeline_opts.go
+++ b/internal/testutils/pipeline_opts.go
@@ -6,6 +6,12 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 )
 
+const (
+	ValidInsecureEndpoint = "http://localhost:8080"
+	ValidSecureEndpoint   = "https://localhost:8080"
+	InvalidEndpoint       = "http://host-without-port"
+)
+
 type OTLPOutputOption func(*telemetryv1alpha1.OtlpOutput)
 
 func OTLPEndpoint(endpoint string) OTLPOutputOption {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- validate the otlp endpoint using similar logic as the otel-collector. This way invalid configuration will not make its way into the otel-collector configuration

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1106

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
