### PR TITLE
chore: Revert kustomization.yaml and provision-k3d.sh

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: europe-docker.pkg.dev/kyma-project/dev/telemetry-manager
-  newTag: PR-1288
+  newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
+  newTag: main

--- a/hack/provision-k3d.sh
+++ b/hack/provision-k3d.sh
@@ -6,8 +6,7 @@ set -o errexit  # exit immediately when a command fails.
 set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being masked
 
-#bin/k3d registry create kyma-registry --port 5001
-#bin/k3d cluster create kyma --registry-use kyma-registry:5001 --image rancher/k3s:v$K8S_VERSION-k3s1 --api-port 6550
-bin/k3d cluster create kyma --image rancher/k3s:v$K8S_VERSION-k3s1 --api-port 6550
+bin/k3d registry create kyma-registry --port 5001
+bin/k3d cluster create kyma --registry-use kyma-registry:5001 --image rancher/k3s:v$K8S_VERSION-k3s1 --api-port 6550
 
 kubectl create ns kyma-system


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Revert mistakenly merged changes to kustomization.yaml and provision-k3d.sh

Changes refer to particular issues, PRs or documents:

- Introduced in https://github.com/kyma-project/telemetry-manager/pull/1288

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
