### PR TITLE
chore: Fix changelogs for non-sequential releases

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -27,8 +27,9 @@ jobs:
           GITHUB_OWNER: "${{ github.repository_owner }}"
           GITHUB_REPO: "telemetry-manager"
 
-      - name: Install kustomize
-        run: make kustomize
+      - name: Install tools
+        shell: bash
+        run: make install-tools
 
       - name: Release
         run: hack/release.sh ${{ github.ref_name }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -31,7 +31,7 @@ jobs:
         run: make kustomize
 
       - name: Release
-        run: hack/release.sh
+        run: hack/release.sh ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GORELEASER_CURRENT_TAG: "${{ github.ref_name }}" # Explicitly set release tag to do not use -dev tag

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,17 +25,10 @@ function prepare_release_artefacts() {
 }
 
 get_previous_release_version() {
-    if [[ ${CURRENT_VERSION} =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
-    then
           # get list of tags in a reverse chronological order excluding dev tags, 
           # sort them based on major, minor, patch numerically, grab the first release before the current one
           TAG_LIST_WITH_PATCH=$(git tag --sort=-creatordate | grep -E "^[0-9]+.[0-9]+.[0-9]$" | sort -t "." -k1,1n -k2,2n -k3,3n | grep -B 1 "${CURRENT_VERSION}" | head -1)
           export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH}
-    else
-          # get the list of tags in a reverse chronological order excluding patch tags
-          TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | grep -E "^[0-9]+.[0-9]+.[0]$"))
-          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITHOUT_PATCH[1]}
-    fi
 }
 
 function create_github_release() {

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,10 +25,13 @@ function prepare_release_artefacts() {
 
 get_previous_release_version() {
     TAG_LIST=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
-    if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
+
+    if [[ ${TAG_LIST[0]} =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
     then
-          TAG_LIST_WITH_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
-          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH[1]}
+          # get list of tags in a reverse chronological order excluding dev tags, 
+          # sort them based on major, minor, patch numerically, grab the first release before the current one
+          TAG_LIST_WITH_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$" | sort -t "." -k1,1n -k2,2n -k3,3n | grep -B 1 ${TAG_LIST[0]} | head -1))
+          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH[0]}
     else
           # get the list of tags in a reverse chronological order excluding patch tags
           TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0]$"))

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -11,10 +11,11 @@ readonly LOCALBIN=${LOCALBIN:-$(pwd)/bin}
 readonly KUSTOMIZE=${KUSTOMIZE:-$LOCALBIN/kustomize}
 readonly GORELEASER_VERSION="${GORELEASER_VERSION:-$ENV_GORELEASER_VERSION}"
 readonly IMG="${IMG:-$ENV_IMG}"
+readonly CURRENT_VERSION="$1"
 
 function prepare_release_artefacts() {
      echo "Preparing release artefacts"
-     cd config/manager && ${KUSTOMIZE} edit set image controller=${IMG} && cd ../..
+     cd config/manager && ${KUSTOMIZE} edit set image controller="${IMG}" && cd ../..
      # Create the resources file that is used for creating the ModuleTemplate for fast and regular channels
      ${KUSTOMIZE} build config/default > telemetry-manager.yaml
      # Create the resources file that is used for creating the ModuleTemplate for experimental channel
@@ -24,17 +25,15 @@ function prepare_release_artefacts() {
 }
 
 get_previous_release_version() {
-    TAG_LIST=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
-
-    if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
+    if [[ ${CURRENT_VERSION} =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
     then
           # get list of tags in a reverse chronological order excluding dev tags, 
           # sort them based on major, minor, patch numerically, grab the first release before the current one
-          TAG_LIST_WITH_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$" | sort -t "." -k1,1n -k2,2n -k3,3n | grep -B 1 ${TAG_LIST[0]} | head -1))
-          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH[0]}
+          TAG_LIST_WITH_PATCH=$(git tag --sort=-creatordate | grep -E "^[0-9]+.[0-9]+.[0-9]$" | sort -t "." -k1,1n -k2,2n -k3,3n | grep -B 1 "${CURRENT_VERSION}" | head -1)
+          export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITH_PATCH}
     else
           # get the list of tags in a reverse chronological order excluding patch tags
-          TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0]$"))
+          TAG_LIST_WITHOUT_PATCH=($(git tag --sort=-creatordate | grep -E "^[0-9]+.[0-9]+.[0]$"))
           export GORELEASER_PREVIOUS_TAG=${TAG_LIST_WITHOUT_PATCH[1]}
     fi
 }

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,7 +26,7 @@ function prepare_release_artefacts() {
 get_previous_release_version() {
     TAG_LIST=($(git tag --sort=-creatordate | egrep "^[0-9]+.[0-9]+.[0-9]$"))
 
-    if [[ ${TAG_LIST[0]} =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
+    if [[ "${TAG_LIST[0]}" =~ ^[0-9]+.[0-9]+.[1-9]$ ]]
     then
           # get list of tags in a reverse chronological order excluding dev tags, 
           # sort them based on major, minor, patch numerically, grab the first release before the current one


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add numerical sorting based on major, minor, patch number to the tag list output from git. This helps in identifying the previous release based on the current one, enabling proper changelog generation with GoReleaser.

Changes refer to particular issues, PRs or documents:

- Resolves #1213 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.
