### PR TITLE
chore: Revert "chore: Prepare release 1.19 (#1233)"

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ### Default Environment Variables
 ## General
 ENV_K3S_K8S_VERSION=1.28.3 # refers to the version of kubernetes used in K3s
-ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.19.0 # Image URL to use all building/pushing image targets
+ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main # Image URL to use all building/pushing image targets
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.28

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: 1.19.0
+  newTag: main

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ var (
 	selfMonitorImage         string
 	selfMonitorPriorityClass string
 
-	version = "1.19.0"
+	version = "main"
 )
 
 const (

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,9 +1,9 @@
 module-name: telemetry
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.19.0
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/otel-collector:0.102.1-fbfb6cdc
   - europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:3.0.7-1e5449d3
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240605-7743c77e
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240404-fd3588ce
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.0-8691013b
 whitesource:
   language: golang-mod


### PR DESCRIPTION
This reverts commit 8add9c7fb8f29aadf5f3769526c3cd75e166360c.

## Description

Changes proposed in this pull request (what was done and why):

- revert the changes of https://github.com/kyma-project/telemetry-manager/pull/1233 as it was created against main

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
