### PR TITLE
fix: Stabilize flaky e2e self-monitoring tests

### DIFF
--- a/test/integration/istio/metrics_self_monitor_outage_test.go
+++ b/test/integration/istio/metrics_self_monitor_outage_test.go
@@ -31,7 +31,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := backend.New(mockNs, backend.SignalTypeMetrics, backend.WithReplicas(1), backend.WithFaultDelayInjection(100, 5))
+		backend := backend.New(mockNs, backend.SignalTypeMetrics, backend.WithReplicas(0))
 		objs = append(objs, backend.K8sObjects()...)
 
 		metricPipeline := testutils.NewMetricPipelineBuilder().

--- a/test/integration/istio/traces_self_monitor_backpressure_test.go
+++ b/test/integration/istio/traces_self_monitor_backpressure_test.go
@@ -80,7 +80,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesBackpressure),
 		It("Should wait for the trace flow to gradually become unhealthy", func() {
 			assert.TracePipelineConditionReasonsTransition(ctx, k8sClient, pipelineName, conditions.TypeFlowHealthy, []assert.ReasonStatus{
 				{Reason: conditions.ReasonSelfMonFlowHealthy, Status: metav1.ConditionTrue},
-				{Reason: conditions.ReasonSelfMonBufferFillingUp, Status: metav1.ConditionFalse},
 				{Reason: conditions.ReasonSelfMonSomeDataDropped, Status: metav1.ConditionFalse},
 			})
 		})

--- a/test/integration/istio/traces_self_monitor_outage_test.go
+++ b/test/integration/istio/traces_self_monitor_outage_test.go
@@ -30,7 +30,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := backend.New(mockNs, backend.SignalTypeTraces, backend.WithReplicas(1), backend.WithFaultDelayInjection(100, 5))
+		backend := backend.New(mockNs, backend.SignalTypeTraces, backend.WithReplicas(0))
 		objs = append(objs, backend.K8sObjects()...)
 
 		tracePipeline := testutils.NewTracePipelineBuilder().


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- dont check the buffer-is-full condition in the backpressure test, as it is also tested in the outage test

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
