### PR TITLE
feat: Set module version in instrumentation scope

### DIFF
--- a/docs/contributor/releasing.md
+++ b/docs/contributor/releasing.md
@@ -29,6 +29,8 @@ This release process covers the steps to release new major and minor versions fo
      For the images listed in the `protecode` field:
       - Update the tag of the `telemetry-manager` image with the new module version following the `x.y.z` pattern. For example, `europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.0.0`.
       - Ensure that all other images have the same versions as those used in the `main.go` file.
+   - `internal/version/version.go`:
+      Update the `Version` variable with the new module version following the `x.y.z` pattern.
 
 6. Merge the PR.
    

--- a/internal/otelcollector/config/metric/agent/processors_test.go
+++ b/internal/otelcollector/config/metric/agent/processors_test.go
@@ -70,8 +70,9 @@ func TestProcessors(t *testing.T) {
 		require.Equal(t, "ignore", collectorConfig.Processors.SetInstrumentationScopeRuntime.ErrorMode)
 		require.Len(t, collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements, 1)
 		require.Equal(t, "scope", collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements[0].Context)
-		require.Len(t, collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements[0].Statements, 1)
-		require.Equal(t, "set(name, \"io.kyma-project.telemetry/runtime\") where name == \"\" or name == \"otelcol/kubeletstatsreceiver\"", collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements[0].Statements[0])
+		require.Len(t, collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements[0].Statements, 2)
+		require.Equal(t, "set(version, \"main\") where name == \"otelcol/kubeletstatsreceiver\"", collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements[0].Statements[0])
+		require.Equal(t, "set(name, \"io.kyma-project.telemetry/runtime\") where name == \"\" or name == \"otelcol/kubeletstatsreceiver\"", collectorConfig.Processors.SetInstrumentationScopeRuntime.MetricStatements[0].Statements[1])
 	})
 
 	t.Run("set instrumentation scope prometheus", func(t *testing.T) {
@@ -82,8 +83,9 @@ func TestProcessors(t *testing.T) {
 		require.Equal(t, "ignore", collectorConfig.Processors.SetInstrumentationScopePrometheus.ErrorMode)
 		require.Len(t, collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements, 1)
 		require.Equal(t, "scope", collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements[0].Context)
-		require.Len(t, collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements[0].Statements, 1)
-		require.Equal(t, "set(name, \"io.kyma-project.telemetry/prometheus\") where name == \"\" or name == \"otelcol/prometheusreceiver\"", collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements[0].Statements[0])
+		require.Len(t, collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements[0].Statements, 2)
+		require.Equal(t, "set(version, \"main\") where name == \"otelcol/prometheusreceiver\"", collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements[0].Statements[0])
+		require.Equal(t, "set(name, \"io.kyma-project.telemetry/prometheus\") where name == \"\" or name == \"otelcol/prometheusreceiver\"", collectorConfig.Processors.SetInstrumentationScopePrometheus.MetricStatements[0].Statements[1])
 	})
 
 	t.Run("set instrumentation scope istio", func(t *testing.T) {
@@ -94,8 +96,9 @@ func TestProcessors(t *testing.T) {
 		require.Equal(t, "ignore", collectorConfig.Processors.SetInstrumentationScopeIstio.ErrorMode)
 		require.Len(t, collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements, 1)
 		require.Equal(t, "scope", collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements[0].Context)
-		require.Len(t, collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements[0].Statements, 1)
-		require.Equal(t, "set(name, \"io.kyma-project.telemetry/istio\") where name == \"\" or name == \"otelcol/prometheusreceiver\"", collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements[0].Statements[0])
+		require.Len(t, collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements[0].Statements, 2)
+		require.Equal(t, "set(version, \"main\") where name == \"otelcol/prometheusreceiver\"", collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements[0].Statements[0])
+		require.Equal(t, "set(name, \"io.kyma-project.telemetry/istio\") where name == \"\" or name == \"otelcol/prometheusreceiver\"", collectorConfig.Processors.SetInstrumentationScopeIstio.MetricStatements[0].Statements[1])
 	})
 
 }

--- a/internal/otelcollector/config/metric/agent/set_instrumentation_scope_test.go
+++ b/internal/otelcollector/config/metric/agent/set_instrumentation_scope_test.go
@@ -18,8 +18,11 @@ func TestTransformedInstrumentationScope(t *testing.T) {
 			want: &TransformProcessor{
 				ErrorMode: "ignore",
 				MetricStatements: []config.TransformProcessorStatements{{
-					Context:    "scope",
-					Statements: []string{"set(name, \"io.kyma-project.telemetry/runtime\") where name == \"\" or name == \"otelcol/kubeletstatsreceiver\""},
+					Context: "scope",
+					Statements: []string{
+						"set(version, \"main\") where name == \"otelcol/kubeletstatsreceiver\"",
+						"set(name, \"io.kyma-project.telemetry/runtime\") where name == \"\" or name == \"otelcol/kubeletstatsreceiver\"",
+					},
 				}},
 			},
 			inputSource: metric.InputSourceRuntime,
@@ -28,8 +31,11 @@ func TestTransformedInstrumentationScope(t *testing.T) {
 			want: &TransformProcessor{
 				ErrorMode: "ignore",
 				MetricStatements: []config.TransformProcessorStatements{{
-					Context:    "scope",
-					Statements: []string{"set(name, \"io.kyma-project.telemetry/prometheus\") where name == \"\" or name == \"otelcol/prometheusreceiver\""},
+					Context: "scope",
+					Statements: []string{
+						"set(version, \"main\") where name == \"otelcol/prometheusreceiver\"",
+						"set(name, \"io.kyma-project.telemetry/prometheus\") where name == \"\" or name == \"otelcol/prometheusreceiver\"",
+					},
 				}},
 			},
 			inputSource: metric.InputSourcePrometheus,
@@ -38,8 +44,11 @@ func TestTransformedInstrumentationScope(t *testing.T) {
 			want: &TransformProcessor{
 				ErrorMode: "ignore",
 				MetricStatements: []config.TransformProcessorStatements{{
-					Context:    "scope",
-					Statements: []string{"set(name, \"io.kyma-project.telemetry/istio\") where name == \"\" or name == \"otelcol/prometheusreceiver\""},
+					Context: "scope",
+					Statements: []string{
+						"set(version, \"main\") where name == \"otelcol/prometheusreceiver\"",
+						"set(name, \"io.kyma-project.telemetry/istio\") where name == \"\" or name == \"otelcol/prometheusreceiver\"",
+					},
 				}},
 			},
 			inputSource: metric.InputSourceIstio,

--- a/internal/otelcollector/config/metric/agent/set_instrumention_scope.go
+++ b/internal/otelcollector/config/metric/agent/set_instrumention_scope.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/metric"
+	"github.com/kyma-project/telemetry-manager/internal/version"
 )
 
 var upstreamInstrumentationScopeName = map[metric.InputSourceType]string{
@@ -27,6 +28,7 @@ func makeInstrumentationScopeProcessor(inputSource metric.InputSourceType) *Tran
 
 func makeInstrumentationStatement(inputSource metric.InputSourceType) []string {
 	return []string{
+		fmt.Sprintf("set(version, \"%s\") where name == \"%s\"", version.Version, upstreamInstrumentationScopeName[inputSource]),
 		fmt.Sprintf("set(name, \"%s\") where name == \"\" or name == \"%s\"", metric.InstrumentationScope[inputSource], upstreamInstrumentationScopeName[inputSource]),
 	}
 }

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -308,18 +308,21 @@ processors:
         metric_statements:
             - context: scope
               statements:
+                - set(version, "main") where name == "otelcol/kubeletstatsreceiver"
                 - set(name, "io.kyma-project.telemetry/runtime") where name == "" or name == "otelcol/kubeletstatsreceiver"
     transform/set-instrumentation-scope-prometheus:
         error_mode: ignore
         metric_statements:
             - context: scope
               statements:
+                - set(version, "main") where name == "otelcol/prometheusreceiver"
                 - set(name, "io.kyma-project.telemetry/prometheus") where name == "" or name == "otelcol/prometheusreceiver"
     transform/set-instrumentation-scope-istio:
         error_mode: ignore
         metric_statements:
             - context: scope
               statements:
+                - set(version, "main") where name == "otelcol/prometheusreceiver"
                 - set(name, "io.kyma-project.telemetry/istio") where name == "" or name == "otelcol/prometheusreceiver"
 exporters:
     otlp:

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -168,12 +168,14 @@ processors:
         metric_statements:
             - context: scope
               statements:
+                - set(version, "main") where name == "otelcol/kubeletstatsreceiver"
                 - set(name, "io.kyma-project.telemetry/runtime") where name == "" or name == "otelcol/kubeletstatsreceiver"
     transform/set-instrumentation-scope-prometheus:
         error_mode: ignore
         metric_statements:
             - context: scope
               statements:
+                - set(version, "main") where name == "otelcol/prometheusreceiver"
                 - set(name, "io.kyma-project.telemetry/prometheus") where name == "" or name == "otelcol/prometheusreceiver"
 exporters:
     otlp:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "main"

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/resources/selfmonitor"
 	"github.com/kyma-project/telemetry-manager/internal/selfmonitor/prober"
 	selfmonitorwebhook "github.com/kyma-project/telemetry-manager/internal/selfmonitor/webhook"
+	"github.com/kyma-project/telemetry-manager/internal/version"
 	"github.com/kyma-project/telemetry-manager/internal/webhookcert"
 	"github.com/kyma-project/telemetry-manager/webhook/dryrun"
 	logparserwebhook "github.com/kyma-project/telemetry-manager/webhook/logparser"
@@ -386,7 +387,7 @@ func main() {
 }
 
 func enableTelemetryModuleController(mgr manager.Manager, webhookConfig telemetry.WebhookConfig, selfMonitorConfig telemetry.SelfMonitorConfig) {
-	setupLog.Info("Starting with telemetry manager controller")
+	setupLog.WithValues("version", version.Version).Info("Starting with telemetry manager controller")
 
 	if err := createTelemetryController(mgr.GetClient(), mgr.GetScheme(), webhookConfig, selfMonitorConfig).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Telemetry")

--- a/test/e2e/metrics_multi_pipeline_test.go
+++ b/test/e2e/metrics_multi_pipeline_test.go
@@ -112,7 +112,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(ContainMd(Not(SatisfyAll(
 					ContainMetric(WithName(BeElementOf(kubeletstats.MetricNames))),
-					ContainScope(WithScopeName(ContainSubstring(InstrumentationScopeRuntime))),
+					ContainScope(
+						SatisfyAll(
+							WithScopeName(ContainSubstring(InstrumentationScopeRuntime)),
+							WithScopeVersion(
+								SatisfyAny(
+									ContainSubstring("main"),
+									ContainSubstring("1."),
+									ContainSubstring("PR-"),
+								),
+							),
+						),
+					),
 				)))))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
@@ -124,7 +135,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(ContainMd(SatisfyAll(
 					ContainMetric(WithName(BeElementOf(prommetricgen.MetricNames))),
-					ContainScope(WithScopeName(ContainSubstring(InstrumentationScopePrometheus))),
+					ContainScope(
+						SatisfyAll(
+							WithScopeName(ContainSubstring(InstrumentationScopePrometheus)),
+							WithScopeVersion(
+								SatisfyAny(
+									ContainSubstring("main"),
+									ContainSubstring("1."),
+									ContainSubstring("PR-"),
+								),
+							),
+						),
+					),
 				))))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
@@ -136,7 +158,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 				g.Expect(resp).To(HaveHTTPBody(ContainMd(Not(SatisfyAll(
 					ContainMetric(WithName(BeElementOf(prommetricgen.MetricNames))),
-					ContainScope(WithScopeName(ContainSubstring(InstrumentationScopePrometheus))),
+					ContainScope(
+						SatisfyAll(
+							WithScopeName(ContainSubstring(InstrumentationScopePrometheus)),
+							WithScopeVersion(
+								SatisfyAny(
+									ContainSubstring("main"),
+									ContainSubstring("1."),
+									ContainSubstring("PR-"),
+								),
+							),
+						),
+					),
 				)))))
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})

--- a/test/testkit/matchers/metric/metric_matchers.go
+++ b/test/testkit/matchers/metric/metric_matchers.go
@@ -70,6 +70,12 @@ func WithScopeName(matcher types.GomegaMatcher) types.GomegaMatcher {
 	}, matcher)
 }
 
+func WithScopeVersion(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.WithTransform(func(sm pmetric.ScopeMetrics) (string, error) {
+		return sm.Scope().Version(), nil
+	}, matcher)
+}
+
 func WithName(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return gomega.WithTransform(func(m pmetric.Metric) (string, error) {
 		return m.Name(), nil

--- a/test/testkit/matchers/metric/metric_matchers_test.go
+++ b/test/testkit/matchers/metric/metric_matchers_test.go
@@ -93,10 +93,13 @@ var _ = Describe("WithDataPointAttrs", func() {
 var _ = Describe("Contain Instrumentation Scope", func() {
 	It("should apply matcher", func() {
 		md := pmetric.NewMetrics()
-		md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Scope().SetName("container")
+		scope := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Scope()
+		scope.SetName("container")
+		scope.SetVersion("1.0")
 
 		Expect(mustMarshalMetrics(md)).Should(ContainMd(WithScope(HaveLen(1))))
 		Expect(mustMarshalMetrics(md)).Should(ContainMd(WithScope(ContainElement(WithScopeName(ContainSubstring("container"))))))
+		Expect(mustMarshalMetrics(md)).Should(ContainMd(WithScope(ContainElement(WithScopeVersion(ContainSubstring("1.0"))))))
 	})
 })
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Set module version in instrumentation scope for Prometheus metrics
- Log version after operator start

Changes refer to particular issues, PRs or documents:

-  #1000

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] New features have a milestone set.
- [ ] New features have defined acceptance criteria in a corresponding GitHub Issue, and all criteria are satisfied with this PR.
- [x] The corresponding GitHub issue has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] Adjusted the documentation if the change is user-facing.
- [x] The feature is unit-tested
- [x] The feature is e2e-tested

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->