### PR TITLE
chore: Remove lint version check

### DIFF
--- a/.github/workflows/pr-code-checks.yml
+++ b/.github/workflows/pr-code-checks.yml
@@ -26,16 +26,6 @@ jobs:
     - name: Run tests
       run: make test
 
-  check-linter-version:
-    if: github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Check linter version
-        run: make check-linter-version
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/hack/make/dependencies.mk
+++ b/hack/make/dependencies.mk
@@ -69,25 +69,6 @@ $(GOLANGCI_LINT): $(LOCALBIN)
     fi
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
 
-.PHONY: check-linter-version
-check-linter-version: GOLANGCI_LINT_LATEST = $(shell curl -sL https://api.github.com/repos/golangci/golangci-lint/releases/latest | jq -r ".tag_name" )
-check-linter-version: GOLANGCI_LINT_WORKFLOW = $(shell yq '.jobs.lint.steps[]|select(.name == "Run lint").with.version'  .github/workflows/pr-code-checks.yml )
-check-linter-version:
-	@if [ "$(GOLANGCI_LINT_VERSION)" != "$(GOLANGCI_LINT_LATEST)" ]; then \
-		echo -e ${RED}########################################################################################${NC}; \
-		echo -e ${RED}A new version of GolangCI-Lint is available: ${GOLANGCI_LINT_LATEST}${NC}; \
-		echo -e ${RED}Update the version for golangci-lint in the ${YELLOW}.env${RED} file${NC}; \
-		echo -e ${RED}########################################################################################${NC}; \
-		exit 1; \
-    fi
-	@if [ "$(GOLANGCI_LINT_WORKFLOW)" != "$(GOLANGCI_LINT_LATEST)" ]; then \
-		echo -e ${RED}########################################################################################${NC}; \
-		echo -e ${RED}A new version of GolangCI-Lint is available: ${GOLANGCI_LINT_LATEST}${NC}; \
-		echo -e ${RED}Update the version for golangci-lint in the ${YELLOW}github workflow definition${NC}; \
-		echo -e ${RED}########################################################################################${NC}; \
-		exit 1; \
-    fi
-
 ## ginkgo
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Following the team agreement, we are removing the linter version check to avoid unnecessary disruptions. Instead, we will rely on Slack notifications to prompt updates for the linter and other tools.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [ ] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [ ] The feature is unit-tested
- [ ] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->