### PR TITLE
fix: Remove labeldrop from self-monitor scrape config

### DIFF
--- a/internal/selfmonitor/config/config_builder.go
+++ b/internal/selfmonitor/config/config_builder.go
@@ -112,10 +112,6 @@ func makeScrapeConfig(scrapeNamespace string) []ScrapeConfig {
 					Regex:        "otelcol_.+;.+/([a-zA-Z0-9-]+)",
 					TargetLabel:  "pipeline_name",
 				},
-				{
-					Action: LabelDrop,
-					Regex:  "^(receiver|exporter|directory|service_instance_id|service_version|transport|service_name|alertname|job|instance|namespace|node)$",
-				},
 			},
 			KubernetesDiscoveryConfigs: []KubernetesDiscoveryConfig{{
 				Role:       RoleEndpoints,

--- a/internal/selfmonitor/config/testdata/config.yaml
+++ b/internal/selfmonitor/config/testdata/config.yaml
@@ -52,8 +52,6 @@ scrape_configs:
           regex: otelcol_.+;.+/([a-zA-Z0-9-]+)
           target_label: pipeline_name
           action: replace
-        - regex: ^(receiver|exporter|directory|service_instance_id|service_version|transport|service_name|alertname|job|instance|namespace|node)$
-          action: labeldrop
       kubernetes_sd_configs:
         - role: endpoints
           namespaces:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove labeldrop statements from self-monitor's scrape config to fix false positive flow health conditions.

Changes refer to particular issues, PRs or documents:

- #1187

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
