### PR TITLE
feat: Drop log body after record successfully parsed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.5-bookworm as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.22.5-bookworm as builder
 
 WORKDIR /telemetry-manager-workspace
 # Copy the Go Modules manifests

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -108,7 +108,7 @@ type HTTPOutput struct {
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
 	// Enables keeping of the log field from the incoming log record. Default is `true`
-	// +kubebuilder:default=true
+	// +kubebuilder:default:=true
 	KeepBody bool `json:"keepBody,omitempty"`
 }
 

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -107,6 +107,9 @@ type HTTPOutput struct {
 	TLSConfig TLSConfig `json:"tls,omitempty"`
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
+	// Enables keeping of the log field from the incoming log record. Default is `true`
+	// +kubebuilder:default:=true
+	KeepBody bool `json:"keepBody,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:rule="has(self.cert) == has(self.key)", message="Can define either both 'cert' and 'key', or neither"

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -108,7 +108,7 @@ type HTTPOutput struct {
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
 	// Enables keeping of the log field from the incoming log record. Default is `true`
-	// +kubebuilder:default:=true
+	// +kubebuilder:default=true
 	KeepBody bool `json:"keepBody,omitempty"`
 }
 

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -51,9 +51,9 @@ type ApplicationInput struct {
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
 	// Defines whether to drop all Kubernetes labels. The default is `false`.
 	DropLabels bool `json:"dropLabels,omitempty"`
-	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepRawBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
+	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `KeepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
 	// +kubebuilder:default:=true
-	KeepRawBody bool `json:"keepRawBody,omitempty"`
+	KeepOriginalBody bool `json:"keepOriginalBody,omitempty"`
 }
 
 // InputNamespaces describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -51,6 +51,9 @@ type ApplicationInput struct {
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
 	// Defines whether to drop all Kubernetes labels. The default is `false`.
 	DropLabels bool `json:"dropLabels,omitempty"`
+	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepRawBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
+	// +kubebuilder:default:=true
+	KeepRawBody bool `json:"keepRawBody,omitempty"`
 }
 
 // InputNamespaces describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.
@@ -107,9 +110,6 @@ type HTTPOutput struct {
 	TLSConfig TLSConfig `json:"tls,omitempty"`
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
-	// If `false`, after successfully parsing the field `log` is removed from the log record. Default is `true`.
-	// +kubebuilder:default:=true
-	KeepBody bool `json:"keepBody,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:rule="has(self.cert) == has(self.key)", message="Can define either both 'cert' and 'key', or neither"

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -107,7 +107,7 @@ type HTTPOutput struct {
 	TLSConfig TLSConfig `json:"tls,omitempty"`
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
-	// Enables keeping of the log field from the incoming log record. Default is `true`
+	// If `false`, after successfully parsing the field `log` is removed from the log record. Default is `true`.
 	// +kubebuilder:default:=true
 	KeepBody bool `json:"keepBody,omitempty"`
 }

--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -51,7 +51,7 @@ type ApplicationInput struct {
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
 	// Defines whether to drop all Kubernetes labels. The default is `false`.
 	DropLabels bool `json:"dropLabels,omitempty"`
-	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `KeepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
+	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `KeepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. The default is `true`.
 	// +kubebuilder:default:=true
 	KeepOriginalBody bool `json:"keepOriginalBody,omitempty"`
 }

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -72,6 +72,9 @@ type ApplicationInput struct {
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
 	// Defines whether to drop all Kubernetes labels. The default is `false`.
 	DropLabels bool `json:"dropLabels,omitempty"`
+	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepRawBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
+	// +kubebuilder:default:=true
+	KeepRawBody bool `json:"keepRawBody,omitempty"`
 }
 
 // InputNamespaces describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.
@@ -128,9 +131,6 @@ type HTTPOutput struct {
 	TLSConfig TLSConfig `json:"tls,omitempty"`
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
-	// If `false`, after successfully parsing the field `log` is removed from the log record. Default is `true`.
-	// +kubebuilder:default:=true
-	KeepBody bool `json:"keepBody,omitempty"`
 }
 
 // LokiOutput configures an output to the Kyma-internal Loki instance.

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -129,7 +129,7 @@ type HTTPOutput struct {
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
 	// Enables keeping of the log field from the incoming log record. Default is `true`
-	// +kubebuilder:default:=true
+	// +kubebuilder:default=true
 	KeepBody bool `json:"keepBody,omitempty"`
 }
 

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -129,7 +129,7 @@ type HTTPOutput struct {
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
 	// Enables keeping of the log field from the incoming log record. Default is `true`
-	// +kubebuilder:default=true
+	// +kubebuilder:default:=true
 	KeepBody bool `json:"keepBody,omitempty"`
 }
 

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -72,9 +72,9 @@ type ApplicationInput struct {
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
 	// Defines whether to drop all Kubernetes labels. The default is `false`.
 	DropLabels bool `json:"dropLabels,omitempty"`
-	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepRawBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
+	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
 	// +kubebuilder:default:=true
-	KeepRawBody bool `json:"keepRawBody,omitempty"`
+	KeepOriginalBody bool `json:"keepOriginalBody,omitempty"`
 }
 
 // InputNamespaces describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection.

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -72,7 +72,7 @@ type ApplicationInput struct {
 	KeepAnnotations bool `json:"keepAnnotations,omitempty"`
 	// Defines whether to drop all Kubernetes labels. The default is `false`.
 	DropLabels bool `json:"dropLabels,omitempty"`
-	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`.
+	// If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. The default is `true`.
 	// +kubebuilder:default:=true
 	KeepOriginalBody bool `json:"keepOriginalBody,omitempty"`
 }

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -128,6 +128,9 @@ type HTTPOutput struct {
 	TLSConfig TLSConfig `json:"tls,omitempty"`
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
+	// Enables keeping of the log field from the incoming log record. Default is `true`
+	// +kubebuilder:default:=true
+	KeepBody bool `json:"keepBody,omitempty"`
 }
 
 // LokiOutput configures an output to the Kyma-internal Loki instance.

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -128,7 +128,7 @@ type HTTPOutput struct {
 	TLSConfig TLSConfig `json:"tls,omitempty"`
 	// Enables de-dotting of Kubernetes labels and annotations for compatibility with ElasticSearch based backends. Dots (.) will be replaced by underscores (_). Default is `false`.
 	Dedot bool `json:"dedot,omitempty"`
-	// Enables keeping of the log field from the incoming log record. Default is `true`
+	// If `false`, after successfully parsing the field `log` is removed from the log record. Default is `true`.
 	// +kubebuilder:default:=true
 	KeepBody bool `json:"keepBody,omitempty"`
 }

--- a/config/busola/logpipeline_busola_extension_cm.yaml
+++ b/config/busola/logpipeline_busola_extension_cm.yaml
@@ -204,6 +204,8 @@ data:
                     placeholder: '443'
                   - name: URI
                     source: spec.output.http.uri
+                  - name: Keep Log Body
+                    source: spec.output.http.keepBody
   form: |
     - path: spec.input
       widget: FormGroup
@@ -404,6 +406,9 @@ data:
             - name: Dedot
               simple: true
               path: dedot
+            - name: Keep Log Body
+              simple: true
+              path: keepBody
   general: |-
     resource:
       kind: LogPipeline

--- a/config/busola/logpipeline_busola_extension_cm.yaml
+++ b/config/busola/logpipeline_busola_extension_cm.yaml
@@ -82,8 +82,8 @@ data:
                 source: spec.input.application.keepAnnotations
               - name: Drop Labels
                 source: spec.input.application.dropLabels
-              - name: Keep Raw Log Body
-                source: spec.input.application.keepRawBody
+              - name: Keep Original Log Body
+                source: spec.input.application.keepOriginalBody
       - widget: Panel
         name: Output
         children:
@@ -235,8 +235,8 @@ data:
           path: application.keepAnnotations
         - name: Drop Labels
           path: application.dropLabels
-        - name: Keep Raw Log Body
-          path: application.keepRawBody
+        - name: Keep Original Log Body
+          path: application.keepOriginalBody
     - name: Filters
       widget: SimpleList
       path: spec.filters

--- a/config/busola/logpipeline_busola_extension_cm.yaml
+++ b/config/busola/logpipeline_busola_extension_cm.yaml
@@ -82,6 +82,8 @@ data:
                 source: spec.input.application.keepAnnotations
               - name: Drop Labels
                 source: spec.input.application.dropLabels
+              - name: Keep Raw Log Body
+                source: spec.input.application.keepRawBody
       - widget: Panel
         name: Output
         children:
@@ -204,8 +206,6 @@ data:
                     placeholder: '443'
                   - name: URI
                     source: spec.output.http.uri
-                  - name: Keep Log Body
-                    source: spec.output.http.keepBody
   form: |
     - path: spec.input
       widget: FormGroup
@@ -235,6 +235,8 @@ data:
           path: application.keepAnnotations
         - name: Drop Labels
           path: application.dropLabels
+        - name: Keep Raw Log Body
+          path: application.keepRawBody
     - name: Filters
       widget: SimpleList
       path: spec.filters
@@ -406,9 +408,6 @@ data:
             - name: Dedot
               simple: true
               path: dedot
-            - name: Keep Log Body
-              simple: true
-              path: keepBody
   general: |-
     resource:
       kind: LogPipeline

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -236,6 +236,11 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      keepBody:
+                        default: true
+                        description: Enables keeping of the log field from the incoming
+                          log record. Default is `true`
+                        type: boolean
                       password:
                         description: Defines the basic auth password.
                         properties:

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -116,8 +116,8 @@ spec:
                         description: If the `log` attribute contains a JSON payload
                           and it is successfully parsed, the `log` attribute will
                           be retained if `KeepOriginalBody` is set to `true`. Otherwise,
-                          the log attribute will be removed from the log record. Default
-                          is `true`.
+                          the log attribute will be removed from the log record. The
+                          default is `true`.
                         type: boolean
                       namespaces:
                         description: Describes whether application logs from specific

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -238,8 +238,8 @@ spec:
                         type: object
                       keepBody:
                         default: true
-                        description: Enables keeping of the log field from the incoming
-                          log record. Default is `true`
+                        description: If `false`, after successfully parsing the field
+                          `log` is removed from the log record. Default is `true`.
                         type: boolean
                       password:
                         description: Defines the basic auth password.

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -111,6 +111,14 @@ spec:
                         description: Defines whether to keep all Kubernetes annotations.
                           The default is `false`.
                         type: boolean
+                      keepRawBody:
+                        default: true
+                        description: If the `log` attribute contains a JSON payload
+                          and it is successfully parsed, the `log` attribute will
+                          be retained if `keepRawBody` is set to `true`. Otherwise,
+                          the log attribute will be removed from the log record. Default
+                          is `true`.
+                        type: boolean
                       namespaces:
                         description: Describes whether application logs from specific
                           Namespaces are selected. The options are mutually exclusive.
@@ -236,11 +244,6 @@ spec:
                                 type: object
                             type: object
                         type: object
-                      keepBody:
-                        default: true
-                        description: If `false`, after successfully parsing the field
-                          `log` is removed from the log record. Default is `true`.
-                        type: boolean
                       password:
                         description: Defines the basic auth password.
                         properties:

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -111,11 +111,11 @@ spec:
                         description: Defines whether to keep all Kubernetes annotations.
                           The default is `false`.
                         type: boolean
-                      keepRawBody:
+                      keepOriginalBody:
                         default: true
                         description: If the `log` attribute contains a JSON payload
                           and it is successfully parsed, the `log` attribute will
-                          be retained if `keepRawBody` is set to `true`. Otherwise,
+                          be retained if `KeepOriginalBody` is set to `true`. Otherwise,
                           the log attribute will be removed from the log record. Default
                           is `true`.
                         type: boolean

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -111,6 +111,14 @@ spec:
                         description: Defines whether to keep all Kubernetes annotations.
                           The default is `false`.
                         type: boolean
+                      keepRawBody:
+                        default: true
+                        description: If the `log` attribute contains a JSON payload
+                          and it is successfully parsed, the `log` attribute will
+                          be retained if `keepRawBody` is set to `true`. Otherwise,
+                          the log attribute will be removed from the log record. Default
+                          is `true`.
+                        type: boolean
                       namespaces:
                         description: Describes whether application logs from specific
                           Namespaces are selected. The options are mutually exclusive.
@@ -236,11 +244,6 @@ spec:
                                 type: object
                             type: object
                         type: object
-                      keepBody:
-                        default: true
-                        description: If `false`, after successfully parsing the field
-                          `log` is removed from the log record. Default is `true`.
-                        type: boolean
                       password:
                         description: Defines the basic auth password.
                         properties:
@@ -632,6 +635,14 @@ spec:
                         description: Defines whether to keep all Kubernetes annotations.
                           The default is `false`.
                         type: boolean
+                      keepRawBody:
+                        default: true
+                        description: If the `log` attribute contains a JSON payload
+                          and it is successfully parsed, the `log` attribute will
+                          be retained if `keepRawBody` is set to `true`. Otherwise,
+                          the log attribute will be removed from the log record. Default
+                          is `true`.
+                        type: boolean
                       namespaces:
                         description: Describes whether application logs from specific
                           Namespaces are selected. The options are mutually exclusive.
@@ -757,11 +768,6 @@ spec:
                                 type: object
                             type: object
                         type: object
-                      keepBody:
-                        default: true
-                        description: If `false`, after successfully parsing the field
-                          `log` is removed from the log record. Default is `true`.
-                        type: boolean
                       password:
                         description: Defines the basic auth password.
                         properties:

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -236,6 +236,11 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      keepBody:
+                        default: true
+                        description: Enables keeping of the log field from the incoming
+                          log record. Default is `true`
+                        type: boolean
                       password:
                         description: Defines the basic auth password.
                         properties:
@@ -752,6 +757,11 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      keepBody:
+                        default: true
+                        description: Enables keeping of the log field from the incoming
+                          log record. Default is `true`
+                        type: boolean
                       password:
                         description: Defines the basic auth password.
                         properties:

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -238,8 +238,8 @@ spec:
                         type: object
                       keepBody:
                         default: true
-                        description: Enables keeping of the log field from the incoming
-                          log record. Default is `true`
+                        description: If `false`, after successfully parsing the field
+                          `log` is removed from the log record. Default is `true`.
                         type: boolean
                       password:
                         description: Defines the basic auth password.
@@ -759,8 +759,8 @@ spec:
                         type: object
                       keepBody:
                         default: true
-                        description: Enables keeping of the log field from the incoming
-                          log record. Default is `true`
+                        description: If `false`, after successfully parsing the field
+                          `log` is removed from the log record. Default is `true`.
                         type: boolean
                       password:
                         description: Defines the basic auth password.

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -116,8 +116,8 @@ spec:
                         description: If the `log` attribute contains a JSON payload
                           and it is successfully parsed, the `log` attribute will
                           be retained if `KeepOriginalBody` is set to `true`. Otherwise,
-                          the log attribute will be removed from the log record. Default
-                          is `true`.
+                          the log attribute will be removed from the log record. The
+                          default is `true`.
                         type: boolean
                       namespaces:
                         description: Describes whether application logs from specific
@@ -640,8 +640,8 @@ spec:
                         description: If the `log` attribute contains a JSON payload
                           and it is successfully parsed, the `log` attribute will
                           be retained if `keepOriginalBody` is set to `true`. Otherwise,
-                          the log attribute will be removed from the log record. Default
-                          is `true`.
+                          the log attribute will be removed from the log record. The
+                          default is `true`.
                         type: boolean
                       namespaces:
                         description: Describes whether application logs from specific

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -111,11 +111,11 @@ spec:
                         description: Defines whether to keep all Kubernetes annotations.
                           The default is `false`.
                         type: boolean
-                      keepRawBody:
+                      keepOriginalBody:
                         default: true
                         description: If the `log` attribute contains a JSON payload
                           and it is successfully parsed, the `log` attribute will
-                          be retained if `keepRawBody` is set to `true`. Otherwise,
+                          be retained if `KeepOriginalBody` is set to `true`. Otherwise,
                           the log attribute will be removed from the log record. Default
                           is `true`.
                         type: boolean
@@ -635,11 +635,11 @@ spec:
                         description: Defines whether to keep all Kubernetes annotations.
                           The default is `false`.
                         type: boolean
-                      keepRawBody:
+                      keepOriginalBody:
                         default: true
                         description: If the `log` attribute contains a JSON payload
                           and it is successfully parsed, the `log` attribute will
-                          be retained if `keepRawBody` is set to `true`. Otherwise,
+                          be retained if `keepOriginalBody` is set to `true`. Otherwise,
                           the log attribute will be removed from the log record. Default
                           is `true`.
                         type: boolean

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -91,6 +91,7 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **input.&#x200b;application.&#x200b;containers.&#x200b;include**  | \[\]string | Specifies to include only the container logs with the specified container names. |
 | **input.&#x200b;application.&#x200b;dropLabels**  | boolean | Defines whether to drop all Kubernetes labels. The default is `false`. |
 | **input.&#x200b;application.&#x200b;keepAnnotations**  | boolean | Defines whether to keep all Kubernetes annotations. The default is `false`. |
+| **input.&#x200b;application.&#x200b;keepRawBody**  | boolean | If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepRawBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`. |
 | **input.&#x200b;application.&#x200b;namespaces**  | object | Describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection. |
 | **input.&#x200b;application.&#x200b;namespaces.&#x200b;exclude**  | \[\]string | Exclude the container logs of the specified Namespace names. |
 | **input.&#x200b;application.&#x200b;namespaces.&#x200b;include**  | \[\]string | Include only the container logs of the specified Namespace names. |
@@ -118,7 +119,6 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;http.&#x200b;keepBody**  | boolean | If `false`, after successfully parsing the field `log` is removed from the log record. Default is `true`. |
 | **output.&#x200b;http.&#x200b;password**  | object | Defines the basic auth password. |
 | **output.&#x200b;http.&#x200b;password.&#x200b;value**  | string | The value as plain text. |
 | **output.&#x200b;http.&#x200b;password.&#x200b;valueFrom**  | object | The value as a reference to a resource. |

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -118,7 +118,7 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;http.&#x200b;keepBody**  | boolean | Enables keeping of the log field from the incoming log record. Default is `true` |
+| **output.&#x200b;http.&#x200b;keepBody**  | boolean | If `false`, after successfully parsing the field `log` is removed from the log record. Default is `true`. |
 | **output.&#x200b;http.&#x200b;password**  | object | Defines the basic auth password. |
 | **output.&#x200b;http.&#x200b;password.&#x200b;value**  | string | The value as plain text. |
 | **output.&#x200b;http.&#x200b;password.&#x200b;valueFrom**  | object | The value as a reference to a resource. |

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -118,6 +118,7 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key**  | string | The name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name**  | string | The name of the Secret containing the referenced value |
 | **output.&#x200b;http.&#x200b;host.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace**  | string | The name of the Namespace containing the Secret with the referenced value. |
+| **output.&#x200b;http.&#x200b;keepBody**  | boolean | Enables keeping of the log field from the incoming log record. Default is `true` |
 | **output.&#x200b;http.&#x200b;password**  | object | Defines the basic auth password. |
 | **output.&#x200b;http.&#x200b;password.&#x200b;value**  | string | The value as plain text. |
 | **output.&#x200b;http.&#x200b;password.&#x200b;valueFrom**  | object | The value as a reference to a resource. |

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -91,7 +91,7 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **input.&#x200b;application.&#x200b;containers.&#x200b;include**  | \[\]string | Specifies to include only the container logs with the specified container names. |
 | **input.&#x200b;application.&#x200b;dropLabels**  | boolean | Defines whether to drop all Kubernetes labels. The default is `false`. |
 | **input.&#x200b;application.&#x200b;keepAnnotations**  | boolean | Defines whether to keep all Kubernetes annotations. The default is `false`. |
-| **input.&#x200b;application.&#x200b;keepRawBody**  | boolean | If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `keepRawBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`. |
+| **input.&#x200b;application.&#x200b;keepOriginalBody**  | boolean | If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `KeepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`. |
 | **input.&#x200b;application.&#x200b;namespaces**  | object | Describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection. |
 | **input.&#x200b;application.&#x200b;namespaces.&#x200b;exclude**  | \[\]string | Exclude the container logs of the specified Namespace names. |
 | **input.&#x200b;application.&#x200b;namespaces.&#x200b;include**  | \[\]string | Include only the container logs of the specified Namespace names. |

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -91,7 +91,7 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **input.&#x200b;application.&#x200b;containers.&#x200b;include**  | \[\]string | Specifies to include only the container logs with the specified container names. |
 | **input.&#x200b;application.&#x200b;dropLabels**  | boolean | Defines whether to drop all Kubernetes labels. The default is `false`. |
 | **input.&#x200b;application.&#x200b;keepAnnotations**  | boolean | Defines whether to keep all Kubernetes annotations. The default is `false`. |
-| **input.&#x200b;application.&#x200b;keepOriginalBody**  | boolean | If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `KeepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. Default is `true`. |
+| **input.&#x200b;application.&#x200b;keepOriginalBody**  | boolean | If the `log` attribute contains a JSON payload and it is successfully parsed, the `log` attribute will be retained if `KeepOriginalBody` is set to `true`. Otherwise, the log attribute will be removed from the log record. The default is `true`. |
 | **input.&#x200b;application.&#x200b;namespaces**  | object | Describes whether application logs from specific Namespaces are selected. The options are mutually exclusive. System Namespaces are excluded by default from the collection. |
 | **input.&#x200b;application.&#x200b;namespaces.&#x200b;exclude**  | \[\]string | Exclude the container logs of the specified Namespace names. |
 | **input.&#x200b;application.&#x200b;namespaces.&#x200b;include**  | \[\]string | Include only the container logs of the specified Namespace names. |

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -165,7 +165,8 @@ func TestMergeSectionsConfig(t *testing.T) {
 			},
 			Output: telemetryv1alpha1.Output{
 				HTTP: &telemetryv1alpha1.HTTPOutput{
-					Dedot: true,
+					Dedot:    true,
+					KeepBody: true,
 					Host: telemetryv1alpha1.ValueType{
 						Value: "localhost",
 					},

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -106,6 +106,7 @@ func TestMergeSectionsConfig(t *testing.T) {
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
+    keep_log            on
     kube_tag_prefix     foo.var.log.containers.
     labels              on
     merge_log           on
@@ -147,6 +148,7 @@ func TestMergeSectionsConfig(t *testing.T) {
 					},
 					KeepAnnotations: true,
 					DropLabels:      false,
+					KeepRawBody:     true,
 				},
 			},
 			Filters: []telemetryv1alpha1.Filter{
@@ -165,8 +167,7 @@ func TestMergeSectionsConfig(t *testing.T) {
 			},
 			Output: telemetryv1alpha1.Output{
 				HTTP: &telemetryv1alpha1.HTTPOutput{
-					Dedot:    true,
-					KeepBody: true,
+					Dedot: true,
 					Host: telemetryv1alpha1.ValueType{
 						Value: "localhost",
 					},
@@ -212,6 +213,7 @@ func TestMergeSectionsConfigCustomOutput(t *testing.T) {
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
+    keep_log            on
     kube_tag_prefix     foo.var.log.containers.
     labels              on
     merge_log           on
@@ -233,6 +235,7 @@ func TestMergeSectionsConfigCustomOutput(t *testing.T) {
 					Namespaces: telemetryv1alpha1.InputNamespaces{
 						System: true,
 					},
+					KeepRawBody: true,
 				},
 			},
 			Output: telemetryv1alpha1.Output{

--- a/internal/fluentbit/config/builder/config_builder_test.go
+++ b/internal/fluentbit/config/builder/config_builder_test.go
@@ -146,9 +146,9 @@ func TestMergeSectionsConfig(t *testing.T) {
 					Namespaces: telemetryv1alpha1.InputNamespaces{
 						System: true,
 					},
-					KeepAnnotations: true,
-					DropLabels:      false,
-					KeepRawBody:     true,
+					KeepAnnotations:  true,
+					DropLabels:       false,
+					KeepOriginalBody: true,
 				},
 			},
 			Filters: []telemetryv1alpha1.Filter{
@@ -235,7 +235,7 @@ func TestMergeSectionsConfigCustomOutput(t *testing.T) {
 					Namespaces: telemetryv1alpha1.InputNamespaces{
 						System: true,
 					},
-					KeepRawBody: true,
+					KeepOriginalBody: true,
 				},
 			},
 			Output: telemetryv1alpha1.Output{

--- a/internal/fluentbit/config/builder/kubernetes_filter.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter.go
@@ -7,7 +7,7 @@ import (
 )
 
 func createKubernetesFilter(pipeline *telemetryv1alpha1.LogPipeline) string {
-	sb := NewFilterSectionBuilder().
+	return NewFilterSectionBuilder().
 		AddConfigParam("name", "kubernetes").
 		AddConfigParam("match", fmt.Sprintf("%s.*", pipeline.Name)).
 		AddConfigParam("merge_log", "on").
@@ -16,11 +16,9 @@ func createKubernetesFilter(pipeline *telemetryv1alpha1.LogPipeline) string {
 		AddConfigParam("kube_tag_prefix", fmt.Sprintf("%s.var.log.containers.", pipeline.Name)).
 		AddConfigParam("annotations", fmt.Sprintf("%v", fluentBitFlag(pipeline.Spec.Input.Application.KeepAnnotations))).
 		AddConfigParam("labels", fmt.Sprintf("%v", fluentBitFlag(!pipeline.Spec.Input.Application.DropLabels))).
-		AddConfigParam("buffer_size", "1MB")
-	if dropLogBody(pipeline) {
-		sb.AddConfigParam("keep_log", "off")
-	}
-	return sb.Build()
+		AddConfigParam("buffer_size", "1MB").
+		AddConfigParam("keep_log", fluentBitFlag(pipeline.Spec.Input.Application.KeepRawBody)).
+		Build()
 }
 
 func fluentBitFlag(b bool) string {
@@ -28,11 +26,4 @@ func fluentBitFlag(b bool) string {
 		return "on"
 	}
 	return "off"
-}
-
-func dropLogBody(pipeline *telemetryv1alpha1.LogPipeline) bool {
-	if pipeline.Spec.Output.HTTP != nil && !pipeline.Spec.Output.HTTP.KeepBody {
-		return true
-	}
-	return false
 }

--- a/internal/fluentbit/config/builder/kubernetes_filter.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter.go
@@ -17,7 +17,7 @@ func createKubernetesFilter(pipeline *telemetryv1alpha1.LogPipeline) string {
 		AddConfigParam("annotations", fmt.Sprintf("%v", fluentBitFlag(pipeline.Spec.Input.Application.KeepAnnotations))).
 		AddConfigParam("labels", fmt.Sprintf("%v", fluentBitFlag(!pipeline.Spec.Input.Application.DropLabels))).
 		AddConfigParam("buffer_size", "1MB").
-		AddConfigParam("keep_log", fluentBitFlag(pipeline.Spec.Input.Application.KeepRawBody)).
+		AddConfigParam("keep_log", fluentBitFlag(pipeline.Spec.Input.Application.KeepOriginalBody)).
 		Build()
 }
 

--- a/internal/fluentbit/config/builder/kubernetes_filter_test.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter_test.go
@@ -17,6 +17,7 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
+    keep_log            on
     kube_tag_prefix     test-logpipeline.var.log.containers.
     labels              on
     merge_log           on
@@ -28,7 +29,8 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
 					KeepAnnotations: true,
-					DropLabels:      false}}}}
+					DropLabels:      false,
+					KeepRawBody:     true}}}}
 
 	actual := createKubernetesFilter(logPipeline)
 	require.Equal(t, expected, actual)
@@ -42,6 +44,7 @@ func TestCreateKubernetesFilterDropAll(t *testing.T) {
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
+    keep_log            on
     kube_tag_prefix     test-logpipeline.var.log.containers.
     labels              off
     merge_log           on
@@ -53,7 +56,8 @@ func TestCreateKubernetesFilterDropAll(t *testing.T) {
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
 					KeepAnnotations: false,
-					DropLabels:      true}}}}
+					DropLabels:      true,
+					KeepRawBody:     true}}}}
 
 	actual := createKubernetesFilter(logPipeline)
 	require.Equal(t, expected, actual)

--- a/internal/fluentbit/config/builder/kubernetes_filter_test.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter_test.go
@@ -17,7 +17,7 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
-    keep_log            on
+    keep_log            off
     kube_tag_prefix     test-logpipeline.var.log.containers.
     labels              on
     merge_log           on
@@ -28,9 +28,8 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
 		Spec: telemetryv1alpha1.LogPipelineSpec{
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
-					KeepAnnotations:  true,
-					DropLabels:       false,
-					KeepOriginalBody: true}}}}
+					KeepAnnotations: true,
+				}}}}
 
 	actual := createKubernetesFilter(logPipeline)
 	require.Equal(t, expected, actual)
@@ -44,7 +43,7 @@ func TestCreateKubernetesFilterDropAll(t *testing.T) {
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
-    keep_log            on
+    keep_log            off
     kube_tag_prefix     test-logpipeline.var.log.containers.
     labels              off
     merge_log           on
@@ -55,9 +54,34 @@ func TestCreateKubernetesFilterDropAll(t *testing.T) {
 		Spec: telemetryv1alpha1.LogPipelineSpec{
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
-					KeepAnnotations:  false,
-					DropLabels:       true,
-					KeepOriginalBody: true}}}}
+					DropLabels: true,
+				}}}}
+
+	actual := createKubernetesFilter(logPipeline)
+	require.Equal(t, expected, actual)
+}
+
+func TestCreateKubernetesFilterKeepOriginalBody(t *testing.T) {
+	expected := `[FILTER]
+    name                kubernetes
+    match               test-logpipeline.*
+    annotations         off
+    buffer_size         1MB
+    k8s-logging.exclude off
+    k8s-logging.parser  on
+    keep_log            on
+    kube_tag_prefix     test-logpipeline.var.log.containers.
+    labels              on
+    merge_log           on
+
+`
+	logPipeline := &telemetryv1alpha1.LogPipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-logpipeline"},
+		Spec: telemetryv1alpha1.LogPipelineSpec{
+			Input: telemetryv1alpha1.Input{
+				Application: telemetryv1alpha1.ApplicationInput{
+					KeepOriginalBody: true,
+				}}}}
 
 	actual := createKubernetesFilter(logPipeline)
 	require.Equal(t, expected, actual)

--- a/internal/fluentbit/config/builder/kubernetes_filter_test.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter_test.go
@@ -28,9 +28,9 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
 		Spec: telemetryv1alpha1.LogPipelineSpec{
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
-					KeepAnnotations: true,
-					DropLabels:      false,
-					KeepRawBody:     true}}}}
+					KeepAnnotations:  true,
+					DropLabels:       false,
+					KeepOriginalBody: true}}}}
 
 	actual := createKubernetesFilter(logPipeline)
 	require.Equal(t, expected, actual)
@@ -55,9 +55,9 @@ func TestCreateKubernetesFilterDropAll(t *testing.T) {
 		Spec: telemetryv1alpha1.LogPipelineSpec{
 			Input: telemetryv1alpha1.Input{
 				Application: telemetryv1alpha1.ApplicationInput{
-					KeepAnnotations: false,
-					DropLabels:      true,
-					KeepRawBody:     true}}}}
+					KeepAnnotations:  false,
+					DropLabels:       true,
+					KeepOriginalBody: true}}}}
 
 	actual := createKubernetesFilter(logPipeline)
 	require.Equal(t, expected, actual)

--- a/internal/fluentbit/config/builder/kubernetes_filter_test.go
+++ b/internal/fluentbit/config/builder/kubernetes_filter_test.go
@@ -9,7 +9,7 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 )
 
-func TestCreateKubernetesFilterKeepAll(t *testing.T) {
+func TestCreateKubernetesFilterKeepAnnotations(t *testing.T) {
 	expected := `[FILTER]
     name                kubernetes
     match               test-logpipeline.*
@@ -35,7 +35,7 @@ func TestCreateKubernetesFilterKeepAll(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestCreateKubernetesFilterDropAll(t *testing.T) {
+func TestCreateKubernetesFilterDropLabels(t *testing.T) {
 	expected := `[FILTER]
     name                kubernetes
     match               test-logpipeline.*

--- a/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
+++ b/webhook/dryrun/testdata/expected/pipelines/dynamic/logpipeline-1.conf
@@ -23,6 +23,7 @@
     buffer_size         1MB
     k8s-logging.exclude off
     k8s-logging.parser  on
+    keep_log            off
     kube_tag_prefix     logpipeline-1.var.log.containers.
     labels              on
     merge_log           on

--- a/webhook/dryrun/testdata/given/logpipeline-1.yaml
+++ b/webhook/dryrun/testdata/given/logpipeline-1.yaml
@@ -8,5 +8,6 @@ spec:
       content: "dummy"
   output:
     http:
+      keepBody: true
       host:
         value: "127.0.0.1"

--- a/webhook/dryrun/testdata/given/logpipeline-1.yaml
+++ b/webhook/dryrun/testdata/given/logpipeline-1.yaml
@@ -8,6 +8,5 @@ spec:
       content: "dummy"
   output:
     http:
-      keepBody: true
       host:
         value: "127.0.0.1"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Added new attribute `keepRawBody` to the application input section of Logpipeline
- The default value of the new attribute is `true`
- If the `keepRawBody` is `false` and the original log content is JSON payload and parsing was successful the `log` attribute of the log record dropped.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/551

## Traceability
- [x] The PR is linked to a GitHub issue.
- [x] The PR has a milestone set.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
