### PR TITLE
docs: Fix missing link in dynatrace integration guide

### DIFF
--- a/docs/user/integration/dynatrace/README.md
+++ b/docs/user/integration/dynatrace/README.md
@@ -213,7 +213,7 @@ There are several approaches to ingest custom metrics to Dynatrace, each with di
         helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
         helm repo update
 
-        helm upgrade --install -n ${DYNATRACE_NS} dynatrace-exporter open-telemetry/opentelemetry-collector -f exporter-values.yaml
+        helm upgrade --install -n ${DYNATRACE_NS} dynatrace-exporter open-telemetry/opentelemetry-collector -f https://raw.githubusercontent.com/kyma-project/telemetry-manager/main/docs/user/integration/dynatrace/exporter-values.yaml
         ```
 
   1. Deploy the MetricPipeline that ships to the custom OTel Collector:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix missing link in dynatrace integration guide

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [x] The PR has a respective `area` and `kind` label.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
