### PR TITLE
feat: Rename navigation node in kyma dashboard to "telemetry"

### DIFF
--- a/config/busola/logpipeline_busola_extension_cm.yaml
+++ b/config/busola/logpipeline_busola_extension_cm.yaml
@@ -414,7 +414,7 @@ data:
       group: telemetry.kyma-project.io
       version: v1alpha1
     name: Log Pipelines
-    category: Observability
+    category: Telemetry
     urlPath: logpipelines
     scope: cluster
     description: >-

--- a/config/busola/metricpipeline_busola_extension_cm.yaml
+++ b/config/busola/metricpipeline_busola_extension_cm.yaml
@@ -543,7 +543,7 @@ data:
       group: telemetry.kyma-project.io
       version: v1alpha1
     name: Metric Pipelines
-    category: Observability
+    category: Telemetry
     urlPath: metricpipelines
     scope: cluster
     description: >-

--- a/config/busola/tracepipeline_busola_extension_cm.yaml
+++ b/config/busola/tracepipeline_busola_extension_cm.yaml
@@ -354,7 +354,7 @@ data:
       group: telemetry.kyma-project.io
       version: v1alpha1
     name: Trace Pipelines
-    category: Observability
+    category: Telemetry
     urlPath: tracepipelines
     scope: cluster
     description: >-


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- For historical reasons the navigation node listening all the telemetry related resource types (LogPipeline,..) is under "Observability". This PR changes it to "Telemetry" as the relation to the actual module is much more obvious

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
