### PR TITLE
fix: Wrong github action load test cluster name

### DIFF
--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -35,7 +35,7 @@ jobs:
             backpressure: "true"
             multi: "false"
             image: "otel-collector"
-          - name: "ci-traces-b"
+          - name: "ci-traces-mb"
             type: "traces"
             backpressure: "true"
             multi: "true"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix wrong cluster name ci-traces-b, this conflicting with previous run

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
