### PR TITLE
chore: Group dependency bumps into single PR per project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+      istio:
+        patterns:
+          - "istio.io/*"
     commit-message:
       prefix: "chore"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       otel: # used by e2e and integration tests to push dummy otlp data
         patterns:
           - "go.opentelemetry.io/otel/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
     commit-message:
       prefix: "chore"
     labels:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- have dependabot create a single commit for all k8s related dependency bumps
- have dependabot create a single commit for all istio related dependency bumps

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
