### PR TITLE
fix: Broken alert rule queries for queue alerts after OTEL version 0.106.1

### DIFF
--- a/internal/selfmonitor/config/expr_builder.go
+++ b/internal/selfmonitor/config/expr_builder.go
@@ -42,14 +42,14 @@ func rate(metric string, selectors ...labelSelector) *exprBuilder {
 	return eb
 }
 
-func div(nominator, denominator string, selectors ...labelSelector) *exprBuilder {
+func div(nominator, denominator, modifier string, selectors ...labelSelector) *exprBuilder {
 	for _, s := range selectors {
 		nominator = s(nominator)
 		denominator = s(denominator)
 	}
 
 	eb := &exprBuilder{
-		expr: fmt.Sprintf("%s / %s", nominator, denominator),
+		expr: fmt.Sprintf("%s / %s %s", nominator, modifier, denominator),
 	}
 	return eb
 }

--- a/internal/selfmonitor/config/otelcol_rule_builder.go
+++ b/internal/selfmonitor/config/otelcol_rule_builder.go
@@ -11,6 +11,7 @@ const (
 	metricOtelCollectorExporterQueueCapacity = "otelcol_exporter_queue_capacity"
 	metricOtelCollectorExporterEnqueueFailed = "otelcol_exporter_enqueue_failed"
 	metricOtelCollectorReceiverRefused       = "otelcol_receiver_refused"
+	metricDivisionModifier                   = "on() group_right()"
 )
 
 type otelCollectorRuleBuilder struct {
@@ -58,7 +59,7 @@ func (rb otelCollectorRuleBuilder) exporterDroppedRule() Rule {
 func (rb otelCollectorRuleBuilder) exporterQueueAlmostFullRule() Rule {
 	return Rule{
 		Alert: rb.namePrefix + RuleNameGatewayExporterQueueAlmostFull,
-		Expr: div(metricOtelCollectorExporterQueueSize, metricOtelCollectorExporterQueueCapacity, selectService(rb.serviceName)).
+		Expr: div(metricOtelCollectorExporterQueueSize, metricOtelCollectorExporterQueueCapacity, metricDivisionModifier, selectService(rb.serviceName)).
 			maxBy(labelPipelineName).
 			greaterThan(0.8).
 			build(),


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- OTEL version 0.106 adds new attribute `data_type` to `otelcol_exporter_queue_size`, this will cause empty results for arithmetic queries such as alert rule `*QueueAlmostFull` rules. The reason is, that the pair of queries used in this operation doesn't have identical label pairs anymore (`otelcol_exporter_queue_size` got a new attribute but not other metric `otelcol_exporter_queue_capacity`). For more details read [this](https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching) document.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
