### PR TITLE
test: Add additional tests for logs/metrics/traces if pods are up and running

### DIFF
--- a/test/e2e/logs_basic_v1alpha1_test.go
+++ b/test/e2e/logs_basic_v1alpha1_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/logs_basic_v1alpha1_test.go
+++ b/test/e2e/logs_basic_v1alpha1_test.go
@@ -75,7 +75,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have unsupportedMode set to false", func() {

--- a/test/e2e/logs_basic_v1alpha1_test.go
+++ b/test/e2e/logs_basic_v1alpha1_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -71,6 +72,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a running pipeline", Label(suite.LabelOperational), func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have unsupportedMode set to false", func() {

--- a/test/e2e/logs_basic_v1beta1_test.go
+++ b/test/e2e/logs_basic_v1beta1_test.go
@@ -83,7 +83,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs, suite.LabelExperimental), Or
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have unsupportedMode set to false", func() {

--- a/test/e2e/logs_basic_v1beta1_test.go
+++ b/test/e2e/logs_basic_v1beta1_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +14,7 @@ import (
 	telemetryv1beta1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1beta1"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/logs_basic_v1beta1_test.go
+++ b/test/e2e/logs_basic_v1beta1_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -79,6 +80,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs, suite.LabelExperimental), Or
 
 		It("Should have a running pipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have unsupportedMode set to false", func() {

--- a/test/e2e/logs_custom_output_test.go
+++ b/test/e2e/logs_custom_output_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"fmt"
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/logs_custom_output_test.go
+++ b/test/e2e/logs_custom_output_test.go
@@ -74,7 +74,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_custom_output_test.go
+++ b/test/e2e/logs_custom_output_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"fmt"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -70,6 +71,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have unsupportedMode set to true", func() {
 			assert.LogPipelineUnsupportedMode(ctx, k8sClient, pipelineName, true)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_dedot_test.go
+++ b/test/e2e/logs_dedot_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -64,6 +65,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a running logpipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_dedot_test.go
+++ b/test/e2e/logs_dedot_test.go
@@ -68,7 +68,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_dedot_test.go
+++ b/test/e2e/logs_dedot_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_drop_labels_test.go
+++ b/test/e2e/logs_drop_labels_test.go
@@ -71,7 +71,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_drop_labels_test.go
+++ b/test/e2e/logs_drop_labels_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -67,6 +68,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a running logpipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_drop_labels_test.go
+++ b/test/e2e/logs_drop_labels_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_exclude_container_test.go
+++ b/test/e2e/logs_exclude_container_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"io"
 	"net/http"
 
@@ -65,6 +66,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a running logpipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_exclude_container_test.go
+++ b/test/e2e/logs_exclude_container_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"io"
 	"net/http"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_exclude_container_test.go
+++ b/test/e2e/logs_exclude_container_test.go
@@ -69,7 +69,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_keep_annotation_test.go
+++ b/test/e2e/logs_keep_annotation_test.go
@@ -69,7 +69,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_keep_annotation_test.go
+++ b/test/e2e/logs_keep_annotation_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -65,6 +66,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a running logpipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_keep_annotation_test.go
+++ b/test/e2e/logs_keep_annotation_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_keep_original_body_test.go
+++ b/test/e2e/logs_keep_original_body_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -84,6 +85,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		It("Should have running logpipelines", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipeline1Name)
 			assert.LogPipelineHealthy(ctx, k8sClient, pipeline2Name)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have log backends running", func() {

--- a/test/e2e/logs_keep_original_body_test.go
+++ b/test/e2e/logs_keep_original_body_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_keep_original_body_test.go
+++ b/test/e2e/logs_keep_original_body_test.go
@@ -88,7 +88,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have log backends running", func() {

--- a/test/e2e/logs_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/logs_mtls_about_to_expire_cert_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +71,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have running pipelines", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a tlsCertAboutToExpire Condition set in pipeline conditions", func() {

--- a/test/e2e/logs_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/logs_mtls_about_to_expire_cert_test.go
@@ -74,7 +74,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a tlsCertAboutToExpire Condition set in pipeline conditions", func() {

--- a/test/e2e/logs_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/logs_mtls_about_to_expire_cert_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +14,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/logs_mtls_test.go
+++ b/test/e2e/logs_mtls_test.go
@@ -74,7 +74,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_mtls_test.go
+++ b/test/e2e/logs_mtls_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/logs_mtls_test.go
+++ b/test/e2e/logs_mtls_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -70,6 +71,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a running logpipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_multi_pipeline_broken_pipeline_test.go
+++ b/test/e2e/logs_multi_pipeline_broken_pipeline_test.go
@@ -69,6 +69,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, brokenPipelineName)
 		})
 
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+		})
+
 		It("Should have a log backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})

--- a/test/e2e/logs_multi_pipeline_broken_pipeline_test.go
+++ b/test/e2e/logs_multi_pipeline_broken_pipeline_test.go
@@ -70,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_multi_pipeline_namespace_filter_test.go
+++ b/test/e2e/logs_multi_pipeline_namespace_filter_test.go
@@ -86,7 +86,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_multi_pipeline_namespace_filter_test.go
+++ b/test/e2e/logs_multi_pipeline_namespace_filter_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_multi_pipeline_namespace_filter_test.go
+++ b/test/e2e/logs_multi_pipeline_namespace_filter_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -82,6 +83,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		It("Should have a running logpipelines", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineIncludeNamespaceName)
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineExcludeNamespaceName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_multi_pipeline_test.go
+++ b/test/e2e/logs_multi_pipeline_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,6 +70,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		It("Should have running pipelines", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipeline1Name)
 			assert.LogPipelineHealthy(ctx, k8sClient, pipeline2Name)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_multi_pipeline_test.go
+++ b/test/e2e/logs_multi_pipeline_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/logs_multi_pipeline_test.go
+++ b/test/e2e/logs_multi_pipeline_test.go
@@ -73,7 +73,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_parser_test.go
+++ b/test/e2e/logs_parser_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 	"time"
 
@@ -73,6 +74,10 @@ Types user:string pass:string`
 
 		It("Should have a running logpipeline", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_parser_test.go
+++ b/test/e2e/logs_parser_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/log"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/loggen"

--- a/test/e2e/logs_parser_test.go
+++ b/test/e2e/logs_parser_test.go
@@ -77,7 +77,7 @@ Types user:string pass:string`
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/e2e/logs_resources_test.go
+++ b/test/e2e/logs_resources_test.go
@@ -83,7 +83,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 		It("Should have a DaemonSet owned by the LogPipeline", func() {
 			var daemonSet appsv1.DaemonSet
-			assert.HasOwnerReference(ctx, k8sClient, &daemonSet, kitkyma.FluentBitDaemonSet, ownerReferenceKind, pipelineName)
+			assert.HasOwnerReference(ctx, k8sClient, &daemonSet, kitkyma.FluentBitDaemonSetName, ownerReferenceKind, pipelineName)
 		})
 
 		It("Should have a Network Policy owned by the LogPipeline", func() {
@@ -94,7 +94,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 		It("Should have a DaemonSet with correct pod priority class", func() {
 			Eventually(func(g Gomega) {
 				var daemonSet appsv1.DaemonSet
-				g.Expect(k8sClient.Get(ctx, kitkyma.FluentBitDaemonSet, &daemonSet)).To(Succeed())
+				g.Expect(k8sClient.Get(ctx, kitkyma.FluentBitDaemonSetName, &daemonSet)).To(Succeed())
 
 				g.Expect(daemonSet.Spec.Template.Spec.PriorityClassName).To(Equal("telemetry-priority-class-high"))
 			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
@@ -172,7 +172,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs), Ordered, func() {
 
 			Eventually(func(g Gomega) bool {
 				var daemonSet appsv1.DaemonSet
-				err := k8sClient.Get(ctx, kitkyma.FluentBitDaemonSet, &daemonSet)
+				err := k8sClient.Get(ctx, kitkyma.FluentBitDaemonSetName, &daemonSet)
 				return apierrors.IsNotFound(err)
 			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(BeTrue(), "DaemonSet still exists")
 

--- a/test/e2e/logs_self_monitor_healthy_test.go
+++ b/test/e2e/logs_self_monitor_healthy_test.go
@@ -67,6 +67,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsHealthy), Ordere
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have running log agent", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})

--- a/test/e2e/logs_self_monitor_healthy_test.go
+++ b/test/e2e/logs_self_monitor_healthy_test.go
@@ -68,7 +68,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsHealthy), Ordere
 		})
 
 		It("Should have running log agent", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a running self-monitor", func() {

--- a/test/e2e/metrics_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/metrics_mtls_about_to_expire_cert_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +14,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/metrics_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/metrics_mtls_about_to_expire_cert_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,6 +72,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 
 		It("Should have running pipelines", func() {
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running metrics gateway", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a tlsCertAboutToExpire Condition set in pipeline conditions", func() {

--- a/test/e2e/metrics_mtls_test.go
+++ b/test/e2e/metrics_mtls_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,6 +67,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 
 		It("Should have running pipelines", func() {
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have running metric gateway", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a metric backend running", func() {

--- a/test/e2e/metrics_mtls_test.go
+++ b/test/e2e/metrics_mtls_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/metrics_multi_pipeline_namespace_selector_test.go
+++ b/test/e2e/metrics_multi_pipeline_namespace_selector_test.go
@@ -90,13 +90,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
+		It("Should have a running metric agent daemonset", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
 		It("Should have a metrics backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
-		})
-
-		It("Should have a running metric agent daemonset", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
 		})
 
 		// verify metrics from apps1Ns delivered to backend1

--- a/test/e2e/metrics_multi_pipeline_test.go
+++ b/test/e2e/metrics_multi_pipeline_test.go
@@ -89,6 +89,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
+		It("Should have a running metric agent daemonset", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
 		It("Should have a metrics backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backendRuntimeName, Namespace: mockNs})
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backendPrometheusName, Namespace: mockNs})

--- a/test/e2e/metrics_prometheus_input_test.go
+++ b/test/e2e/metrics_prometheus_input_test.go
@@ -67,12 +67,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
-		It("Ensures the metrics backend is ready", func() {
-			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
-		})
-
 		It("Ensures the metric agent daemonset is ready", func() {
 			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
+		It("Ensures the metrics backend is ready", func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Ensures the metricpipeline is running", func() {

--- a/test/e2e/metrics_runtime_input_resources_test.go
+++ b/test/e2e/metrics_runtime_input_resources_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -77,6 +78,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 		It("Should have healthy pipelines", func() {
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineOnlyContainerMetricsEnabledName)
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineOnlyPodMetricsEnabledName)
+		})
+
+		It("Ensures the metric gateway deployment is ready", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
+		})
+
+		It("Ensures the metric agent daemonset is ready", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
 		})
 
 		It("Should have metrics backends running", func() {

--- a/test/e2e/metrics_runtime_input_resources_test.go
+++ b/test/e2e/metrics_runtime_input_resources_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/metric"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/otel/kubeletstats"

--- a/test/e2e/metrics_runtime_input_test.go
+++ b/test/e2e/metrics_runtime_input_test.go
@@ -65,12 +65,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
-		It("Ensures the metrics backend is ready", func() {
-			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
-		})
-
 		It("Ensures the metric agent daemonset is ready", func() {
 			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
+		It("Ensures the metrics backend is ready", func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Ensures accessibility of metric agent metrics endpoint", func() {

--- a/test/e2e/metrics_self_monitor_healthy_test.go
+++ b/test/e2e/metrics_self_monitor_healthy_test.go
@@ -100,6 +100,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsHealthy), Ord
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Ensures the metric gateway deployment is ready", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
+		})
+
 		It("Should deliver telemetrygen metrics", func() {
 			assert.MetricsFromNamespaceDelivered(proxyClient, backendExportURL, kitkyma.DefaultNamespaceName, telemetrygen.MetricNames)
 		})

--- a/test/e2e/metrics_service_name_test.go
+++ b/test/e2e/metrics_service_name_test.go
@@ -67,6 +67,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 
 		})
 
+		It("Ensures the metric agent daemonset is ready", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
 		It("Should have a metrics backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})

--- a/test/e2e/telemetry_logs_analysis_test.go
+++ b/test/e2e/telemetry_logs_analysis_test.go
@@ -168,7 +168,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 
 		It("Should have running agents", func() {
 			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have running pipelines", func() {

--- a/test/e2e/traces_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/traces_mtls_about_to_expire_cert_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +14,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/traces_mtls_about_to_expire_cert_test.go
+++ b/test/e2e/traces_mtls_about_to_expire_cert_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,6 +72,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 
 		It("Should have running pipelines", func() {
 			assert.TracePipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have a running trace gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a tlsCertificateAboutToExpire Condition set in pipeline conditions", func() {

--- a/test/e2e/traces_multi_pipeline_test.go
+++ b/test/e2e/traces_multi_pipeline_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,10 +70,16 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), Ordered, func() {
 			assert.TracePipelineHealthy(ctx, k8sClient, pipeline1Name)
 			assert.TracePipelineHealthy(ctx, k8sClient, pipeline2Name)
 		})
+
+		It("Should have a running trace gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.TraceGatewayName)
+		})
+
 		It("Should have a trace backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
 		})
+
 		It("Should verify traces from telemetrygen are delivered", func() {
 			assert.TracesFromNamespaceDelivered(proxyClient, backend1ExportURL, mockNs)
 			assert.TracesFromNamespaceDelivered(proxyClient, backend2ExportURL, mockNs)

--- a/test/e2e/traces_multi_pipeline_test.go
+++ b/test/e2e/traces_multi_pipeline_test.go
@@ -3,7 +3,6 @@
 package e2e
 
 import (
-	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/testutils"
 	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
 	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"

--- a/test/e2e/traces_noisy_span_filter_test.go
+++ b/test/e2e/traces_noisy_span_filter_test.go
@@ -161,6 +161,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			assert.TracePipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running trace gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.TraceGatewayName)
+		})
+
 		It("Should have a trace backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})

--- a/test/e2e/traces_self_monitor_healthy_test.go
+++ b/test/e2e/traces_self_monitor_healthy_test.go
@@ -96,6 +96,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesHealthy), Orde
 			assert.TracePipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running trace gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.TraceGatewayName)
+		})
+
 		It("Should deliver telemetrygen traces", func() {
 			assert.TracesFromNamespaceDelivered(proxyClient, backendExportURL, kitkyma.DefaultNamespaceName)
 		})

--- a/test/integration/istio/access_logs_test.go
+++ b/test/integration/istio/access_logs_test.go
@@ -3,6 +3,7 @@
 package istio
 
 import (
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -88,6 +89,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 
 		It("Should have the log pipeline running", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
+		})
+
+		It("Should have a running log agent daemonset", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
 		})
 
 		It("Should invoke the metrics endpoint to generate access logs", func() {

--- a/test/integration/istio/access_logs_test.go
+++ b/test/integration/istio/access_logs_test.go
@@ -92,7 +92,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have a running log agent daemonset", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should invoke the metrics endpoint to generate access logs", func() {

--- a/test/integration/istio/logs_self_monitor_backpressure_test.go
+++ b/test/integration/istio/logs_self_monitor_backpressure_test.go
@@ -63,7 +63,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsBackpressure), O
 		})
 
 		It("Should have a running log agent daemonset", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a running self-monitor", func() {

--- a/test/integration/istio/logs_self_monitor_backpressure_test.go
+++ b/test/integration/istio/logs_self_monitor_backpressure_test.go
@@ -62,6 +62,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsBackpressure), O
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running log agent daemonset", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})

--- a/test/integration/istio/logs_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_self_monitor_outage_test.go
@@ -70,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsOutage), Ordered
 		})
 
 		It("Should have a running log agent daemonset", func() {
-			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSetName)
 		})
 
 		It("Should have a log backend running", func() {

--- a/test/integration/istio/logs_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_self_monitor_outage_test.go
@@ -69,6 +69,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsOutage), Ordered
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})
 
+		It("Should have a running log agent daemonset", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.FluentBitDaemonSet)
+		})
+
 		It("Should have a log backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: mockNs, Name: backend.DefaultName})
 		})

--- a/test/integration/istio/metrics_istio_input_test.go
+++ b/test/integration/istio/metrics_istio_input_test.go
@@ -110,6 +110,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
+		It("Should have a running metric agent daemonset", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
 		It("Should have a metrics backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})

--- a/test/integration/istio/metrics_prometheus_input_test.go
+++ b/test/integration/istio/metrics_prometheus_input_test.go
@@ -79,12 +79,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
-		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
-		})
-
 		It("Should have a running metric agent daemonset", func() {
 			assert.DaemonSetReady(ctx, k8sClient, kitkyma.MetricAgentName)
+		})
+
+		It("Should have a metrics backend running", func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})
 
 		Context("Verify metric scraping works with annotating pods and services", Ordered, func() {

--- a/test/integration/istio/metrics_self_monitor_backpressure_test.go
+++ b/test/integration/istio/metrics_self_monitor_backpressure_test.go
@@ -66,6 +66,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsBackpressure)
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running metric gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})

--- a/test/integration/istio/metrics_self_monitor_outage_test.go
+++ b/test/integration/istio/metrics_self_monitor_outage_test.go
@@ -91,6 +91,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running metric gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})

--- a/test/integration/istio/traces_self_monitor_backpressure_test.go
+++ b/test/integration/istio/traces_self_monitor_backpressure_test.go
@@ -66,6 +66,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesBackpressure),
 			assert.TracePipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running trace gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.TraceGatewayName)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})

--- a/test/integration/istio/traces_self_monitor_outage_test.go
+++ b/test/integration/istio/traces_self_monitor_outage_test.go
@@ -68,6 +68,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 			assert.TracePipelineHealthy(ctx, k8sClient, pipelineName)
 		})
 
+		It("Should have a running trace gateway deployment", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.TraceGatewayName)
+		})
+
 		It("Should have a running self-monitor", func() {
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.SelfMonitorName)
 		})

--- a/test/testkit/kyma/common_names.go
+++ b/test/testkit/kyma/common_names.go
@@ -57,7 +57,7 @@ var (
 	TraceGatewayClusterRoleBinding = types.NamespacedName{Name: TraceGatewayBaseName, Namespace: SystemNamespaceName}
 	TraceGatewayConfigMap          = types.NamespacedName{Name: TraceGatewayBaseName, Namespace: SystemNamespaceName}
 
-	FluentBitDaemonSet              = types.NamespacedName{Name: FluentBitBaseName, Namespace: SystemNamespaceName}
+	FluentBitDaemonSetName          = types.NamespacedName{Name: FluentBitBaseName, Namespace: SystemNamespaceName}
 	FluentBitServiceAccount         = types.NamespacedName{Name: FluentBitBaseName, Namespace: SystemNamespaceName}
 	FluentBitClusterRole            = types.NamespacedName{Name: FluentBitBaseName, Namespace: SystemNamespaceName}
 	FluentBitClusterRoleBinding     = types.NamespacedName{Name: FluentBitBaseName, Namespace: SystemNamespaceName}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Check if the daemoneset for logs/metrics are up and ready
- Check if the deployment for metrics/traces

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
