### PR TITLE
fix: Use correct date command

### DIFF
--- a/hack/make/provision.mk
+++ b/hack/make/provision.mk
@@ -30,7 +30,13 @@ provision-k3d-istio: provision-k3d
 # GARDENER_PROJECT=
 # GARDENER_SECRET_NAME=
 GIT_COMMIT_SHA=$(shell git rev-parse --short=8 HEAD)
-export HIBERNATION_HOUR=$(shell date -d5H +%-H)
+UNAME=$(shell uname -s)
+ifeq ($UNAME,Linux)
+	export HIBERNATION_HOUR=$(shell date -d5H +%-H)
+endif
+ifeq ($UNAME,Darwin)
+	export HIBERNATION_HOUR=$(shell date -v+5H +%-H)
+endif
 GARDENER_K8S_VERSION ?= $(ENV_GARDENER_K8S_VERSION)
 # Cluster name is also set via load test. If its set then use that else use ci-XX
 export GARDENER_CLUSTER_NAME ?= $(shell echo "ci-${GIT_COMMIT_SHA}-${GARDENER_K8S_VERSION}" | sed 's/\.//g')


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- use os agnostic date command

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The PR has a milestone set.
- [ ] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
