### PR TITLE
chore: Simplify overrides handler

### DIFF
--- a/controllers/telemetry/logparser_controller.go
+++ b/controllers/telemetry/logparser_controller.go
@@ -55,7 +55,7 @@ func NewLogParserController(client client.Client, config LogParserControllerConf
 		reconcilerCfg,
 		&k8sutils.DaemonSetProber{Client: client},
 		&k8sutils.DaemonSetAnnotator{Client: client},
-		overrides.New(client, overrides.HandlerConfig{ConfigNamespace: config.TelemetryNamespace}),
+		overrides.New(client, overrides.HandlerConfig{SystemNamespace: config.TelemetryNamespace}),
 	)
 
 	return &LogParserController{

--- a/controllers/telemetry/logpipeline_controller.go
+++ b/controllers/telemetry/logpipeline_controller.go
@@ -19,7 +19,6 @@ limitations under the License.
 import (
 	"context"
 
-	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -59,24 +58,17 @@ type LogPipelineControllerConfig struct {
 	FluentBitMemoryLimit   string
 	FluentBitMemoryRequest string
 	FluentBitImage         string
-	OverridesConfigMapKey  string
-	OverridesConfigMapName string
 	PipelineDefaults       builder.PipelineDefaults
 	PriorityClassName      string
 	SelfMonitorName        string
 	TelemetryNamespace     string
 }
 
-func NewLogPipelineController(client client.Client, reconcileTriggerChan <-chan event.GenericEvent, atomicLevel zap.AtomicLevel, config LogPipelineControllerConfig) (*LogPipelineController, error) {
+func NewLogPipelineController(client client.Client, reconcileTriggerChan <-chan event.GenericEvent, config LogPipelineControllerConfig) (*LogPipelineController, error) {
 	flowHealthProber, err := prober.NewLogPipelineProber(types.NamespacedName{Name: config.SelfMonitorName, Namespace: config.TelemetryNamespace})
 	if err != nil {
 		return nil, err
 	}
-
-	overridesHandler := overrides.New(client, atomicLevel, overrides.HandlerConfig{
-		ConfigMapName: types.NamespacedName{Name: config.OverridesConfigMapName, Namespace: config.TelemetryNamespace},
-		ConfigMapKey:  config.OverridesConfigMapKey,
-	})
 
 	reconcilerCfg := logpipeline.Config{
 		SectionsConfigMap:     types.NamespacedName{Name: "telemetry-fluent-bit-sections", Namespace: config.TelemetryNamespace},
@@ -86,7 +78,6 @@ func NewLogPipelineController(client client.Client, reconcileTriggerChan <-chan 
 		EnvSecret:             types.NamespacedName{Name: "telemetry-fluent-bit-env", Namespace: config.TelemetryNamespace},
 		OutputTLSConfigSecret: types.NamespacedName{Name: "telemetry-fluent-bit-output-tls-config", Namespace: config.TelemetryNamespace},
 		DaemonSet:             types.NamespacedName{Name: "telemetry-fluent-bit", Namespace: config.TelemetryNamespace},
-		OverrideConfigMap:     types.NamespacedName{Name: config.OverridesConfigMapName, Namespace: config.TelemetryNamespace},
 		PipelineDefaults:      config.PipelineDefaults,
 		DaemonSetConfig: fluentbit.DaemonSetConfig{
 			FluentBitImage:    config.FluentBitImage,
@@ -105,7 +96,7 @@ func NewLogPipelineController(client client.Client, reconcileTriggerChan <-chan 
 		&k8sutils.DaemonSetProber{Client: client},
 		flowHealthProber,
 		istiostatus.NewChecker(client),
-		overridesHandler,
+		overrides.New(client, overrides.HandlerConfig{ConfigNamespace: config.TelemetryNamespace}),
 		tlscert.New(client))
 
 	return &LogPipelineController{

--- a/controllers/telemetry/logpipeline_controller.go
+++ b/controllers/telemetry/logpipeline_controller.go
@@ -96,7 +96,7 @@ func NewLogPipelineController(client client.Client, reconcileTriggerChan <-chan 
 		&k8sutils.DaemonSetProber{Client: client},
 		flowHealthProber,
 		istiostatus.NewChecker(client),
-		overrides.New(client, overrides.HandlerConfig{ConfigNamespace: config.TelemetryNamespace}),
+		overrides.New(client, overrides.HandlerConfig{SystemNamespace: config.TelemetryNamespace}),
 		tlscert.New(client))
 
 	return &LogPipelineController{

--- a/internal/overrides/handler.go
+++ b/internal/overrides/handler.go
@@ -34,7 +34,7 @@ type Handler struct {
 }
 
 type HandlerConfig struct {
-	ConfigNamespace string
+	SystemNamespace string
 }
 
 type Option = func(*Handler)
@@ -55,12 +55,11 @@ func DefaultAtomicLevel() zap.AtomicLevel {
 
 func New(client client.Reader, config HandlerConfig, opts ...Option) *Handler {
 	h := &Handler{
-		client:       client,
-		config:       config,
-		atomicLevel:  defaultAtomicLevel,
-		defaultLevel: defaultAtomicLevel.Level(),
+		client: client,
+		config: config,
 	}
 
+	WithAtomicLevel(DefaultAtomicLevel())(h)
 	for _, opt := range opts {
 		opt(h)
 	}
@@ -105,7 +104,7 @@ func (h *Handler) readConfigMapOrEmpty(ctx context.Context) (string, error) {
 	var cm corev1.ConfigMap
 	cmName := types.NamespacedName{
 		Name:      configMapName,
-		Namespace: h.config.ConfigNamespace,
+		Namespace: h.config.SystemNamespace,
 	}
 	if err := h.client.Get(ctx, cmName, &cm); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/overrides/handler.go
+++ b/internal/overrides/handler.go
@@ -3,6 +3,7 @@ package overrides
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -13,6 +14,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// name of the configmap where the overrides config is stored, the namespace is provided using HandlerConfig
+	configMapName = "telemetry-override-config"
+	// config key in the overrides configmap
+	configKey = "override-config"
+)
+
+var (
+	defaultAtomicLevel zap.AtomicLevel
+	once               sync.Once
+)
+
 type Handler struct {
 	client       client.Reader
 	config       HandlerConfig
@@ -21,17 +34,38 @@ type Handler struct {
 }
 
 type HandlerConfig struct {
-	ConfigMapName types.NamespacedName
-	ConfigMapKey  string
+	ConfigNamespace string
 }
 
-func New(client client.Reader, atomicLevel zap.AtomicLevel, config HandlerConfig) *Handler {
-	return &Handler{
-		atomicLevel:  atomicLevel,
-		defaultLevel: atomicLevel.Level(),
+type Option = func(*Handler)
+
+func WithAtomicLevel(level zap.AtomicLevel) Option {
+	return func(h *Handler) {
+		h.atomicLevel = level
+		h.defaultLevel = level.Level()
+	}
+}
+
+func DefaultAtomicLevel() zap.AtomicLevel {
+	once.Do(func() {
+		defaultAtomicLevel = zap.NewAtomicLevel()
+	})
+	return defaultAtomicLevel
+}
+
+func New(client client.Reader, config HandlerConfig, opts ...Option) *Handler {
+	h := &Handler{
 		client:       client,
 		config:       config,
+		atomicLevel:  defaultAtomicLevel,
+		defaultLevel: defaultAtomicLevel.Level(),
 	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	return h
 }
 
 func (h *Handler) LoadOverrides(ctx context.Context) (*Config, error) {
@@ -69,14 +103,17 @@ func (h *Handler) loadOverridesConfig(ctx context.Context) (*Config, error) {
 
 func (h *Handler) readConfigMapOrEmpty(ctx context.Context) (string, error) {
 	var cm corev1.ConfigMap
-	cmName := h.config.ConfigMapName
+	cmName := types.NamespacedName{
+		Name:      configMapName,
+		Namespace: h.config.ConfigNamespace,
+	}
 	if err := h.client.Get(ctx, cmName, &cm); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", nil
 		}
 		return "", fmt.Errorf("failed to get overrides configmap: %w", err)
 	}
-	if data, ok := cm.Data[h.config.ConfigMapKey]; ok {
+	if data, ok := cm.Data[configKey]; ok {
 		return data, nil
 	}
 	return "", nil

--- a/internal/overrides/handler.go
+++ b/internal/overrides/handler.go
@@ -22,8 +22,8 @@ const (
 )
 
 var (
-	defaultAtomicLevel zap.AtomicLevel
-	once               sync.Once
+	atomicLevel zap.AtomicLevel
+	once        sync.Once
 )
 
 type Handler struct {
@@ -46,11 +46,13 @@ func WithAtomicLevel(level zap.AtomicLevel) Option {
 	}
 }
 
-func DefaultAtomicLevel() zap.AtomicLevel {
+// AtomicLevel returns a global atomic log level shared by all Handler instances and the root controller runtime logger.
+// This enables the log level to be changed globally if the user overrides it.
+func AtomicLevel() zap.AtomicLevel {
 	once.Do(func() {
-		defaultAtomicLevel = zap.NewAtomicLevel()
+		atomicLevel = zap.NewAtomicLevel()
 	})
-	return defaultAtomicLevel
+	return atomicLevel
 }
 
 func New(client client.Reader, config HandlerConfig, opts ...Option) *Handler {
@@ -59,7 +61,7 @@ func New(client client.Reader, config HandlerConfig, opts ...Option) *Handler {
 		config: config,
 	}
 
-	WithAtomicLevel(DefaultAtomicLevel())(h)
+	WithAtomicLevel(AtomicLevel())(h)
 	for _, opt := range opts {
 		opt(h)
 	}

--- a/internal/reconciler/logpipeline/reconciler.go
+++ b/internal/reconciler/logpipeline/reconciler.go
@@ -52,7 +52,6 @@ type Config struct {
 	ParsersConfigMap      types.NamespacedName
 	EnvSecret             types.NamespacedName
 	OutputTLSConfigSecret types.NamespacedName
-	OverrideConfigMap     types.NamespacedName
 	PipelineDefaults      builder.PipelineDefaults
 	Overrides             overrides.Config
 	DaemonSetConfig       fluentbit.DaemonSetConfig

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -31,11 +31,10 @@ import (
 const defaultReplicaCount int32 = 2
 
 type Config struct {
-	Agent                  otelcollector.AgentConfig
-	Gateway                otelcollector.GatewayConfig
-	OverridesConfigMapName types.NamespacedName
-	MaxPipelines           int
-	ModuleVersion          string
+	Agent         otelcollector.AgentConfig
+	Gateway       otelcollector.GatewayConfig
+	MaxPipelines  int
+	ModuleVersion string
 }
 
 type AgentConfigBuilder interface {

--- a/internal/reconciler/telemetry/reconciler.go
+++ b/internal/reconciler/telemetry/reconciler.go
@@ -10,7 +10,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,11 +33,10 @@ const (
 )
 
 type Config struct {
-	Traces                 TracesConfig
-	Metrics                MetricsConfig
-	Webhook                WebhookConfig
-	OverridesConfigMapName types.NamespacedName
-	SelfMonitor            SelfMonitorConfig
+	Traces      TracesConfig
+	Metrics     MetricsConfig
+	Webhook     WebhookConfig
+	SelfMonitor SelfMonitorConfig
 }
 
 type TracesConfig struct {

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -46,9 +46,8 @@ import (
 const defaultReplicaCount int32 = 2
 
 type Config struct {
-	Gateway                otelcollector.GatewayConfig
-	OverridesConfigMapName types.NamespacedName
-	MaxPipelines           int
+	Gateway      otelcollector.GatewayConfig
+	MaxPipelines int
 }
 
 type GatewayConfigBuilder interface {

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	istiosecurityclientv1beta "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -326,7 +325,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	overridesHandler = overrides.New(mgr.GetClient(), overrides.HandlerConfig{ConfigNamespace: telemetryNamespace})
+	overridesHandler = overrides.New(mgr.GetClient(), overrides.HandlerConfig{SystemNamespace: telemetryNamespace})
 
 	tracePipelineReconcileTriggerChan := make(chan event.GenericEvent)
 	enableTracingController(mgr, tracePipelineReconcileTriggerChan)
@@ -522,8 +521,7 @@ func createTracePipelineController(client client.Client, reconcileTriggerChan <-
 			},
 			OTLPServiceName: traceOTLPServiceName,
 		},
-		OverridesConfigMapName: types.NamespacedName{Name: overridesConfigMapName, Namespace: telemetryNamespace},
-		MaxPipelines:           maxTracePipelines,
+		MaxPipelines: maxTracePipelines,
 	}
 
 	return telemetrycontrollers.NewTracePipelineController(
@@ -573,9 +571,8 @@ func createMetricPipelineController(client client.Client, reconcileTriggerChan <
 			},
 			OTLPServiceName: metricOTLPServiceName,
 		},
-		OverridesConfigMapName: types.NamespacedName{Name: overridesConfigMapName, Namespace: telemetryNamespace},
-		MaxPipelines:           maxMetricPipelines,
-		ModuleVersion:          version,
+		MaxPipelines:  maxMetricPipelines,
+		ModuleVersion: version,
 	}
 
 	return telemetrycontrollers.NewMetricPipelineController(
@@ -629,9 +626,8 @@ func createTelemetryController(client client.Client, scheme *runtime.Scheme, web
 			OTLPServiceName: metricOTLPServiceName,
 			Namespace:       telemetryNamespace,
 		},
-		Webhook:                webhookConfig,
-		OverridesConfigMapName: types.NamespacedName{Name: overridesConfigMapName, Namespace: telemetryNamespace},
-		SelfMonitor:            selfMonitorConfig,
+		Webhook:     webhookConfig,
+		SelfMonitor: selfMonitorConfig,
 	}
 
 	return operator.NewTelemetryController(client, telemetry.New(client, scheme, config, overridesHandler), config)

--- a/main.go
+++ b/main.go
@@ -133,10 +133,12 @@ const (
 	defaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/tpi/fluent-bit:3.0.7-1e5449d3"
 	defaultOtelImage              = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.104.0-1.20.0-rc1"
 	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.0-8691013b"
-	metricOTLPServiceName         = "telemetry-otlp-metrics"
-	selfMonitorName               = "telemetry-self-monitor"
-	traceOTLPServiceName          = "telemetry-otlp-traces"
-	webhookServiceName            = "telemetry-manager-webhook"
+
+	metricOTLPServiceName = "telemetry-otlp-metrics"
+	traceOTLPServiceName  = "telemetry-otlp-traces"
+	webhookServiceName    = "telemetry-manager-webhook"
+
+	selfMonitorName = "telemetry-self-monitor"
 )
 
 //nolint:gochecknoinits // Runtime's scheme addition is required.
@@ -267,8 +269,8 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
-	overrides.DefaultAtomicLevel().SetLevel(parsedLevel)
-	ctrLogger, err := logger.New(overrides.DefaultAtomicLevel())
+	overrides.AtomicLevel().SetLevel(parsedLevel)
+	ctrLogger, err := logger.New(overrides.AtomicLevel())
 
 	ctrl.SetLogger(zapr.NewLogger(ctrLogger.WithContext().Desugar()))
 	if err != nil {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Simplify overrides.Handler instantiation by decreasing the number of parameters passed into the constructor
- Makde default atomilLevel a singleton defined in the overrides pkg
- Sort constants in main.go

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
