### PR TITLE
test: Add TracePipeline reconciler unit test when all TracePipelines are non-reconcilable

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -29,7 +29,7 @@ override:
     path: ^internal/reconciler/metricpipeline$
   - threshold: 65
     path: ^internal/reconciler/telemetry$
-  - threshold: 75
+  - threshold: 76
     path: ^internal/reconciler/tracepipeline$
   - threshold: 83
     path: ^internal/resources/otelcollector$

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -55,6 +55,11 @@ type GatewayConfigBuilder interface {
 	Build(ctx context.Context, pipelines []telemetryv1alpha1.TracePipeline) (*gateway.Config, otlpexporter.EnvVars, error)
 }
 
+type GatewayResourcesHandler interface {
+	ApplyResources(ctx context.Context, c client.Client, opts otelcollector.GatewayApplyOptions) error
+	DeleteResources(ctx context.Context, c client.Client, isIstioActive bool) error
+}
+
 //go:generate mockery --name PipelineLock --filename pipeline_lock.go
 type PipelineLock interface {
 	TryAcquireLock(ctx context.Context, owner metav1.Object) error
@@ -91,7 +96,7 @@ type Reconciler struct {
 	pipelinesConditionsCleared bool
 
 	gatewayConfigBuilder    GatewayConfigBuilder
-	gatewayResourcesHandler *otelcollector.GatewayResourcesHandler
+	gatewayResourcesHandler GatewayResourcesHandler
 	pipelineLock            PipelineLock
 	prober                  DeploymentProber
 	flowHealthProber        FlowHealthProber

--- a/internal/reconciler/tracepipeline/reconciler_test.go
+++ b/internal/reconciler/tracepipeline/reconciler_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/trace/gateway"
 	"github.com/kyma-project/telemetry-manager/internal/overrides"
-	"github.com/kyma-project/telemetry-manager/internal/reconciler/logpipeline/stubs"
 	"github.com/kyma-project/telemetry-manager/internal/reconciler/tracepipeline/mocks"
+	"github.com/kyma-project/telemetry-manager/internal/reconciler/tracepipeline/stubs"
 	"github.com/kyma-project/telemetry-manager/internal/resourcelock"
 	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
 	"github.com/kyma-project/telemetry-manager/internal/selfmonitor/prober"
@@ -736,6 +736,45 @@ func TestReconcile(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("all trace pipelines are non-reconcilable", func(t *testing.T) {
+		pipeline := testutils.NewTracePipelineBuilder().WithOTLPOutput(testutils.OTLPEndpointFromSecret(
+			"non-existing",
+			"default",
+			"endpoint")).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline).WithStatusSubresource(&pipeline).Build()
+
+		gatewayConfigBuilderMock := &mocks.GatewayConfigBuilder{}
+		gatewayConfigBuilderMock.On("Build", mock.Anything, mock.Anything).Return(&gateway.Config{}, nil, nil)
+
+		gatewayResourcesHandlerStub := &stubs.GatewayResourcesHandler{}
+
+		pipelineLockStub := &mocks.PipelineLock{}
+		pipelineLockStub.On("TryAcquireLock", mock.Anything, mock.Anything).Return(nil)
+		pipelineLockStub.On("IsLockHolder", mock.Anything, mock.Anything).Return(true, nil)
+
+		proberStub := &mocks.DeploymentProber{}
+		proberStub.On("IsReady", mock.Anything, mock.Anything).Return(true, nil)
+
+		flowHealthProberStub := &mocks.FlowHealthProber{}
+		flowHealthProberStub.On("Probe", mock.Anything, pipeline.Name).Return(prober.OTelPipelineProbeResult{}, nil)
+
+		sut := Reconciler{
+			Client:                  fakeClient,
+			config:                  testConfig,
+			gatewayConfigBuilder:    gatewayConfigBuilderMock,
+			gatewayResourcesHandler: gatewayResourcesHandlerStub,
+			pipelineLock:            pipelineLockStub,
+			prober:                  proberStub,
+			flowHealthProber:        flowHealthProberStub,
+			overridesHandler:        overridesHandlerStub,
+			istioStatusChecker:      istioStatusCheckerStub,
+		}
+		_, err := sut.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: pipeline.Name}})
+		require.NoError(t, err)
+
+		require.True(t, gatewayResourcesHandlerStub.DeleteFuncCalled)
 	})
 }
 

--- a/internal/reconciler/tracepipeline/stubs/gateway_resources_handler.go
+++ b/internal/reconciler/tracepipeline/stubs/gateway_resources_handler.go
@@ -2,8 +2,10 @@ package stubs
 
 import (
 	"context"
-	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
 )
 
 type GatewayResourcesHandler struct {

--- a/internal/reconciler/tracepipeline/stubs/gateway_resources_handler.go
+++ b/internal/reconciler/tracepipeline/stubs/gateway_resources_handler.go
@@ -1,0 +1,22 @@
+package stubs
+
+import (
+	"context"
+	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type GatewayResourcesHandler struct {
+	ApplyFuncCalled  bool
+	DeleteFuncCalled bool
+}
+
+func (grh *GatewayResourcesHandler) ApplyResources(ctx context.Context, c client.Client, opts otelcollector.GatewayApplyOptions) error {
+	grh.ApplyFuncCalled = true
+	return nil
+}
+
+func (grh *GatewayResourcesHandler) DeleteResources(ctx context.Context, c client.Client, isIstioActive bool) error {
+	grh.DeleteFuncCalled = true
+	return nil
+}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add a TracePipeline reconciler unit test to ensure that the `DeleteResources(ctx context.Context, c client.Client, isIstioActive bool)` function is called when all TracePipelines are non-reconcilable

Changes refer to particular issues, PRs or documents:

- #298 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
