### PR TITLE
chore: Include reconcilers in the test coverage check

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -19,20 +19,28 @@ threshold:
 # specific to more general rules.
 override:
   # Temporarily decrease coverage threshold for certain packages, we need to increase the coverage and remove these entries from the list
-  - threshold: 75
-    path: ^webhook/dryrun$
   - threshold: 57
     path: ^internal/istiostatus$
   - threshold: 86
     path: ^internal/otelcollector/config/otlpexporter$
+  - threshold: 74
+    path: ^internal/reconciler/logpipeline$
+  - threshold: 78
+    path: ^internal/reconciler/metricpipeline$
+  - threshold: 65
+    path: ^internal/reconciler/telemetry$
+  - threshold: 75
+    path: ^internal/reconciler/tracepipeline$
   - threshold: 85
     path: ^internal/resources/otelcollector$
-  - threshold: 86
-    path: ^internal/webhookcert$
   - threshold: 75
     path: ^internal/resources/selfmonitor$
   - threshold: 75
     path: ^internal/resourcelock$
+  - threshold: 86
+    path: ^internal/webhookcert$
+  - threshold: 75
+    path: ^webhook/dryrun$
   - threshold: 70
     path: ^webhook/logpipeline
 
@@ -46,7 +54,7 @@ exclude:
     - mocks
     - ^internal/k8sutils   # k8sutils has to be dissected into smaller single-purpose packages, for now excluding from coverage check
     - internal/logger
-    - ^internal/reconciler # reconcilers are covered by e2e tests
+    - ^internal/reconciler/logparser  # logparser reconciler will be removed soon
     - ^test                # e2e and integration tests
     - webhook/logparser    # logparser will be removed soon
     - ^internal/testutils  # some functions in testutils are being used in e2e tests only


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

After rewriting reconciler unit tests, we should make sure that test coverage does not drop

- Include reconcilers in the test coverage check
- Sort exceptions alphabetically

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->