### PR TITLE
chore: Fix spelling of OTel acronym

### DIFF
--- a/apis/telemetry/v1alpha1/tracepipeline_types.go
+++ b/apis/telemetry/v1alpha1/tracepipeline_types.go
@@ -28,7 +28,7 @@ type TracePipelineSpec struct {
 
 // TracePipelineOutput defines the output configuration section.
 type TracePipelineOutput struct {
-	// Configures the underlying Otel Collector with an [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md). If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) is used.
+	// Configures the underlying OTel Collector with an [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md). If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) is used.
 	Otlp *OtlpOutput `json:"otlp"`
 }
 

--- a/apis/telemetry/v1beta1/tracepipeline_types.go
+++ b/apis/telemetry/v1beta1/tracepipeline_types.go
@@ -48,7 +48,7 @@ type TracePipelineSpec struct {
 
 // TracePipelineOutput defines the output configuration section.
 type TracePipelineOutput struct {
-	// Configures the underlying Otel Collector with an [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md). If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) is used.
+	// Configures the underlying OTel Collector with an [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md). If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) is used.
 	OTLP *OTLPOutput `json:"otlp"`
 }
 

--- a/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -59,7 +59,7 @@ spec:
                   can be defined per pipeline.
                 properties:
                   otlp:
-                    description: Configures the underlying Otel Collector with an
+                    description: Configures the underlying OTel Collector with an
                       [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md).
                       If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)
                       is used.

--- a/config/development/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_tracepipelines.yaml
@@ -59,7 +59,7 @@ spec:
                   can be defined per pipeline.
                 properties:
                   otlp:
-                    description: Configures the underlying Otel Collector with an
+                    description: Configures the underlying OTel Collector with an
                       [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md).
                       If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)
                       is used.
@@ -470,7 +470,7 @@ spec:
                   can be defined per pipeline.
                 properties:
                   otlp:
-                    description: Configures the underlying Otel Collector with an
+                    description: Configures the underlying OTel Collector with an
                       [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md).
                       If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)
                       is used.

--- a/docs/contributor/arch/001-otel-collector-metric-based-pipeline-status.md
+++ b/docs/contributor/arch/001-otel-collector-metric-based-pipeline-status.md
@@ -54,7 +54,7 @@ However, this setup does come with its drawbacks:
 
 #### Standalone Prometheus Deployment
 
-An alternative approach would involve embedding Prometheus in the code of Telemetry Manager, similar to how we deploy Fluent Bit or Otel Collector.
+An alternative approach would involve embedding Prometheus in the code of Telemetry Manager, similar to how we deploy Fluent Bit or OTel Collector.
 This approach grants you complete control and maximum flexibility in managing Prometheus.
 It's equally important to communicate to the end user that this internal Prometheus is intended exclusively for internal purposes and should not be utilized for monitoring user workloads.
 Clear communication regarding its internal nature is crucial to avoid any misuses or misunderstandings.

--- a/docs/contributor/pocs/otlp-logs.md
+++ b/docs/contributor/pocs/otlp-logs.md
@@ -124,7 +124,7 @@ We split the OpenTelemetry Collector for log processing to an agent (DaemonSet) 
 
 The following figure shows the different plugins that are configured in the processing pipeline. Note the use of the batch processor in the gateway, which introduces asynchronicity to the pipeline and causes that backpressure is not propagated back to the agent. To minimize the risk of log loss due to the batch processors properties, a persistent exporter queue was introduced in the gateway, which uses a persistent volume to buffer logs in case of a backend failure.
 
-![Otel Collector Setup](./assets/otlp-logs.drawio.svg)
+![OTel Collector Setup](./assets/otlp-logs.drawio.svg)
 
 To deploy the OpenTelemetry Collector agent and gateway, perform the following steps:
 

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -67,7 +67,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | Parameter | Type | Description |
 | ---- | ----------- | ---- |
 | **output** (required) | object | Defines a destination for shipping trace data. Only one can be defined per pipeline. |
-| **output.&#x200b;otlp** (required) | object | Configures the underlying Otel Collector with an [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md). If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) is used. |
+| **output.&#x200b;otlp** (required) | object | Configures the underlying OTel Collector with an [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/README.md). If you switch `protocol`to `http`, an [OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) is used. |
 | **output.&#x200b;otlp.&#x200b;authentication**  | object | Defines authentication options for the OTLP output |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic**  | object | Activates `Basic` authentication for the destination providing relevant Secrets. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;password** (required) | object | Contains the basic auth password or a Secret reference. |


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Consistent spelling for “OTel” (see official acronym at https://opentelemetry.io/docs/specs/otel/#project-naming)

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
