### PR TITLE
chore: Remove kyma dependency from Gardener deprovision

### DIFF
--- a/hack/make/provision.mk
+++ b/hack/make/provision.mk
@@ -61,6 +61,6 @@ provision-gardener: ## Provision gardener cluster with latest k8s version
 	mv ${GARDENER_CLUSTER_NAME}_kubeconfig.yaml ~/.kube/config
 
 .PHONY: deprovision-gardener
-deprovision-gardener: kyma ## Deprovision gardener cluster
+deprovision-gardener:## Deprovision gardener cluster
 	kubectl --kubeconfig=${GARDENER_SA_PATH} annotate shoot ${GARDENER_CLUSTER_NAME} confirmation.gardener.cloud/deletion=true
 	kubectl --kubeconfig=${GARDENER_SA_PATH} delete shoot ${GARDENER_CLUSTER_NAME} --wait=false


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- With this [PR](https://github.com/kyma-project/telemetry-manager/pull/1220/files#diff-3f659f70fa78445803fb10dd7ee651fc36f09ba7015adef99281cece7114f02b) `kyma` dependecy has been removed. Remove it from deprovision-gardner target as well

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
