### PR TITLE
feat: Enable self monitor

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -120,14 +120,20 @@ jobs:
           release: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy Istio Module
+      - name: Run tests without Istio
+        if: ${{ matrix.scenario == 'healthy' }}
+        run: |
+          bin/ginkgo run --tags e2e --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/e2e
+
         # we need Istio for fault injection to simulate backpressure and outages
+      - name: Deploy Istio Module
         if: ${{ matrix.scenario != 'healthy' }}
         run: hack/deploy-istio.sh
 
-      - name: Run tests
+      - name: Run tests with Istio
+        if: ${{ matrix.scenario != 'healthy' }}
         run: |
-          bin/ginkgo run --tags e2e,istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/integration/istio
+          bin/ginkgo run --tags istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -121,7 +121,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Istio Module
-        if: matrix.scenario != healthy # we need Istio for fault injection to simulate backpressure and outages
+        # we need Istio for fault injection to simulate backpressure and outages
+        if: matrix.scenario != healthy
         run: hack/deploy-istio.sh
 
       - name: Run tests

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -101,16 +101,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ginkgo-labels:
+        signal-type:
           - logs
           - metrics
           - traces
-          - logs-backpressure
-          - logs-outage
-          - traces-backpressure
-          - traces-outage
-          - metrics-backpressure
-          - metrics-outage
+        scenario:
+          - healthy
+          - backpressure
+          - outage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -123,11 +121,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Istio Module
+        if: matrix.scenario != healthy # we need Istio for fault injection to simulate backpressure and outages
         run: hack/deploy-istio.sh
 
       - name: Run tests
         run: |
-          bin/ginkgo run --tags e2e,istio --label-filter="self-mon-${{ matrix.ginkgo-labels }}" test/integration/istio
+          bin/ginkgo run --tags e2e,istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Deploy Istio Module
         # we need Istio for fault injection to simulate backpressure and outages
-        if: matrix.scenario != healthy
+        if: ${{ matrix.scenario != healthy }}
         run: hack/deploy-istio.sh
 
       - name: Run tests

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e-release:
+  e2e:
     strategy:
       fail-fast: false
       matrix:
@@ -23,6 +23,8 @@ jobs:
         - metrics
         - traces
         - telemetry
+        - max-pipeline
+        - telemetry-log-analysis
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -51,12 +53,6 @@ jobs:
         - logs
         - metrics
         - traces
-        - self-mon-logs
-        - self-mon-metrics
-        - self-mon-traces
-        - telemetry
-        - telemetry-log-analysis
-        - max-pipeline
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -68,7 +64,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        run: bin/ginkgo run --tags e2e --label-filter="${{ matrix.ginkgo-labels }}" test/e2e
+        run: bin/ginkgo run --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && v1beta1" test/e2e
 
       - name: Finalize test
         uses: "./.github/template/finalize-test"
@@ -77,17 +73,6 @@ jobs:
           failure: failure()
 
   e2e-istio:
-    strategy:
-      fail-fast: false
-      matrix:
-        ginkgo-labels:
-          - integration
-          - self-mon-logs-backpressure
-          - self-mon-logs-outage
-          - self-mon-traces-backpressure
-          - self-mon-traces-outage
-          - self-mon-metrics-backpressure
-          - self-mon-metrics-outage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -96,6 +81,7 @@ jobs:
       - name: Prepare Test
         uses: "./.github/template/prepare-test"
         with:
+          release: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Istio Module
@@ -103,7 +89,45 @@ jobs:
 
       - name: Run tests
         run: |
-          bin/ginkgo run --tags istio --label-filter="${{ matrix.ginkgo-labels }}" test/integration/istio
+          bin/ginkgo run --tags istio --label-filter="integration" test/integration/istio
+
+      - name: Finalize Test
+        uses: "./.github/template/finalize-test"
+        if: success() || failure()
+        with:
+          failure: failure()
+
+  e2e-self-mon:
+    strategy:
+      fail-fast: false
+      matrix:
+        ginkgo-labels:
+          - logs
+          - metrics
+          - traces
+          - logs-backpressure
+          - logs-outage
+          - traces-backpressure
+          - traces-outage
+          - metrics-backpressure
+          - metrics-outage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Prepare Test
+        uses: "./.github/template/prepare-test"
+        with:
+          release: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy Istio Module
+        run: hack/deploy-istio.sh
+
+      - name: Run tests
+        run: |
+          bin/ginkgo run --tags e2e,istio --label-filter="self-mon-${{ matrix.ginkgo-labels }}" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Deploy Istio Module
         # we need Istio for fault injection to simulate backpressure and outages
-        if: ${{ matrix.scenario != healthy }}
+        if: ${{ matrix.scenario != 'healthy' }}
         run: hack/deploy-istio.sh
 
       - name: Run tests

--- a/config/development/kustomization.yaml
+++ b/config/development/kustomization.yaml
@@ -19,18 +19,6 @@ labels:
     app.kubernetes.io/instance: telemetry-manager
     app.kubernetes.io/managed-by: kustomize
 
-patches:
-  - patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --self-monitor-enabled=true
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --self-monitor-priority-class=telemetry-priority-class
-    target:
-      kind: Deployment
-      name: manager
-
 resources:
 - crd
 - ../rbac

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
         - --fluent-bit-priority-class-name=telemetry-priority-class-high
         - --metric-gateway-priority-class=telemetry-priority-class
         - --trace-collector-priority-class=telemetry-priority-class
+        - --self-monitor-priority-class=telemetry-priority-class
         - --validating-webhook-enabled=true
         image: controller:latest
         name: manager

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -42,18 +42,17 @@ import (
 )
 
 type Config struct {
-	DaemonSet               types.NamespacedName
-	SectionsConfigMap       types.NamespacedName
-	FilesConfigMap          types.NamespacedName
-	LuaConfigMap            types.NamespacedName
-	ParsersConfigMap        types.NamespacedName
-	EnvSecret               types.NamespacedName
-	OutputTLSConfigSecret   types.NamespacedName
-	OverrideConfigMap       types.NamespacedName
-	PipelineDefaults        builder.PipelineDefaults
-	Overrides               overrides.Config
-	DaemonSetConfig         fluentbit.DaemonSetConfig
-	ObserveBySelfMonitoring bool
+	DaemonSet             types.NamespacedName
+	SectionsConfigMap     types.NamespacedName
+	FilesConfigMap        types.NamespacedName
+	LuaConfigMap          types.NamespacedName
+	ParsersConfigMap      types.NamespacedName
+	EnvSecret             types.NamespacedName
+	OutputTLSConfigSecret types.NamespacedName
+	OverrideConfigMap     types.NamespacedName
+	PipelineDefaults      builder.PipelineDefaults
+	Overrides             overrides.Config
+	DaemonSetConfig       fluentbit.DaemonSetConfig
 }
 
 //go:generate mockery --name DaemonSetProber --filename daemon_set_prober.go
@@ -91,27 +90,24 @@ type Reconciler struct {
 	config                     Config
 	pipelinesConditionsCleared bool
 
-	prober                   DaemonSetProber
-	flowHealthProbingEnabled bool
-	flowHealthProber         FlowHealthProber
-	tlsCertValidator         TLSCertValidator
-	syncer                   syncer
-	overridesHandler         OverridesHandler
-	istioStatusChecker       IstioStatusChecker
+	prober             DaemonSetProber
+	flowHealthProber   FlowHealthProber
+	tlsCertValidator   TLSCertValidator
+	syncer             syncer
+	overridesHandler   OverridesHandler
+	istioStatusChecker IstioStatusChecker
 }
 
 func NewReconciler(
 	client client.Client,
 	config Config,
 	agentProber DaemonSetProber,
-	flowHealthProbingEnabled bool,
 	flowHealthProber FlowHealthProber,
 	overridesHandler *overrides.Handler) *Reconciler {
 	var r Reconciler
 	r.Client = client
 	r.config = config
 	r.prober = agentProber
-	r.flowHealthProbingEnabled = flowHealthProbingEnabled
 	r.flowHealthProber = flowHealthProber
 	r.syncer = syncer{client, config}
 	r.overridesHandler = overridesHandler
@@ -201,12 +197,12 @@ func (r *Reconciler) reconcileFluentBit(ctx context.Context, pipeline *telemetry
 		return fmt.Errorf("failed to create fluent bit cluster role Binding: %w", err)
 	}
 
-	exporterMetricsService := fluentbit.MakeExporterMetricsService(r.config.DaemonSet, r.config.ObserveBySelfMonitoring)
+	exporterMetricsService := fluentbit.MakeExporterMetricsService(r.config.DaemonSet)
 	if err := k8sutils.CreateOrUpdateService(ctx, ownerRefSetter, exporterMetricsService); err != nil {
 		return fmt.Errorf("failed to reconcile exporter metrics service: %w", err)
 	}
 
-	metricsService := fluentbit.MakeMetricsService(r.config.DaemonSet, r.config.ObserveBySelfMonitoring)
+	metricsService := fluentbit.MakeMetricsService(r.config.DaemonSet)
 	if err := k8sutils.CreateOrUpdateService(ctx, ownerRefSetter, metricsService); err != nil {
 		return fmt.Errorf("failed to reconcile fluent bit metrics service: %w", err)
 	}

--- a/internal/reconciler/logpipeline/reconciler_test.go
+++ b/internal/reconciler/logpipeline/reconciler_test.go
@@ -432,13 +432,12 @@ func TestUpdateStatus(t *testing.T) {
 				flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(tt.probe, tt.probeErr)
 
 				sut := Reconciler{
-					Client:                   fakeClient,
-					config:                   testConfig,
-					prober:                   agentProberStub,
-					flowHealthProbingEnabled: true,
-					flowHealthProber:         flowHealthProberStub,
-					overridesHandler:         overridesHandlerStub,
-					istioStatusChecker:       istioStatusCheckerStub,
+					Client:             fakeClient,
+					config:             testConfig,
+					prober:             agentProberStub,
+					flowHealthProber:   flowHealthProberStub,
+					overridesHandler:   overridesHandlerStub,
+					istioStatusChecker: istioStatusCheckerStub,
 					syncer: syncer{
 						Client: fakeClient,
 						config: testConfig,

--- a/internal/reconciler/logpipeline/reconciler_test.go
+++ b/internal/reconciler/logpipeline/reconciler_test.go
@@ -59,10 +59,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -86,10 +90,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -113,10 +121,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -154,10 +166,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -198,10 +214,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -250,10 +270,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -291,10 +315,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -511,10 +539,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{
@@ -607,6 +639,10 @@ func TestUpdateStatus(t *testing.T) {
 
 				proberStub := &mocks.DaemonSetProber{}
 				proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
+
+				flowHealthProberStub := &mocks.FlowHealthProber{}
+				flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 				tlsStub := &mocks.TLSCertValidator{}
 				tlsStub.On("ValidateCertificate", mock.Anything, mock.Anything, mock.Anything).Return(tt.tlsCertErr)
 
@@ -614,6 +650,7 @@ func TestUpdateStatus(t *testing.T) {
 					Client:             fakeClient,
 					config:             testConfig,
 					prober:             proberStub,
+					flowHealthProber:   flowHealthProberStub,
 					tlsCertValidator:   tlsStub,
 					overridesHandler:   overridesHandlerStub,
 					istioStatusChecker: istioStatusCheckerStub,

--- a/internal/reconciler/logpipeline/reconciler_test.go
+++ b/internal/reconciler/logpipeline/reconciler_test.go
@@ -210,10 +210,14 @@ func TestUpdateStatus(t *testing.T) {
 		proberStub := &mocks.DaemonSetProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, assert.AnError)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.LogPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 			syncer: syncer{

--- a/internal/reconciler/logpipeline/status.go
+++ b/internal/reconciler/logpipeline/status.go
@@ -38,11 +38,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string) erro
 
 	r.setAgentHealthyCondition(ctx, &pipeline)
 	r.setFluentBitConfigGeneratedCondition(ctx, &pipeline)
-
-	if r.flowHealthProbingEnabled {
-		r.setFlowHealthCondition(ctx, &pipeline)
-	}
-
+	r.setFlowHealthCondition(ctx, &pipeline)
 	r.setLegacyConditions(ctx, &pipeline)
 
 	if err := r.Status().Update(ctx, &pipeline); err != nil {

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -96,18 +96,17 @@ type Reconciler struct {
 	client.Client
 	config Config
 
-	agentConfigBuilder       AgentConfigBuilder
-	gatewayConfigBuilder     GatewayConfigBuilder
-	agentApplier             AgentApplier
-	gatewayApplier           GatewayApplier
-	pipelineLock             PipelineLock
-	gatewayProber            DeploymentProber
-	agentProber              DaemonSetProber
-	flowHealthProbingEnabled bool
-	flowHealthProber         FlowHealthProber
-	tlsCertValidator         TLSCertValidator
-	overridesHandler         OverridesHandler
-	istioStatusChecker       IstioStatusChecker
+	agentConfigBuilder   AgentConfigBuilder
+	gatewayConfigBuilder GatewayConfigBuilder
+	agentApplier         AgentApplier
+	gatewayApplier       GatewayApplier
+	pipelineLock         PipelineLock
+	gatewayProber        DeploymentProber
+	agentProber          DaemonSetProber
+	flowHealthProber     FlowHealthProber
+	tlsCertValidator     TLSCertValidator
+	overridesHandler     OverridesHandler
+	istioStatusChecker   IstioStatusChecker
 }
 
 func NewReconciler(
@@ -115,7 +114,6 @@ func NewReconciler(
 	config Config,
 	gatewayProber DeploymentProber,
 	agentProber DaemonSetProber,
-	flowHealthProbingEnabled bool,
 	flowHealthProber FlowHealthProber,
 	overridesHandler *overrides.Handler,
 ) *Reconciler {
@@ -143,13 +141,12 @@ func NewReconciler(
 			Name:      "telemetry-metricpipeline-lock",
 			Namespace: config.Gateway.Namespace,
 		}, config.MaxPipelines),
-		gatewayProber:            gatewayProber,
-		agentProber:              agentProber,
-		flowHealthProbingEnabled: flowHealthProbingEnabled,
-		flowHealthProber:         flowHealthProber,
-		tlsCertValidator:         tlscert.New(client),
-		overridesHandler:         overridesHandler,
-		istioStatusChecker:       istiostatus.NewChecker(client),
+		gatewayProber:      gatewayProber,
+		agentProber:        agentProber,
+		flowHealthProber:   flowHealthProber,
+		tlsCertValidator:   tlscert.New(client),
+		overridesHandler:   overridesHandler,
+		istioStatusChecker: istiostatus.NewChecker(client),
 	}
 }
 

--- a/internal/reconciler/metricpipeline/reconciler_test.go
+++ b/internal/reconciler/metricpipeline/reconciler_test.go
@@ -77,6 +77,9 @@ func TestReconcile(t *testing.T) {
 		gatewayProberStub := &mocks.DeploymentProber{}
 		gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -84,6 +87,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -116,6 +120,9 @@ func TestReconcile(t *testing.T) {
 		gatewayProberStub := &mocks.DeploymentProber{}
 		gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, assert.AnError)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -123,6 +130,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -155,6 +163,9 @@ func TestReconcile(t *testing.T) {
 		gatewayProberStub := &mocks.DeploymentProber{}
 		gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -162,6 +173,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -200,6 +212,9 @@ func TestReconcile(t *testing.T) {
 		agentProberStub := &mocks.DaemonSetProber{}
 		agentProberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -210,6 +225,7 @@ func TestReconcile(t *testing.T) {
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
 			agentProber:          agentProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -249,6 +265,9 @@ func TestReconcile(t *testing.T) {
 		agentProberMock := &mocks.DaemonSetProber{}
 		agentProberMock.On("IsReady", mock.Anything, mock.Anything).Return(false, assert.AnError)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -259,6 +278,7 @@ func TestReconcile(t *testing.T) {
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
 			agentProber:          agentProberMock,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -298,6 +318,9 @@ func TestReconcile(t *testing.T) {
 		agentProberMock := &mocks.DaemonSetProber{}
 		agentProberMock.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -308,6 +331,7 @@ func TestReconcile(t *testing.T) {
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
 			agentProber:          agentProberMock,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -349,6 +373,9 @@ func TestReconcile(t *testing.T) {
 		gatewayProberStub := &mocks.DeploymentProber{}
 		gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -356,6 +383,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -388,12 +416,16 @@ func TestReconcile(t *testing.T) {
 		gatewayProberStub := &mocks.DeploymentProber{}
 		gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
 			gatewayConfigBuilder: gatewayConfigBuilderMock,
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -425,12 +457,16 @@ func TestReconcile(t *testing.T) {
 		gatewayProberStub := &mocks.DeploymentProber{}
 		gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
 			gatewayConfigBuilder: gatewayConfigBuilderMock,
 			pipelineLock:         pipelineLockStub,
 			gatewayProber:        gatewayProberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -663,6 +699,10 @@ func TestReconcile(t *testing.T) {
 
 				gatewayProberStub := &mocks.DeploymentProber{}
 				gatewayProberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
+
+				flowHealthProberStub := &mocks.FlowHealthProber{}
+				flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 				tlsStub := &mocks.TLSCertValidator{}
 				tlsStub.On("ValidateCertificate", mock.Anything, mock.Anything, mock.Anything).Return(tt.tlsCertErr)
 
@@ -673,6 +713,7 @@ func TestReconcile(t *testing.T) {
 					gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 					pipelineLock:         pipelineLockStub,
 					gatewayProber:        gatewayProberStub,
+					flowHealthProber:     flowHealthProberStub,
 					tlsCertValidator:     tlsStub,
 					overridesHandler:     overridesHandlerStub,
 					istioStatusChecker:   istioStatusCheckerStub,

--- a/internal/reconciler/metricpipeline/reconciler_test.go
+++ b/internal/reconciler/metricpipeline/reconciler_test.go
@@ -562,16 +562,15 @@ func TestReconcile(t *testing.T) {
 				flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(tt.probe, tt.probeErr)
 
 				sut := Reconciler{
-					Client:                   fakeClient,
-					config:                   testConfig,
-					gatewayConfigBuilder:     gatewayConfigBuilderMock,
-					gatewayApplier:           &otelcollector.GatewayApplier{Config: testConfig.Gateway},
-					pipelineLock:             pipelineLockStub,
-					gatewayProber:            gatewayProberStub,
-					flowHealthProbingEnabled: true,
-					flowHealthProber:         flowHealthProberStub,
-					overridesHandler:         overridesHandlerStub,
-					istioStatusChecker:       istioStatusCheckerStub,
+					Client:               fakeClient,
+					config:               testConfig,
+					gatewayConfigBuilder: gatewayConfigBuilderMock,
+					gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
+					pipelineLock:         pipelineLockStub,
+					gatewayProber:        gatewayProberStub,
+					flowHealthProber:     flowHealthProberStub,
+					overridesHandler:     overridesHandlerStub,
+					istioStatusChecker:   istioStatusCheckerStub,
 				}
 				_, err := sut.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: pipeline.Name}})
 				require.NoError(t, err)

--- a/internal/reconciler/metricpipeline/status.go
+++ b/internal/reconciler/metricpipeline/status.go
@@ -35,10 +35,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, with
 	r.setAgentHealthyCondition(ctx, &pipeline)
 	r.setGatewayHealthyCondition(ctx, &pipeline)
 	r.setGatewayConfigGeneratedCondition(ctx, &pipeline, withinPipelineCountLimit)
-
-	if r.flowHealthProbingEnabled {
-		r.setFlowHealthCondition(ctx, &pipeline)
-	}
+	r.setFlowHealthCondition(ctx, &pipeline)
 
 	if err := r.Status().Update(ctx, &pipeline); err != nil {
 		return fmt.Errorf("failed to update MetricPipeline status: %w", err)

--- a/internal/reconciler/telemetry/log_components_checker.go
+++ b/internal/reconciler/telemetry/log_components_checker.go
@@ -14,8 +14,7 @@ import (
 )
 
 type logComponentsChecker struct {
-	client                   client.Client
-	flowHealthProbingEnabled bool
+	client client.Client
 }
 
 func (l *logComponentsChecker) Check(ctx context.Context, telemetryInDeletion bool) (*metav1.Condition, error) {

--- a/internal/reconciler/telemetry/log_components_checker_test.go
+++ b/internal/reconciler/telemetry/log_components_checker_test.go
@@ -269,8 +269,7 @@ func TestLogComponentsCheck(t *testing.T) {
 			fakeClient := b.Build()
 
 			m := &logComponentsChecker{
-				client:                   fakeClient,
-				flowHealthProbingEnabled: test.flowHealthProbingEnabled,
+				client: fakeClient,
 			}
 
 			condition, err := m.Check(context.Background(), test.telemetryInDeletion)

--- a/internal/reconciler/telemetry/metric_components_checker.go
+++ b/internal/reconciler/telemetry/metric_components_checker.go
@@ -14,8 +14,7 @@ import (
 )
 
 type metricComponentsChecker struct {
-	client                   client.Client
-	flowHealthProbingEnabled bool
+	client client.Client
 }
 
 func (m *metricComponentsChecker) Check(ctx context.Context, telemetryInDeletion bool) (*metav1.Condition, error) {
@@ -67,10 +66,7 @@ func (m *metricComponentsChecker) firstUnhealthyPipelineReason(pipelines []telem
 		conditions.TypeConfigurationGenerated,
 		conditions.TypeGatewayHealthy,
 		conditions.TypeAgentHealthy,
-	}
-
-	if m.flowHealthProbingEnabled {
-		condTypes = append(condTypes, conditions.TypeFlowHealthy)
+		conditions.TypeFlowHealthy,
 	}
 
 	for _, condType := range condTypes {

--- a/internal/reconciler/telemetry/metric_components_checker_test.go
+++ b/internal/reconciler/telemetry/metric_components_checker_test.go
@@ -21,11 +21,10 @@ func TestMetricComponentsCheck(t *testing.T) {
 	configGeneratedCond := metav1.Condition{Type: conditions.TypeConfigurationGenerated, Status: metav1.ConditionTrue, Reason: conditions.ReasonAgentGatewayConfigured}
 
 	tests := []struct {
-		name                     string
-		pipelines                []telemetryv1alpha1.MetricPipeline
-		telemetryInDeletion      bool
-		flowHealthProbingEnabled bool
-		expectedCondition        *metav1.Condition
+		name                string
+		pipelines           []telemetryv1alpha1.MetricPipeline
+		telemetryInDeletion bool
+		expectedCondition   *metav1.Condition
 	}{
 		{
 			name:                "should be healthy if no pipelines deployed",
@@ -192,7 +191,6 @@ func TestMetricComponentsCheck(t *testing.T) {
 					WithStatusCondition(metav1.Condition{Type: conditions.TypeFlowHealthy, Status: metav1.ConditionFalse, Reason: conditions.ReasonSelfMonGatewayThrottling}).
 					Build(),
 			},
-			flowHealthProbingEnabled: true,
 			expectedCondition: &metav1.Condition{
 				Type:    conditions.TypeMetricComponentsHealthy,
 				Status:  "False",
@@ -209,7 +207,6 @@ func TestMetricComponentsCheck(t *testing.T) {
 					WithStatusCondition(metav1.Condition{Type: conditions.TypeFlowHealthy, Status: metav1.ConditionFalse, Reason: conditions.ReasonSelfMonGatewayThrottling}).
 					Build(),
 			},
-			flowHealthProbingEnabled: true,
 			expectedCondition: &metav1.Condition{
 				Type:    conditions.TypeMetricComponentsHealthy,
 				Status:  "False",
@@ -252,8 +249,7 @@ func TestMetricComponentsCheck(t *testing.T) {
 			fakeClient := b.Build()
 
 			m := &metricComponentsChecker{
-				client:                   fakeClient,
-				flowHealthProbingEnabled: test.flowHealthProbingEnabled,
+				client: fakeClient,
 			}
 
 			condition, err := m.Check(context.Background(), test.telemetryInDeletion)

--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -56,7 +56,6 @@ type WebhookConfig struct {
 type SelfMonitorConfig struct {
 	selfmonitor.Config
 
-	Enabled       bool
 	WebhookURL    string
 	WebhookScheme string
 }
@@ -80,15 +79,15 @@ type Reconciler struct {
 	selfMonitorApplierDeleter *selfmonitor.ApplierDeleter
 }
 
-func NewReconciler(client client.Client, scheme *runtime.Scheme, config Config, overridesHandler *overrides.Handler, flowHealthProbingEnabled bool) *Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, config Config, overridesHandler *overrides.Handler) *Reconciler {
 	return &Reconciler{
 		Client: client,
 		Scheme: scheme,
 		config: config,
 		healthCheckers: healthCheckers{
-			logs:    &logComponentsChecker{client: client, flowHealthProbingEnabled: flowHealthProbingEnabled},
-			traces:  &traceComponentsChecker{client: client, flowHealthProbingEnabled: flowHealthProbingEnabled},
-			metrics: &metricComponentsChecker{client: client, flowHealthProbingEnabled: flowHealthProbingEnabled},
+			logs:    &logComponentsChecker{client: client},
+			traces:  &traceComponentsChecker{client: client},
+			metrics: &metricComponentsChecker{client: client},
 		},
 		overridesHandler: overridesHandler,
 		selfMonitorApplierDeleter: &selfmonitor.ApplierDeleter{
@@ -137,10 +136,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Reconciler) reconcileSelfMonitor(ctx context.Context, telemetry operatorv1alpha1.Telemetry) error {
-	if !r.config.SelfMonitor.Enabled {
-		return nil
-	}
-
 	pipelinesPresent, err := r.checkPipelineExist(ctx)
 	if err != nil {
 		return err

--- a/internal/reconciler/telemetry/trace_components_checker.go
+++ b/internal/reconciler/telemetry/trace_components_checker.go
@@ -14,8 +14,7 @@ import (
 )
 
 type traceComponentsChecker struct {
-	client                   client.Client
-	flowHealthProbingEnabled bool
+	client client.Client
 }
 
 func (t *traceComponentsChecker) Check(ctx context.Context, telemetryInDeletion bool) (*metav1.Condition, error) {
@@ -67,10 +66,7 @@ func (t *traceComponentsChecker) firstUnhealthyPipelineReason(pipelines []teleme
 	condTypes := []string{
 		conditions.TypeConfigurationGenerated,
 		conditions.TypeGatewayHealthy,
-	}
-
-	if t.flowHealthProbingEnabled {
-		condTypes = append(condTypes, conditions.TypeFlowHealthy)
+		conditions.TypeFlowHealthy,
 	}
 
 	for _, condType := range condTypes {

--- a/internal/reconciler/telemetry/trace_components_checker_test.go
+++ b/internal/reconciler/telemetry/trace_components_checker_test.go
@@ -21,11 +21,10 @@ func TestTraceComponentsCheck(t *testing.T) {
 	runningCondition := metav1.Condition{Type: conditions.TypeRunning, Status: metav1.ConditionTrue, Reason: conditions.ReasonTraceGatewayDeploymentReady}
 
 	tests := []struct {
-		name                     string
-		pipelines                []telemetryv1alpha1.TracePipeline
-		telemetryInDeletion      bool
-		flowHealthProbingEnabled bool
-		expectedCondition        *metav1.Condition
+		name                string
+		pipelines           []telemetryv1alpha1.TracePipeline
+		telemetryInDeletion bool
+		expectedCondition   *metav1.Condition
 	}{
 		{
 			name:                "should be healthy if no pipelines deployed",
@@ -174,7 +173,6 @@ func TestTraceComponentsCheck(t *testing.T) {
 					WithStatusCondition(metav1.Condition{Type: conditions.TypeFlowHealthy, Status: metav1.ConditionTrue, Reason: conditions.ReasonSelfMonFlowHealthy}).
 					Build(),
 			},
-			flowHealthProbingEnabled: true,
 			expectedCondition: &metav1.Condition{
 				Type:    conditions.TypeTraceComponentsHealthy,
 				Status:  "True",
@@ -190,7 +188,6 @@ func TestTraceComponentsCheck(t *testing.T) {
 					WithStatusCondition(metav1.Condition{Type: conditions.TypeFlowHealthy, Status: metav1.ConditionFalse, Reason: conditions.ReasonSelfMonGatewayThrottling}).
 					Build(),
 			},
-			flowHealthProbingEnabled: true,
 			expectedCondition: &metav1.Condition{
 				Type:    conditions.TypeTraceComponentsHealthy,
 				Status:  "False",
@@ -233,8 +230,7 @@ func TestTraceComponentsCheck(t *testing.T) {
 			fakeClient := b.Build()
 
 			m := &traceComponentsChecker{
-				client:                   fakeClient,
-				flowHealthProbingEnabled: test.flowHealthProbingEnabled,
+				client: fakeClient,
 			}
 
 			condition, err := m.Check(context.Background(), test.telemetryInDeletion)

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -96,21 +96,19 @@ type Reconciler struct {
 	config                     Config
 	pipelinesConditionsCleared bool
 
-	gatewayConfigBuilder     GatewayConfigBuilder
-	gatewayApplier           GatewayApplier
-	pipelineLock             PipelineLock
-	prober                   DeploymentProber
-	flowHealthProbingEnabled bool
-	flowHealthProber         FlowHealthProber
-	tlsCertValidator         TLSCertValidator
-	overridesHandler         OverridesHandler
-	istioStatusChecker       IstioStatusChecker
+	gatewayConfigBuilder GatewayConfigBuilder
+	gatewayApplier       GatewayApplier
+	pipelineLock         PipelineLock
+	prober               DeploymentProber
+	flowHealthProber     FlowHealthProber
+	tlsCertValidator     TLSCertValidator
+	overridesHandler     OverridesHandler
+	istioStatusChecker   IstioStatusChecker
 }
 
 func NewReconciler(client client.Client,
 	config Config,
 	prober DeploymentProber,
-	flowHealthProbingEnabled bool,
 	flowHealthProber FlowHealthProber,
 	overridesHandler *overrides.Handler) *Reconciler {
 	return &Reconciler{
@@ -127,12 +125,11 @@ func NewReconciler(client client.Client,
 				Name:      "telemetry-tracepipeline-lock",
 				Namespace: config.Gateway.Namespace,
 			}, config.MaxPipelines),
-		prober:                   prober,
-		flowHealthProbingEnabled: flowHealthProbingEnabled,
-		flowHealthProber:         flowHealthProber,
-		tlsCertValidator:         tlscert.New(client),
-		overridesHandler:         overridesHandler,
-		istioStatusChecker:       istiostatus.NewChecker(client),
+		prober:             prober,
+		flowHealthProber:   flowHealthProber,
+		tlsCertValidator:   tlscert.New(client),
+		overridesHandler:   overridesHandler,
+		istioStatusChecker: istiostatus.NewChecker(client),
 	}
 }
 

--- a/internal/reconciler/tracepipeline/reconciler_test.go
+++ b/internal/reconciler/tracepipeline/reconciler_test.go
@@ -400,16 +400,15 @@ func TestReconcile(t *testing.T) {
 				flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(tt.probe, tt.probeErr)
 
 				sut := Reconciler{
-					Client:                   fakeClient,
-					config:                   testConfig,
-					gatewayConfigBuilder:     gatewayConfigBuilderMock,
-					gatewayApplier:           &otelcollector.GatewayApplier{Config: testConfig.Gateway},
-					pipelineLock:             pipelineLockStub,
-					prober:                   gatewayProberStub,
-					flowHealthProbingEnabled: true,
-					flowHealthProber:         flowHealthProberStub,
-					overridesHandler:         overridesHandlerStub,
-					istioStatusChecker:       istioStatusCheckerStub,
+					Client:               fakeClient,
+					config:               testConfig,
+					gatewayConfigBuilder: gatewayConfigBuilderMock,
+					gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
+					pipelineLock:         pipelineLockStub,
+					prober:               gatewayProberStub,
+					flowHealthProber:     flowHealthProberStub,
+					overridesHandler:     overridesHandlerStub,
+					istioStatusChecker:   istioStatusCheckerStub,
 				}
 				_, err := sut.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: pipeline.Name}})
 				require.NoError(t, err)

--- a/internal/reconciler/tracepipeline/reconciler_test.go
+++ b/internal/reconciler/tracepipeline/reconciler_test.go
@@ -65,6 +65,9 @@ func TestReconcile(t *testing.T) {
 		proberStub := &mocks.DeploymentProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -72,6 +75,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			prober:               proberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -111,6 +115,9 @@ func TestReconcile(t *testing.T) {
 		proberStub := &mocks.DeploymentProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -118,6 +125,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			prober:               proberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -159,12 +167,16 @@ func TestReconcile(t *testing.T) {
 		proberStub := &mocks.DeploymentProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
 			gatewayConfigBuilder: gatewayConfigBuilderMock,
 			pipelineLock:         pipelineLockStub,
 			prober:               proberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -214,6 +226,9 @@ func TestReconcile(t *testing.T) {
 		proberStub := &mocks.DeploymentProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -221,6 +236,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			prober:               proberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -259,11 +275,15 @@ func TestReconcile(t *testing.T) {
 		proberStub := &mocks.DeploymentProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:             fakeClient,
 			config:             testConfig,
 			pipelineLock:       pipelineLockStub,
 			prober:             proberStub,
+			flowHealthProber:   flowHealthProberStub,
 			overridesHandler:   overridesHandlerStub,
 			istioStatusChecker: istioStatusCheckerStub,
 		}
@@ -469,6 +489,9 @@ func TestReconcile(t *testing.T) {
 		proberStub := &mocks.DeploymentProber{}
 		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(false, nil)
 
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 		sut := Reconciler{
 			Client:               fakeClient,
 			config:               testConfig,
@@ -476,6 +499,7 @@ func TestReconcile(t *testing.T) {
 			gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 			pipelineLock:         pipelineLockStub,
 			prober:               proberStub,
+			flowHealthProber:     flowHealthProberStub,
 			overridesHandler:     overridesHandlerStub,
 			istioStatusChecker:   istioStatusCheckerStub,
 		}
@@ -574,6 +598,9 @@ func TestReconcile(t *testing.T) {
 				tlsStub := &mocks.TLSCertValidator{}
 				tlsStub.On("ValidateCertificate", mock.Anything, mock.Anything, mock.Anything).Return(tt.tlsCertErr)
 
+				flowHealthProberStub := &mocks.FlowHealthProber{}
+				flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
 				sut := Reconciler{
 					Client:               fakeClient,
 					config:               testConfig,
@@ -581,6 +608,7 @@ func TestReconcile(t *testing.T) {
 					gatewayApplier:       &otelcollector.GatewayApplier{Config: testConfig.Gateway},
 					pipelineLock:         pipelineLockStub,
 					prober:               proberStub,
+					flowHealthProber:     flowHealthProberStub,
 					tlsCertValidator:     tlsStub,
 					overridesHandler:     overridesHandlerStub,
 					istioStatusChecker:   istioStatusCheckerStub,

--- a/internal/reconciler/tracepipeline/status.go
+++ b/internal/reconciler/tracepipeline/status.go
@@ -35,7 +35,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, with
 	r.setGatewayHealthyCondition(ctx, &pipeline)
 	r.setGatewayConfigGeneratedCondition(ctx, &pipeline, withinPipelineCountLimit)
 	r.setFlowHealthCondition(ctx, &pipeline)
-	r.setLegacyConditions(ctx, &pipeline, withinPipelineCountLimit)
+	r.setLegacyConditions(ctx, &pipeline)
 
 	if err := r.Status().Update(ctx, &pipeline); err != nil {
 		return fmt.Errorf("failed to update TracePipeline status: %w", err)

--- a/internal/reconciler/tracepipeline/status.go
+++ b/internal/reconciler/tracepipeline/status.go
@@ -34,9 +34,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, pipelineName string, with
 
 	r.setGatewayHealthyCondition(ctx, &pipeline)
 	r.setGatewayConfigGeneratedCondition(ctx, &pipeline, withinPipelineCountLimit)
-	if r.flowHealthProbingEnabled {
-		r.setFlowHealthCondition(ctx, &pipeline)
-	}
+	r.setFlowHealthCondition(ctx, &pipeline)
 	r.setLegacyConditions(ctx, &pipeline, withinPipelineCountLimit)
 
 	if err := r.Status().Update(ctx, &pipeline); err != nil {

--- a/internal/resources/fluentbit/resources.go
+++ b/internal/resources/fluentbit/resources.go
@@ -265,11 +265,9 @@ func MakeClusterRole(name types.NamespacedName) *rbacv1.ClusterRole {
 	return &clusterRole
 }
 
-func MakeMetricsService(name types.NamespacedName, observeBySelfMonitoring bool) *corev1.Service {
+func MakeMetricsService(name types.NamespacedName) *corev1.Service {
 	serviceLabels := Labels()
-	if observeBySelfMonitoring {
-		serviceLabels["telemetry.kyma-project.io/self-monitor"] = "enabled"
-	}
+	serviceLabels["telemetry.kyma-project.io/self-monitor"] = "enabled"
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-metrics", name.Name),
@@ -297,11 +295,9 @@ func MakeMetricsService(name types.NamespacedName, observeBySelfMonitoring bool)
 	}
 }
 
-func MakeExporterMetricsService(name types.NamespacedName, observeBySelfMonitoring bool) *corev1.Service {
+func MakeExporterMetricsService(name types.NamespacedName) *corev1.Service {
 	serviceLabels := Labels()
-	if observeBySelfMonitoring {
-		serviceLabels["telemetry.kyma-project.io/self-monitor"] = "enabled"
-	}
+	serviceLabels["telemetry.kyma-project.io/self-monitor"] = "enabled"
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/resources/fluentbit/resources_test.go
+++ b/internal/resources/fluentbit/resources_test.go
@@ -85,7 +85,7 @@ func TestMakeClusterRole(t *testing.T) {
 
 func TestMakeMetricsService(t *testing.T) {
 	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
-	service := MakeMetricsService(name, true)
+	service := MakeMetricsService(name)
 
 	require.NotNil(t, service)
 	require.Equal(t, service.Name, "telemetry-fluent-bit-metrics")
@@ -107,7 +107,7 @@ func TestMakeMetricsService(t *testing.T) {
 
 func TestMakeExporterMetricsService(t *testing.T) {
 	name := types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: "telemetry-system"}
-	service := MakeExporterMetricsService(name, true)
+	service := MakeExporterMetricsService(name)
 
 	require.NotNil(t, service)
 	require.Equal(t, service.Name, "telemetry-fluent-bit-exporter-metrics")

--- a/internal/resources/otelcollector/agent.go
+++ b/internal/resources/otelcollector/agent.go
@@ -38,14 +38,7 @@ type AgentApplyOptions struct {
 func (aa *AgentApplier) ApplyResources(ctx context.Context, c client.Client, opts AgentApplyOptions) error {
 	name := types.NamespacedName{Namespace: aa.Config.Namespace, Name: aa.Config.BaseName}
 
-	if err := applyCommonResources(
-		ctx,
-		c,
-		name,
-		aa.makeAgentClusterRole(),
-		opts.AllowedPorts,
-		aa.Config.ObserveBySelfMonitoring,
-	); err != nil {
+	if err := applyCommonResources(ctx, c, name, aa.makeAgentClusterRole(), opts.AllowedPorts); err != nil {
 		return fmt.Errorf("failed to create common resource: %w", err)
 	}
 

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -216,60 +216,6 @@ func TestApplyAgentResources(t *testing.T) {
 		require.Equal(t, name+"-metrics", svc.Name)
 		require.Equal(t, namespace, svc.Namespace)
 		require.Equal(t, map[string]string{
-			"app.kubernetes.io/name": name,
-		}, svc.Labels)
-		require.Equal(t, map[string]string{
-			"app.kubernetes.io/name": name,
-		}, svc.Spec.Selector)
-		require.Equal(t, map[string]string{
-			"prometheus.io/port":   "8888",
-			"prometheus.io/scheme": "http",
-			"prometheus.io/scrape": "true",
-		}, svc.Annotations)
-		require.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
-		require.Len(t, svc.Spec.Ports, 1)
-		require.Equal(t, corev1.ServicePort{
-			Name:       "http-metrics",
-			Protocol:   corev1.ProtocolTCP,
-			Port:       8888,
-			TargetPort: intstr.FromInt32(8888),
-		}, svc.Spec.Ports[0])
-	})
-}
-
-func TestApplyAgentResources_WithSelfMonEnabled(t *testing.T) {
-	ctx := context.Background()
-	client := fake.NewClientBuilder().Build()
-	namespace := "my-namespace"
-	name := "my-agent"
-	cfg := "dummy otel collector config"
-
-	sut := AgentApplier{
-		Config: AgentConfig{
-			Config: Config{
-				BaseName:                name,
-				Namespace:               namespace,
-				ObserveBySelfMonitoring: true,
-			},
-		},
-	}
-
-	err := sut.ApplyResources(ctx, client, AgentApplyOptions{
-		AllowedPorts:        []int32{5555, 6666},
-		CollectorConfigYAML: cfg,
-	})
-	require.NoError(t, err)
-
-	t.Run("should create metrics service", func(t *testing.T) {
-		var svcs corev1.ServiceList
-		require.NoError(t, client.List(ctx, &svcs))
-		require.Len(t, svcs.Items, 1)
-
-		svc := svcs.Items[0]
-		require.NotNil(t, svc)
-		require.Equal(t, name+"-metrics", svc.Name)
-		require.Equal(t, namespace, svc.Namespace)
-		require.Equal(t, map[string]string{
 			"app.kubernetes.io/name":                 name,
 			"telemetry.kyma-project.io/self-monitor": "enabled",
 		}, svc.Labels)

--- a/internal/resources/otelcollector/config.go
+++ b/internal/resources/otelcollector/config.go
@@ -5,9 +5,8 @@ import (
 )
 
 type Config struct {
-	BaseName                string
-	Namespace               string
-	ObserveBySelfMonitoring bool
+	BaseName  string
+	Namespace string
 }
 
 type GatewayConfig struct {

--- a/internal/resources/otelcollector/gateway.go
+++ b/internal/resources/otelcollector/gateway.go
@@ -49,14 +49,7 @@ type GatewayApplyOptions struct {
 func (ga *GatewayApplier) ApplyResources(ctx context.Context, c client.Client, opts GatewayApplyOptions) error {
 	name := types.NamespacedName{Namespace: ga.Config.Namespace, Name: ga.Config.BaseName}
 
-	if err := applyCommonResources(
-		ctx,
-		c,
-		name,
-		ga.makeGatewayClusterRole(name),
-		opts.AllowedPorts,
-		ga.Config.ObserveBySelfMonitoring,
-	); err != nil {
+	if err := applyCommonResources(ctx, c, name, ga.makeGatewayClusterRole(name), opts.AllowedPorts); err != nil {
 		return fmt.Errorf("failed to create common resource: %w", err)
 	}
 

--- a/test/e2e/logs_self_monitor_healthy_test.go
+++ b/test/e2e/logs_self_monitor_healthy_test.go
@@ -3,31 +3,26 @@
 package e2e
 
 import (
-	"net/http"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/prometheus"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
-	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
 
-var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTraces), Ordered, func() {
+var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsHealthy), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
 		pipelineName     = suite.ID()
@@ -36,74 +31,61 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTraces), Ordered, fu
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
-
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
-		backend := backend.New(mockNs, backend.SignalTypeTraces)
+		backend := backend.New(mockNs, backend.SignalTypeLogs)
+		logProducer := loggen.New(mockNs)
 		objs = append(objs, backend.K8sObjects()...)
+		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
-		tracePipeline := testutils.NewTracePipelineBuilder().
+		logPipeline := testutils.NewLogPipelineBuilder().
 			WithName(pipelineName).
-			WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+			WithHTTPOutput(testutils.HTTPHost(backend.Host()), testutils.HTTPPort(backend.Port())).
 			Build()
-		objs = append(objs,
-			&tracePipeline,
-			telemetrygen.NewPod(kitkyma.DefaultNamespaceName, telemetrygen.SignalTypeTraces).K8sObject(),
-		)
+		objs = append(objs, &logPipeline)
 
 		return objs
 	}
 
-	Context("When a trace pipeline exists", Ordered, func() {
+	Context("Before deploying a logpipeline", func() {
+		It("Should have a healthy webhook", func() {
+			assert.WebhookHealthy(ctx, k8sClient)
+		})
+	})
+
+	Context("When a logpipeline exists", Ordered, func() {
 		BeforeAll(func() {
 			k8sObjects := makeResources()
-
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
 			})
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
 		})
 
+		It("Should have a running logpipeline", func() {
+			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})
 
-		It("Should have a network policy deployed", func() {
-			var networkPolicy networkingv1.NetworkPolicy
-			Expect(k8sClient.Get(ctx, kitkyma.SelfMonitorNetworkPolicy, &networkPolicy)).To(Succeed())
+		It("Should have a log backend running", func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: backend.DefaultName})
+		})
 
+		It("Should have a log producer running", func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
+		})
+
+		It("Should have produced logs in the backend", func() {
+			assert.LogsDelivered(proxyClient, loggen.DefaultName, backendExportURL)
+		})
+
+		It("Should have TypeFlowHealthy condition set to True", func() {
 			Eventually(func(g Gomega) {
-				var podList corev1.PodList
-				g.Expect(k8sClient.List(ctx, &podList, client.InNamespace(kitkyma.SystemNamespaceName), client.MatchingLabels{"app.kubernetes.io/name": kitkyma.SelfMonitorBaseName})).To(Succeed())
-				g.Expect(podList.Items).NotTo(BeEmpty())
-
-				selfMonitorPodName := podList.Items[0].Name
-				pprofEndpoint := proxyClient.ProxyURLForPod(kitkyma.SystemNamespaceName, selfMonitorPodName, "debug/pprof/", ports.Pprof)
-
-				resp, err := proxyClient.Get(pprofEndpoint)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(resp).To(HaveHTTPStatus(http.StatusServiceUnavailable))
-			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
-		})
-
-		It("Should have service deployed", func() {
-			var service corev1.Service
-			Expect(k8sClient.Get(ctx, kitkyma.SelfMonitorName, &service)).To(Succeed())
-		})
-
-		It("Should have a running pipeline", func() {
-			assert.TracePipelineHealthy(ctx, k8sClient, pipelineName)
-		})
-
-		It("Should deliver telemetrygen traces", func() {
-			assert.TracesFromNamespaceDelivered(proxyClient, backendExportURL, kitkyma.DefaultNamespaceName)
-		})
-
-		It("The telemetryFlowHealthy condition should be true", func() {
-			// TODO: add the conditions.TypeFlowHealthy check to assert.TracePipelineHealthy after self monitor is released
-			Eventually(func(g Gomega) {
-				var pipeline telemetryv1alpha1.TracePipeline
+				var pipeline telemetryv1alpha1.LogPipeline
 				key := types.NamespacedName{Name: pipelineName}
 				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 				g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeFlowHealthy)).To(BeTrue())

--- a/test/e2e/metrics_self_monitor_healthy_test.go
+++ b/test/e2e/metrics_self_monitor_healthy_test.go
@@ -3,26 +3,31 @@
 package e2e
 
 import (
+	"net/http"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/prometheus"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
-	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
 
-var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogs), Ordered, func() {
+var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsHealthy), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
 		pipelineName     = suite.ID()
@@ -31,61 +36,78 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogs), Ordered, func
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
+
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
-		backend := backend.New(mockNs, backend.SignalTypeLogs)
-		logProducer := loggen.New(mockNs)
+		backend := backend.New(mockNs, backend.SignalTypeMetrics)
 		objs = append(objs, backend.K8sObjects()...)
-		objs = append(objs, logProducer.K8sObject())
 		backendExportURL = backend.ExportURL(proxyClient)
 
-		logPipeline := testutils.NewLogPipelineBuilder().
+		pipeline := testutils.NewMetricPipelineBuilder().
 			WithName(pipelineName).
-			WithHTTPOutput(testutils.HTTPHost(backend.Host()), testutils.HTTPPort(backend.Port())).
+			WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
 			Build()
-		objs = append(objs, &logPipeline)
+		objs = append(objs,
+			telemetrygen.NewPod(kitkyma.DefaultNamespaceName, telemetrygen.SignalTypeMetrics).K8sObject(),
+			&pipeline,
+		)
 
 		return objs
 	}
 
-	Context("Before deploying a logpipeline", func() {
-		It("Should have a healthy webhook", func() {
-			assert.WebhookHealthy(ctx, k8sClient)
-		})
-	})
-
-	Context("When a logpipeline exists", Ordered, func() {
+	Context("When a metric pipeline exists", Ordered, func() {
 		BeforeAll(func() {
 			k8sObjects := makeResources()
+
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
 			})
 			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
 		})
 
-		It("Should have a running logpipeline", func() {
-			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
-		})
-
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})
 
-		It("Should have a log backend running", func() {
-			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: backend.DefaultName})
+		It("Should have a network policy deployed", func() {
+			var networkPolicy networkingv1.NetworkPolicy
+			Expect(k8sClient.Get(ctx, kitkyma.SelfMonitorNetworkPolicy, &networkPolicy)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				var podList corev1.PodList
+				g.Expect(k8sClient.List(ctx, &podList, client.InNamespace(kitkyma.SystemNamespaceName), client.MatchingLabels{"app.kubernetes.io/name": kitkyma.SelfMonitorBaseName})).To(Succeed())
+				g.Expect(podList.Items).NotTo(BeEmpty())
+
+				selfMonitorPodName := podList.Items[0].Name
+				pprofEndpoint := proxyClient.ProxyURLForPod(kitkyma.SystemNamespaceName, selfMonitorPodName, "debug/pprof/", ports.Pprof)
+
+				resp, err := proxyClient.Get(pprofEndpoint)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusServiceUnavailable))
+			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 		})
 
-		It("Should have a log producer running", func() {
-			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
+		It("Should have service deployed", func() {
+			var service corev1.Service
+			Expect(k8sClient.Get(ctx, kitkyma.SelfMonitorName, &service)).To(Succeed())
 		})
 
-		It("Should have produced logs in the backend", func() {
-			assert.LogsDelivered(proxyClient, loggen.DefaultName, backendExportURL)
+		It("Should have a metrics backend running", func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
+		})
+
+		It("Should have a running pipeline", func() {
+			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should deliver telemetrygen metrics", func() {
+			assert.MetricsFromNamespaceDelivered(proxyClient, backendExportURL, kitkyma.DefaultNamespaceName, telemetrygen.MetricNames)
 		})
 
 		It("Should have TypeFlowHealthy condition set to True", func() {
+			// TODO: add the conditions.TypeFlowHealthy check to assert.MetricPipelineHealthy after self monitor is released
 			Eventually(func(g Gomega) {
-				var pipeline telemetryv1alpha1.LogPipeline
+				var pipeline telemetryv1alpha1.MetricPipeline
 				key := types.NamespacedName{Name: pipelineName}
 				g.Expect(k8sClient.Get(ctx, key, &pipeline)).To(Succeed())
 				g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeFlowHealthy)).To(BeTrue())

--- a/test/testkit/suite/suite.go
+++ b/test/testkit/suite/suite.go
@@ -43,23 +43,22 @@ const (
 	LabelTraces                = "traces"
 	LabelMetrics               = "metrics"
 	LabelTelemetry             = "telemetry"
-	LabelSelfMonitoringLogs    = "self-mon-logs"
-	LabelSelfMonitoringTraces  = "self-mon-traces"
-	LabelSelfMonitoringMetrics = "self-mon-metrics"
 	LabelV1Beta1               = "v1beta1"
 	LabelTelemetryLogsAnalysis = "telemetry-logs-analysis"
 	LabelMaxPipeline           = "max-pipeline"
 
-	// Istio test labels
-	LabelIntegration                    = "integration"
-	LabelSelfMonitoringLogsBackpressure = "self-mon-logs-backpressure"
-	LabelSelfMonitoringLogsOutage       = "self-mon-logs-outage"
-
-	LabelSelfMonitoringTracesBackpressure = "self-mon-traces-backpressure"
-	LabelSelfMonitoringTracesOutage       = "self-mon-traces-outage"
-
+	LabelSelfMonitoringLogsHealthy         = "self-mon-logs-healthy"
+	LabelSelfMonitoringLogsBackpressure    = "self-mon-logs-backpressure"
+	LabelSelfMonitoringLogsOutage          = "self-mon-logs-outage"
+	LabelSelfMonitoringTracesHealthy       = "self-mon-traces-healthy"
+	LabelSelfMonitoringTracesBackpressure  = "self-mon-traces-backpressure"
+	LabelSelfMonitoringTracesOutage        = "self-mon-traces-outage"
+	LabelSelfMonitoringMetricsHealthy      = "self-mon-metrics-healthy"
 	LabelSelfMonitoringMetricsBackpressure = "self-mon-metrics-backpressure"
 	LabelSelfMonitoringMetricsOutage       = "self-mon-metrics-outage"
+
+	// Istio test label
+	LabelIntegration = "integration"
 
 	// Operational tests preserve K8s objects between test runs.
 	LabelOperational = "operational"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove the feature flags, enable self-monitoring by default
- Restructure the e2e tests into 3 test families:
`e2e` - runs all the non-istio tests (except self-monitoring)
`e2e-dev` - runs v1beta1 basic tests
`e2e-istio` runs Istio integration tests
`e2e-self-mon` - 3x3 matrix that runs 3 self-monitoring scenarios for 3 signal types 

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/pull/1136

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [x] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
