### PR TITLE
feat: Update of self monitor to prometheus 2.53.0

### DIFF
--- a/docs/contributor/benchmarks/README.md
+++ b/docs/contributor/benchmarks/README.md
@@ -307,6 +307,7 @@ Each test scenario has its own test scripts responsible for preparing the test s
 | 3.0.7 (new metrics) |                  4036                   |                   7173                   |              31689              |       825,852        |    0.1,0.1    |                  2481                   |                   1852                   |             104689              |       747,395        |     0.1,0     |                   1520                   |                   484                    |              37907              |       561,731        |    0.1,0.1    |                   807                    |                    58                    |              94365              |       544,211        |      0,0      |
 |         3.0.7 (new) |                  9514                   |                  30273                   |              30263              |       105, 113       |     1, 1      |                  9027                   |                  23850                   |             1521511             |       186, 552       |    1, 0.7     |                   7285                   |                   8357                   |             1891569             |       662, 668       |   0.8, 0.8    |                   5602                   |                   2619                   |             5249308             |       680, 713       |   0.5, 0.5    |
 
+
 </div>
 
 ## Self Monitor
@@ -352,11 +353,12 @@ Configured memory, CPU limits, and storage are based on this base value and will
 
 <div class="table-wrapper" markdown="block">
 
-| Version/Test |      Default       |                      |                               |                      |               | 
-|-------------:|:------------------:|:--------------------:|:-----------------------------:|:--------------------:|:-------------:|
-|              | Scrape Samples/sec | Total Series Created | Head Chunk Storage Size/bytes | Pod Memory Usage(MB) | Pod CPU Usage | 
-|       2.45.5 |        15.4        |         157          |            131072             |          62          |       0       | 
-|  2.45.5(new) |        15.4        |         239          |            131072             |          42          |       0       | 
+| Version/Test |Default (ci-self-monitor)|                 |                                  |                      |               | 
+|-------------:|:------------------:|:--------------------:|:--------------------------------:|:--------------------:|:-------------:|
+|              | Scrape Samples/sec | Total Series Created | Head Chunk Storage Size in bytes | Pod Memory Usage(MB) | Pod CPU Usage | 
+|       2.45.5 |        15.4        |         157          |            131072                |          62          |       0       | 
+|  2.45.5(new) |        15.4        |         239          |            131072                |          42          |       0       | 
+|       2.53.0 |        20.4        |         210          |                 0                |          36          |       0       |
 
 
 </div>

--- a/hack/load-tests/run-load-test.sh
+++ b/hack/load-tests/run-load-test.sh
@@ -361,11 +361,11 @@ function get_result_and_cleanup_fluentbit() {
 # shellcheck disable=SC2112
 function get_result_and_cleanup_selfmonitor() {
    # ingestion rate per second for scrape samples https://valyala.medium.com/prometheus-storage-technical-terms-for-humans-4ab4de6c3d48
-   SCRAPESAMPLES=$(curl -fs --data-urlencode 'query=sum_over_time(scrape_samples_scraped{service="telemetry-self-monitor-metrics"}[20m]) / 1200' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
+   SCRAPESAMPLES=$(curl -fs --data-urlencode 'query=round(sum(sum_over_time(scrape_samples_scraped{service="telemetry-self-monitor-metrics"}[20m]) / 1200))' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
 
-   SERIESCREATED=$(curl -fs --data-urlencode 'query=max(prometheus_tsdb_head_series{service="telemetry-self-monitor-metrics"})' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
+   SERIESCREATED=$(curl -fs --data-urlencode 'query=round(sum(max_over_time(prometheus_tsdb_head_series{service="telemetry-self-monitor-metrics"}[20m])))' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
 
-   HEADSTORAGESIZE=$(curl -fs --data-urlencode 'query=max(prometheus_tsdb_head_chunks_storage_size_bytes{service="telemetry-self-monitor-metrics"})' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
+   HEADSTORAGESIZE=$(curl -fs --data-urlencode 'query=round(sum(max_over_time(prometheus_tsdb_head_chunks_storage_size_bytes{service="telemetry-self-monitor-metrics"}[20m])))' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
 
    MEMORY=$(curl -fs --data-urlencode 'query=round(sum(avg_over_time(container_memory_working_set_bytes{namespace="kyma-system", container="self-monitor"}[20m]) * on(namespace,pod) group_left(workload) avg_over_time(namespace_workload_pod:kube_pod_owner:relabel{namespace="kyma-system", workload="telemetry-self-monitor"}[20m])) by (pod) / 1024 / 1024)' localhost:9090/api/v1/query | jq -r '.data.result[] | .value[1]')
 

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ const (
 	defaultOtelImage              = "europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.102.1-fbfb6cdc"
 	defaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:3.0.7-1e5449d3"
 	defaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240605-7743c77e"
-	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.45.5-4f1be411"
+	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.0-8691013b"
 
 	overridesConfigMapName = "telemetry-override-config"
 	overridesConfigMapKey  = "override-config"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -4,7 +4,7 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.102.1-fbfb6cdc
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:3.0.7-1e5449d3
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240404-fd3588ce
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.45.5-4f1be411
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.0-8691013b
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Update of self monitor to prometheus 2.53.0
- 2.53.0 is the next LTS release of prometheus (https://prometheus.io/docs/introduction/release-cycle/)
- updated to alpine 1.20 as well
- improved perf test metrics to be consistent with other queries and considering the maximums over the whole execution time

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/third-party-images/pull/438
- https://github.com/kyma-project/telemetry-manager/actions/runs/9600191641/job/26475782779

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
