### PR TITLE
chore: Exclude test doubles from whitesource checks

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -9,5 +9,7 @@ whitesource:
   language: golang-mod
   subprojects: false
   exclude:
+    - "**/mocks/**"
+    - "**/stubs/**"
     - "**/test/**"
     - "**/*_test.go"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Exclude test doubles from whitesource checks

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
