### PR TITLE
chore: Add unexported-return linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -181,6 +181,7 @@ linters-settings:
     rules:
       - name: dot-imports
         disabled: true
+      - name: unexported-return
 
   gocyclo:
     # Minimal code complexity to report.

--- a/internal/resources/otelcollector/agent.go
+++ b/internal/resources/otelcollector/agent.go
@@ -28,7 +28,7 @@ const (
 
 type AgentApplierDeleter struct {
 	Config AgentConfig
-	RBAC   rbac
+	RBAC   Rbac
 }
 
 type AgentApplyOptions struct {

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -310,7 +310,7 @@ func TestDeleteAgentResources(t *testing.T) {
 	})
 }
 
-func createAgentRBAC() rbac {
+func createAgentRBAC() Rbac {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      agentName,
@@ -340,7 +340,7 @@ func createAgentRBAC() rbac {
 		},
 	}
 
-	return rbac{
+	return Rbac{
 		clusterRole:        clusterRole,
 		clusterRoleBinding: clusterRoleBinding,
 		role:               nil,

--- a/internal/resources/otelcollector/core.go
+++ b/internal/resources/otelcollector/core.go
@@ -21,7 +21,7 @@ import (
 )
 
 // applyCommonResources applies resources to gateway and agent deployment node
-func applyCommonResources(ctx context.Context, c client.Client, name types.NamespacedName, rbac rbac, allowedPorts []int32) error {
+func applyCommonResources(ctx context.Context, c client.Client, name types.NamespacedName, rbac Rbac, allowedPorts []int32) error {
 	// Create service account before RBAC resources
 	if err := k8sutils.CreateOrUpdateServiceAccount(ctx, c, makeServiceAccount(name)); err != nil {
 		return fmt.Errorf("failed to create service account: %w", err)

--- a/internal/resources/otelcollector/gateway.go
+++ b/internal/resources/otelcollector/gateway.go
@@ -28,7 +28,7 @@ import (
 
 type GatewayApplierDeleter struct {
 	Config GatewayConfig
-	RBAC   rbac
+	RBAC   Rbac
 }
 
 type GatewayApplyOptions struct {

--- a/internal/resources/otelcollector/gateway_test.go
+++ b/internal/resources/otelcollector/gateway_test.go
@@ -519,7 +519,7 @@ func createGatewayConfig() GatewayConfig {
 	}
 }
 
-func createGatewayRBAC() rbac {
+func createGatewayRBAC() Rbac {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gatewayName,
@@ -578,7 +578,7 @@ func createGatewayRBAC() rbac {
 		},
 	}
 
-	return rbac{
+	return Rbac{
 		clusterRole:        clusterRole,
 		clusterRoleBinding: clusterRoleBinding,
 		role:               role,

--- a/internal/resources/otelcollector/rbac.go
+++ b/internal/resources/otelcollector/rbac.go
@@ -6,15 +6,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type rbac struct {
+type Rbac struct {
 	clusterRole        *rbacv1.ClusterRole
 	clusterRoleBinding *rbacv1.ClusterRoleBinding
 	role               *rbacv1.Role
 	roleBinding        *rbacv1.RoleBinding
 }
 
-func MakeTraceGatewayRBAC(name types.NamespacedName) rbac {
-	return rbac{
+func MakeTraceGatewayRBAC(name types.NamespacedName) Rbac {
+	return Rbac{
 		clusterRole:        makeTraceGatewayClusterRole(name),
 		clusterRoleBinding: makeClusterRoleBinding(name),
 		role:               nil,
@@ -22,8 +22,8 @@ func MakeTraceGatewayRBAC(name types.NamespacedName) rbac {
 	}
 }
 
-func MakeMetricAgentRBAC(name types.NamespacedName) rbac {
-	return rbac{
+func MakeMetricAgentRBAC(name types.NamespacedName) Rbac {
+	return Rbac{
 		clusterRole:        makeMetricAgentClusterRole(name),
 		clusterRoleBinding: makeClusterRoleBinding(name),
 		role:               nil,
@@ -31,8 +31,8 @@ func MakeMetricAgentRBAC(name types.NamespacedName) rbac {
 	}
 }
 
-func MakeMetricGatewayRBAC(name types.NamespacedName, kymaInputAllowed bool) rbac {
-	return rbac{
+func MakeMetricGatewayRBAC(name types.NamespacedName, kymaInputAllowed bool) Rbac {
+	return Rbac{
 		clusterRole:        makeMetricGatewayClusterRole(name, kymaInputAllowed),
 		clusterRoleBinding: makeClusterRoleBinding(name),
 		role:               makeMetricGatewayRole(name, kymaInputAllowed),

--- a/internal/testutils/pod_builder.go
+++ b/internal/testutils/pod_builder.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type podBuilder struct {
+type PodBuilder struct {
 	name                 string
 	namespace            string
 	labels               map[string]string
@@ -15,24 +15,24 @@ type podBuilder struct {
 	withExpiredThreshold bool
 }
 
-func NewPodBuilder(name, namespace string) *podBuilder {
-	pb := &podBuilder{
+func NewPodBuilder(name, namespace string) *PodBuilder {
+	pb := &PodBuilder{
 		name:      name,
 		namespace: namespace,
 	}
 	return pb
 }
 
-func (pb *podBuilder) WithLabels(labels map[string]string) *podBuilder {
+func (pb *PodBuilder) WithLabels(labels map[string]string) *PodBuilder {
 	pb.labels = labels
 	return pb
 }
 
-func (pb *podBuilder) WithImageNotFound() *podBuilder {
+func (pb *PodBuilder) WithImageNotFound() *PodBuilder {
 
 	pb.status = &corev1.PodStatus{
 		Phase:      corev1.PodPending,
-		Conditions: createPodReadyConditions(corev1.ConditionFalse, "", ""),
+		Conditions: createPodReadyConditions(corev1.ConditionFalse),
 		ContainerStatuses: []corev1.ContainerStatus{
 			{
 				Name: "collector",
@@ -48,19 +48,19 @@ func (pb *podBuilder) WithImageNotFound() *podBuilder {
 	return pb
 }
 
-func (pb *podBuilder) WithOOMStatus() *podBuilder {
+func (pb *PodBuilder) WithOOMStatus() *PodBuilder {
 	pb.status = &corev1.PodStatus{
 		Phase:             corev1.PodRunning,
-		Conditions:        createPodReadyConditions(corev1.ConditionFalse, "", ""),
+		Conditions:        createPodReadyConditions(corev1.ConditionFalse),
 		ContainerStatuses: createContainerStatus("OOMKilled", "Container was OOM killed", "OOMKilled", 137),
 	}
 	return pb
 }
 
-func (pb *podBuilder) WithCrashBackOffStatus() *podBuilder {
+func (pb *PodBuilder) WithCrashBackOffStatus() *PodBuilder {
 	pb.status = &corev1.PodStatus{
 		Phase:      corev1.PodRunning,
-		Conditions: createPodReadyConditions(corev1.ConditionFalse, "", ""),
+		Conditions: createPodReadyConditions(corev1.ConditionFalse),
 		ContainerStatuses: []corev1.ContainerStatus{
 			{
 				Name: "collector",
@@ -86,7 +86,7 @@ func (pb *podBuilder) WithCrashBackOffStatus() *podBuilder {
 	return pb
 }
 
-func (pb *podBuilder) WithEvictedStatus() *podBuilder {
+func (pb *PodBuilder) WithEvictedStatus() *PodBuilder {
 	pb.status = &corev1.PodStatus{
 		Phase:   corev1.PodFailed,
 		Reason:  "Evicted",
@@ -95,7 +95,7 @@ func (pb *podBuilder) WithEvictedStatus() *podBuilder {
 	return pb
 }
 
-func (pb *podBuilder) WithPendingStatus() *podBuilder {
+func (pb *PodBuilder) WithPendingStatus() *PodBuilder {
 	pb.status = &corev1.PodStatus{
 		Phase: corev1.PodPending,
 		Conditions: []corev1.PodCondition{
@@ -110,23 +110,23 @@ func (pb *podBuilder) WithPendingStatus() *podBuilder {
 	return pb
 }
 
-func (pb *podBuilder) WithNonZeroExitStatus() *podBuilder {
+func (pb *PodBuilder) WithNonZeroExitStatus() *PodBuilder {
 	pb.status = &corev1.PodStatus{
 		Phase:             corev1.PodRunning,
-		Conditions:        createPodReadyConditions(corev1.ConditionFalse, "", ""),
+		Conditions:        createPodReadyConditions(corev1.ConditionFalse),
 		ContainerStatuses: createContainerStatus("Error", "Container failed", "Error", 2),
 	}
 	return pb
 }
 
-func (pb *podBuilder) WithRunningStatus() *podBuilder {
+func (pb *PodBuilder) WithRunningStatus() *PodBuilder {
 	pb.status = &corev1.PodStatus{
 		Phase:      corev1.PodRunning,
-		Conditions: createPodReadyConditions(corev1.ConditionTrue, "", ""),
+		Conditions: createPodReadyConditions(corev1.ConditionTrue),
 	}
 	return pb
 }
-func (pb *podBuilder) Build() corev1.Pod {
+func (pb *PodBuilder) Build() corev1.Pod {
 	if pb.labels == nil {
 		pb.labels = make(map[string]string)
 		pb.labels["app"] = "foo"
@@ -179,14 +179,14 @@ func createContainerStatus(waitingReason, waitingMsg, terminatedReason string, e
 	}
 }
 
-func createPodReadyConditions(status corev1.ConditionStatus, reason, msg string) []corev1.PodCondition {
+func createPodReadyConditions(status corev1.ConditionStatus) []corev1.PodCondition {
 	condition := corev1.PodCondition{
 		Type:               corev1.PodReady,
 		Status:             status,
 		LastProbeTime:      metav1.Time{},
 		LastTransitionTime: metav1.NewTime(time.Now()),
-		Reason:             reason,
-		Message:            msg,
+		Reason:             "",
+		Message:            "",
 	}
 	conditions := []corev1.PodCondition{}
 	conditions = append(conditions, condition)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add new linter [unexported-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return) which will fail when an exported function or method returns a value of an un-exported type.
- Fixed the occurrences where the rule of this linter was not followed.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
