### PR TITLE
chore: Do not use env prefix for env variables in otel config

### DIFF
--- a/docs/contributor/pocs/assets/otel-log-agent-values.yaml
+++ b/docs/contributor/pocs/assets/otel-log-agent-values.yaml
@@ -122,7 +122,7 @@ config:
   service:
     telemetry:
       metrics:
-        address: ${env:MY_POD_IP}:8888
+        address: ${MY_POD_IP}:8888
     pipelines:
       logs:
         processors: {}

--- a/docs/contributor/pocs/assets/otel-log-gateway-values.yaml
+++ b/docs/contributor/pocs/assets/otel-log-gateway-values.yaml
@@ -17,7 +17,7 @@ config:
     otlp: {}
   extensions:
     health_check:
-      endpoint: ${env:MY_POD_IP}:13133
+      endpoint: ${MY_POD_IP}:13133
     file_storage/queue:
   exporters:
     otlp:
@@ -31,7 +31,7 @@ config:
   service:
     telemetry:
       metrics:
-        address: ${env:MY_POD_IP}:8888
+        address: ${MY_POD_IP}:8888
     extensions:
       - file_storage/queue
       - health_check

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -37,7 +37,7 @@ func makeKubeletStatsConfig() *KubeletStatsReceiver {
 		CollectionInterval: collectionInterval,
 		AuthType:           "serviceAccount",
 		InsecureSkipVerify: true,
-		Endpoint:           fmt.Sprintf("https://${env:%s}:%d", config.EnvVarCurrentNodeName, portKubelet),
+		Endpoint:           fmt.Sprintf("https://${%s}:%d", config.EnvVarCurrentNodeName, portKubelet),
 		MetricGroups:       []MetricGroupType{MetricGroupTypeContainer, MetricGroupTypePod},
 		Metrics: KubeletMetricsConfig{
 			ContainerCPUUsage:       KubeletMetricConfig{Enabled: true},

--- a/internal/otelcollector/config/metric/agent/receivers_test.go
+++ b/internal/otelcollector/config/metric/agent/receivers_test.go
@@ -36,7 +36,7 @@ func TestReceivers(t *testing.T) {
 		require.NotNil(t, collectorConfig.Receivers.KubeletStats)
 		require.Equal(t, "serviceAccount", collectorConfig.Receivers.KubeletStats.AuthType)
 		require.Equal(t, true, collectorConfig.Receivers.KubeletStats.InsecureSkipVerify)
-		require.Equal(t, "https://${env:MY_NODE_NAME}:10250", collectorConfig.Receivers.KubeletStats.Endpoint)
+		require.Equal(t, "https://${MY_NODE_NAME}:10250", collectorConfig.Receivers.KubeletStats.Endpoint)
 
 		require.Nil(t, collectorConfig.Receivers.PrometheusAppPods)
 		require.Nil(t, collectorConfig.Receivers.PrometheusIstio)

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -50,7 +50,7 @@ receivers:
     kubeletstats:
         collection_interval: 30s
         auth_type: serviceAccount
-        endpoint: https://${env:MY_NODE_NAME}:10250
+        endpoint: https://${MY_NODE_NAME}:10250
         insecure_skip_verify: true
         metric_groups:
             - container

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -39,7 +39,7 @@ receivers:
     kubeletstats:
         collection_interval: 30s
         auth_type: serviceAccount
-        endpoint: https://${env:MY_NODE_NAME}:10250
+        endpoint: https://${MY_NODE_NAME}:10250
         insecure_skip_verify: true
         metric_groups:
             - container


### PR DESCRIPTION
## Description

The ${env:ENV} syntax in otel-collector config does parse the value as yaml, which can be dangerous depending on the input. I removed the prefix everywhere to use plain ${ENV} which does not do any parsing.

Changes proposed in this pull request (what was done and why):

- Changed all occurences to not use the env prefix

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
