### PR TITLE
chore: Change self monitor retention size configuration from 80MB to 50MB

### DIFF
--- a/internal/resources/selfmonitor/resources.go
+++ b/internal/resources/selfmonitor/resources.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	retentionTime = "2h"
-	retentionSize = "80MB"
+	retentionSize = "50MB"
 )
 
 var (


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Mitigate the impact of the [issue](https://github.com/kubernetes/kubernetes/issues/122160) on self-monitor deployment, retention size configuration value decreased to 50MB to avoid configured volume exceeding the limit

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
