### PR TITLE
feat: Add required RBAC for k8s cluster receiver

### DIFF
--- a/config/development/kustomization.yaml
+++ b/config/development/kustomization.yaml
@@ -24,6 +24,9 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --kyma-input-allowed=true
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --k8s-cluster-receiver-allowed=true
     target:
       kind: Deployment
       name: manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -235,14 +235,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -195,6 +195,46 @@ rules:
   - list
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - statefulsets

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,11 +26,22 @@ rules:
   - events
   verbs:
   - create
+  - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - ""
   resources:
   - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
   verbs:
   - get
   - list
@@ -54,6 +65,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/spec
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes/stats
   verbs:
   - get
@@ -63,6 +82,38 @@ rules:
   - ""
   resources:
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
   verbs:
   - get
   - list
@@ -106,7 +157,47 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - statefulsets
   verbs:
   - get
   - list

--- a/controllers/telemetry/metricpipeline_controller.go
+++ b/controllers/telemetry/metricpipeline_controller.go
@@ -81,7 +81,7 @@ func NewMetricPipelineController(client client.Client, reconcileTriggerChan <-ch
 	}
 
 	agentRBAC := otelcollector.MakeMetricAgentRBAC(types.NamespacedName{Name: config.Agent.BaseName, Namespace: config.Agent.Namespace})
-	gatewayRBAC := otelcollector.MakeMetricGatewayRBAC(types.NamespacedName{Name: config.Gateway.BaseName, Namespace: config.Gateway.Namespace}, config.KymaInputAllowed)
+	gatewayRBAC := otelcollector.MakeMetricGatewayRBAC(types.NamespacedName{Name: config.Gateway.BaseName, Namespace: config.Gateway.Namespace}, config.KymaInputAllowed, config.K8sClusterReceiverAllowed)
 
 	reconciler := metricpipeline.New(
 		client,

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -29,11 +29,12 @@ import (
 const defaultReplicaCount int32 = 2
 
 type Config struct {
-	Agent            otelcollector.AgentConfig
-	Gateway          otelcollector.GatewayConfig
-	MaxPipelines     int
-	ModuleVersion    string
-	KymaInputAllowed bool
+	Agent                     otelcollector.AgentConfig
+	Gateway                   otelcollector.GatewayConfig
+	MaxPipelines              int
+	ModuleVersion             string
+	KymaInputAllowed          bool
+	K8sClusterReceiverAllowed bool
 }
 
 type AgentConfigBuilder interface {

--- a/internal/resources/otelcollector/rbac.go
+++ b/internal/resources/otelcollector/rbac.go
@@ -31,9 +31,9 @@ func MakeMetricAgentRBAC(name types.NamespacedName) Rbac {
 	}
 }
 
-func MakeMetricGatewayRBAC(name types.NamespacedName, kymaInputAllowed bool) Rbac {
+func MakeMetricGatewayRBAC(name types.NamespacedName, kymaInputAllowed bool, k8sClusterReceiverAllowed bool) Rbac {
 	return Rbac{
-		clusterRole:        makeMetricGatewayClusterRole(name, kymaInputAllowed),
+		clusterRole:        makeMetricGatewayClusterRole(name, kymaInputAllowed, k8sClusterReceiverAllowed),
 		clusterRoleBinding: makeClusterRoleBinding(name),
 		role:               makeMetricGatewayRole(name, kymaInputAllowed),
 		roleBinding:        makeMetricGatewayRoleBinding(name, kymaInputAllowed),
@@ -83,7 +83,7 @@ func makeMetricAgentClusterRole(name types.NamespacedName) *rbacv1.ClusterRole {
 	}
 }
 
-func makeMetricGatewayClusterRole(name types.NamespacedName, kymaInputAllowed bool) *rbacv1.ClusterRole {
+func makeMetricGatewayClusterRole(name types.NamespacedName, kymaInputAllowed bool, k8sClusterReceiverAllowed bool) *rbacv1.ClusterRole {
 	clusterRole := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name.Name,
@@ -110,6 +110,32 @@ func makeMetricGatewayClusterRole(name types.NamespacedName, kymaInputAllowed bo
 			Resources: []string{"telemetries"},
 			Verbs:     []string{"get", "list", "watch"},
 		})
+	}
+
+	if k8sClusterReceiverAllowed {
+		clusterRules := []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"events", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "services", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "namespaces", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		}, {
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+			Verbs:     []string{"get", "list", "watch"},
+		}, {
+			APIGroups: []string{"extensions"},
+			Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+			Verbs:     []string{"get", "list", "watch"},
+		}, {
+			APIGroups: []string{"batch"},
+			Resources: []string{"cronjobs", "jobs"},
+			Verbs:     []string{"get", "list", "watch"},
+		}, {
+			APIGroups: []string{"autoscaling"},
+			Resources: []string{"horizontalpodautoscalers"},
+			Verbs:     []string{"get", "list", "watch"},
+		}}
+
+		clusterRole.Rules = append(clusterRole.Rules, clusterRules...)
 	}
 
 	return &clusterRole

--- a/internal/resources/otelcollector/rbac.go
+++ b/internal/resources/otelcollector/rbac.go
@@ -115,19 +115,19 @@ func makeMetricGatewayClusterRole(name types.NamespacedName, kymaInputAllowed bo
 	if k8sClusterReceiverAllowed {
 		clusterRules := []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
-			Resources: []string{"events", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "services", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "namespaces", "pods"},
+			Resources: []string{"events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services"},
 			Verbs:     []string{"get", "list", "watch"},
 		}, {
 			APIGroups: []string{"apps"},
-			Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+			Resources: []string{"daemonsets", "deployments", "replicasets", "statefulsets"},
 			Verbs:     []string{"get", "list", "watch"},
 		}, {
 			APIGroups: []string{"extensions"},
-			Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+			Resources: []string{"daemonsets", "deployments", "replicasets"},
 			Verbs:     []string{"get", "list", "watch"},
 		}, {
 			APIGroups: []string{"batch"},
-			Resources: []string{"cronjobs", "jobs"},
+			Resources: []string{"jobs", "cronjobs"},
 			Verbs:     []string{"get", "list", "watch"},
 		}, {
 			APIGroups: []string{"autoscaling"},

--- a/internal/resources/otelcollector/rbac_test.go
+++ b/internal/resources/otelcollector/rbac_test.go
@@ -245,19 +245,19 @@ func TestMakeMetricGatewayRBACWithK8sClusterReceiverAllowed(t *testing.T) {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"events", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "services", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "namespaces", "pods"},
+				Resources: []string{"events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services"},
 				Verbs:     []string{"get", "list", "watch"},
 			}, {
 				APIGroups: []string{"apps"},
-				Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+				Resources: []string{"daemonsets", "deployments", "replicasets", "statefulsets"},
 				Verbs:     []string{"get", "list", "watch"},
 			}, {
 				APIGroups: []string{"extensions"},
-				Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+				Resources: []string{"daemonsets", "deployments", "replicasets"},
 				Verbs:     []string{"get", "list", "watch"},
 			}, {
 				APIGroups: []string{"batch"},
-				Resources: []string{"cronjobs", "jobs"},
+				Resources: []string{"jobs", "cronjobs"},
 				Verbs:     []string{"get", "list", "watch"},
 			}, {
 				APIGroups: []string{"autoscaling"},

--- a/internal/resources/otelcollector/rbac_test.go
+++ b/internal/resources/otelcollector/rbac_test.go
@@ -103,7 +103,7 @@ func TestMakeMetricGatewayRBAC(t *testing.T) {
 	name := "test-gateway"
 	namespace := "test-namespace"
 
-	rbac := MakeMetricGatewayRBAC(types.NamespacedName{Name: name, Namespace: namespace}, false)
+	rbac := MakeMetricGatewayRBAC(types.NamespacedName{Name: name, Namespace: namespace}, false, false)
 
 	t.Run("should have a cluster role", func(t *testing.T) {
 		cr := rbac.clusterRole
@@ -149,7 +149,7 @@ func TestMakeMetricGatewayRBACWithKymaInputAllowed(t *testing.T) {
 	name := "test-gateway"
 	namespace := "test-namespace"
 
-	rbac := MakeMetricGatewayRBAC(types.NamespacedName{Name: name, Namespace: namespace}, true)
+	rbac := MakeMetricGatewayRBAC(types.NamespacedName{Name: name, Namespace: namespace}, true, false)
 
 	t.Run("should have a cluster role", func(t *testing.T) {
 		cr := rbac.clusterRole
@@ -222,6 +222,60 @@ func TestMakeMetricGatewayRBACWithKymaInputAllowed(t *testing.T) {
 		require.Equal(t, "rbac.authorization.k8s.io", rb.RoleRef.APIGroup)
 		require.Equal(t, "Role", rb.RoleRef.Kind)
 		require.Equal(t, name, rb.RoleRef.Name)
+	})
+}
+
+func TestMakeMetricGatewayRBACWithK8sClusterReceiverAllowed(t *testing.T) {
+	name := "test-gateway"
+	namespace := "test-namespace"
+
+	metricGWRBAC := MakeMetricGatewayRBAC(types.NamespacedName{Name: name, Namespace: namespace}, false, true)
+	t.Run("should have a cluster role", func(t *testing.T) {
+		cr := metricGWRBAC.clusterRole
+		expectedRules := []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"events", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "services", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "namespaces", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			}, {
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+				Verbs:     []string{"get", "list", "watch"},
+			}, {
+				APIGroups: []string{"extensions"},
+				Resources: []string{"deployments", "daemonsets", "replicasets", "statefulsets"},
+				Verbs:     []string{"get", "list", "watch"},
+			}, {
+				APIGroups: []string{"batch"},
+				Resources: []string{"cronjobs", "jobs"},
+				Verbs:     []string{"get", "list", "watch"},
+			}, {
+				APIGroups: []string{"autoscaling"},
+				Resources: []string{"horizontalpodautoscalers"},
+				Verbs:     []string{"get", "list", "watch"},
+			}}
+
+		require.Equal(t, expectedRules, cr.Rules)
+		require.Equal(t, name, cr.Name)
+		require.Equal(t, namespace, cr.Namespace)
+		require.Equal(t, map[string]string{
+			"app.kubernetes.io/name": name,
+		}, cr.Labels)
+	})
+
+	t.Run("should have a cluster role binding", func(t *testing.T) {
+		crb := metricGWRBAC.clusterRoleBinding
+		checkClusterRoleBinding(t, crb, name, namespace)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -121,7 +121,8 @@ var (
 	selfMonitorImage         string
 	selfMonitorPriorityClass string
 
-	kymaInputAllowed bool
+	kymaInputAllowed          bool
+	k8sClusterReceiverAllowed bool
 
 	version = "main"
 )
@@ -259,6 +260,7 @@ func main() {
 	flag.StringVar(&selfMonitorPriorityClass, "self-monitor-priority-class", "", "Priority class name for self-monitor")
 
 	flag.BoolVar(&kymaInputAllowed, "kyma-input-allowed", false, "Allow collecting status metrics for Kyma Telemetry module")
+	flag.BoolVar(&k8sClusterReceiverAllowed, "k8s-cluster-receiver-allowed", false, "Allow collecting cluster level metrics from API Server in kyma")
 
 	flag.Parse()
 	if err := validateFlags(); err != nil {
@@ -527,9 +529,10 @@ func enableMetricsController(mgr manager.Manager, reconcileTriggerChan <-chan ev
 					},
 					OTLPServiceName: metricOTLPServiceName,
 				},
-				MaxPipelines:     maxMetricPipelines,
-				ModuleVersion:    version,
-				KymaInputAllowed: kymaInputAllowed,
+				MaxPipelines:              maxMetricPipelines,
+				ModuleVersion:             version,
+				KymaInputAllowed:          kymaInputAllowed,
+				K8sClusterReceiverAllowed: k8sClusterReceiverAllowed,
 			},
 			TelemetryNamespace: telemetryNamespace,
 			SelfMonitorName:    selfMonitorName,

--- a/main.go
+++ b/main.go
@@ -226,7 +226,6 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch
 
-//+kubebuilder:rbac:groups=extensions,resources=statefulsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions,resources=daemonsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions,resources=deployments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions,resources=replicasets,verbs=get;list;watch

--- a/main.go
+++ b/main.go
@@ -188,6 +188,13 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=namespaces/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=nodes/spec,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=replicationcontrollers,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=replicationcontrollers/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=resourcequotas,verbs=get;list;watch
 //+kubebuilder:rbac:urls=/metrics,verbs=get
 //+kubebuilder:rbac:urls=/metrics/cadvisor,verbs=get
 
@@ -196,6 +203,9 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
 
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 
@@ -210,6 +220,10 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 
 // +kubebuilder:rbac:groups=security.istio.io,resources=peerauthentications,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.istio.io,namespace=system,resources=peerauthentications,verbs=create;update;patch;delete
+
+//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
+
+//+kubebuilder:rbac:groups=extensions,resources=statefulsets,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 

--- a/main.go
+++ b/main.go
@@ -223,7 +223,13 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
 
+//+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch
+
 //+kubebuilder:rbac:groups=extensions,resources=statefulsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=extensions,resources=daemonsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=extensions,resources=deployments,verbs=get;list;watch
+//+kubebuilder:rbac:groups=extensions,resources=replicasets,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add the required RBAC for the k8s cluster receiver from [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver#rbac)
- Add a flag to enable k8s cluster receiver
- Added option `k8s-cluster-receiver-allowed` under dev deployment
Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1184

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
