### PR TITLE
test: Flaky self-monitor metric outage tests

### DIFF
--- a/test/integration/istio/metrics_self_monitor_outage_test.go
+++ b/test/integration/istio/metrics_self_monitor_outage_test.go
@@ -41,7 +41,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 
 		objs = append(objs,
 			&metricPipeline,
-			telemetrygen.NewDeployment(mockNs, telemetrygen.SignalTypeMetrics, telemetrygen.WithRate(500_000), telemetrygen.WithWorkers(5)).WithReplicas(2).K8sObject(),
+			telemetrygen.NewDeployment(mockNs, telemetrygen.SignalTypeMetrics, telemetrygen.WithRate(10_000_000), telemetrygen.WithWorkers(50), telemetrygen.WithInterval("30s")).WithReplicas(2).K8sObject(),
 		)
 
 		return objs

--- a/test/testkit/mocks/telemetrygen/telemetrygen.go
+++ b/test/testkit/mocks/telemetrygen/telemetrygen.go
@@ -91,6 +91,13 @@ func WithSpanSize(spanSize int) Option {
 	}
 }
 
+// WithInterval Reporting interval
+func WithInterval(duration string) Option {
+	return func(spec *corev1.PodSpec) {
+		spec.Containers[0].Args = append(spec.Containers[0].Args, "--interval")
+		spec.Containers[0].Args = append(spec.Containers[0].Args, fmt.Sprintf("%v", duration))
+	}
+}
 func NewPod(namespace string, signalType SignalType, opts ...Option) *kitk8s.Pod {
 	return kitk8s.NewPod(DefaultName, namespace).WithPodSpec(PodSpec(signalType, opts...)).WithLabel("app.kubernetes.io/name", DefaultName)
 }
@@ -115,7 +122,7 @@ func PodSpec(signalType SignalType, opts ...Option) corev1.PodSpec {
 				Args: []string{
 					string(signalType),
 					"--rate",
-					"10",
+					"30s",
 					"--duration",
 					"30m",
 					"--otlp-endpoint",

--- a/test/testkit/mocks/telemetrygen/telemetrygen.go
+++ b/test/testkit/mocks/telemetrygen/telemetrygen.go
@@ -122,7 +122,7 @@ func PodSpec(signalType SignalType, opts ...Option) corev1.PodSpec {
 				Args: []string{
 					string(signalType),
 					"--rate",
-					"30s",
+					"10",
 					"--duration",
 					"30m",
 					"--otlp-endpoint",


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix flaky self-monitor-metic-outage e2e test
- BufferFillingUp tests fail occasionally for both metric and trace self-monitor outage tests, GatewayExporterDroppedData alert firing before GatewayExporterQueueAlmostFull alert. Data dropped from the queue before reaching 80% of the queue capacity, because some queued items reached the max retries limit of 6 minutes before the queue reached 80% of capacity.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
