### PR TITLE
chore: Collect JUnit reports as part of gingko executions

### DIFF
--- a/.github/template/finalize-test/action.yaml
+++ b/.github/template/finalize-test/action.yaml
@@ -5,11 +5,19 @@ inputs:
   failure:
     description: Are we in failure mode?
     required: true
+  job-name:
+    description: The name of the job
+    required: false
 
 runs:
   using: "composite"
 
   steps:
+    - name: Upload Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.job-name }}-report
+        path: junit-report.xml
 
     - name: Describe manager pod
       shell: bash

--- a/.github/template/finalize-test/action.yaml
+++ b/.github/template/finalize-test/action.yaml
@@ -17,7 +17,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.job-name }}-report
-        path: junit-report.xml
+        path: junit-report*.xml
 
     - name: Describe manager pod
       shell: bash

--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -46,6 +46,13 @@ jobs:
         GARDENER_PROJECT: ${{ secrets.GARDENER_PROJECT }}
         GARDENER_SA_PATH: /tmp/gardener-sa.yaml
         GARDENER_K8S_VERSION: ${{ matrix.k8s_version }}
+  
+    - name: Upload Report
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: ${{ github.job }}-report
+        path: junit-report*.xml
 
     - name: Send slack message on failure
       uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -91,13 +91,14 @@ jobs:
 
       - name: Run tests
         run: |
-          bin/ginkgo run --tags istio --label-filter="integration" test/integration/istio
+          bin/ginkgo run --junit-report=junit-report.xml --tags istio --label-filter="integration" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"
         if: success() || failure()
         with:
           failure: failure()
+          job-name: ${{ github.job }}
 
   e2e-self-mon:
     strategy:
@@ -125,7 +126,7 @@ jobs:
       - name: Run tests without Istio
         if: ${{ matrix.scenario == 'healthy' }}
         run: |
-          bin/ginkgo run --tags e2e --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/e2e
+          bin/ginkgo run --junit-report=junit-report-healthy.xml --tags e2e --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/e2e
 
         # we need Istio for fault injection to simulate backpressure and outages
       - name: Deploy Istio Module
@@ -135,13 +136,14 @@ jobs:
       - name: Run tests with Istio
         if: ${{ matrix.scenario != 'healthy' }}
         run: |
-          bin/ginkgo run --tags istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/integration/istio
+          bin/ginkgo run --junit-report=junit-report-unhealthy.xml --tags istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"
         if: success() || failure()
         with:
           failure: failure()
+          job-name: ${{ github.job }}-${{ matrix.signal-type }}-${{ matrix.scenario }}
 
   PR-Integration-Success:
     needs: [e2e, e2e-dev, e2e-istio, e2e-self-mon]

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -37,7 +37,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        run: bin/ginkgo run --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && !experimental" test/e2e
+        run: bin/ginkgo run -v --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && !experimental" test/e2e
 
       - name: Finalize test
         uses: "./.github/template/finalize-test"
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bin/ginkgo run --tags istio --label-filter="integration" test/integration/istio
+          bin/ginkgo run -v --tags istio --label-filter="integration" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Upload Report
         uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
           name: JUnit-Report-${{ matrix.name }}
           path: junit-report.xml

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -37,7 +37,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        run: bin/ginkgo run -v --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && !experimental" test/e2e
+        run: bin/ginkgo run --junit-report=junit-report.xml --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && !experimental" test/e2e
+
+      - name: Upload Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: JUnit-Report-${{ matrix.name }}
+          path: junit-report.xml
 
       - name: Finalize test
         uses: "./.github/template/finalize-test"
@@ -89,7 +95,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bin/ginkgo run -v --tags istio --label-filter="integration" test/integration/istio
+          bin/ginkgo run --tags istio --label-filter="integration" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -39,18 +39,12 @@ jobs:
       - name: Run tests
         run: bin/ginkgo run --junit-report=junit-report.xml --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && !experimental" test/e2e
 
-      - name: Upload Report
-        uses: actions/upload-artifact@v4
-        if: success() || failure()
-        with:
-          name: JUnit-Report-${{ matrix.name }}
-          path: junit-report.xml
-
       - name: Finalize test
         uses: "./.github/template/finalize-test"
         if: success() || failure()
         with:
           failure: failure()
+          job-name: ${{ github.job }}-${{ matrix.ginkgo-labels }}
 
   e2e-dev:
     strategy:
@@ -71,13 +65,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        run: bin/ginkgo run --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && experimental" test/e2e
+        run: bin/ginkgo run --junit-report=junit-report.xml --tags e2e --label-filter="${{ matrix.ginkgo-labels }} && experimental" test/e2e
 
       - name: Finalize test
         uses: "./.github/template/finalize-test"
         if: success() || failure()
         with:
           failure: failure()
+          job-name: ${{ github.job }}-${{ matrix.ginkgo-labels }}
 
   e2e-istio:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run test on latest tag
         shell: bash
         run: |
-          bin/ginkgo run --tags e2e --flake-attempts=5 --label-filter="operational" -v test/e2e
+          bin/ginkgo run --junit-report=junit-report-latest-version.xml --tags e2e --flake-attempts=5 --label-filter="operational" -v test/e2e
 
       - name: Wait for cleanup of test run
         shell: bash
@@ -72,13 +72,14 @@ jobs:
         shell: bash
         run: |
           make install-tools # delete after the tools via go modules are released
-          bin/ginkgo run --tags e2e --flake-attempts=5 --label-filter="operational" -v test/e2e
+          bin/ginkgo run --junit-report=junit-report-current-version.xml --tags e2e --flake-attempts=5 --label-filter="operational" -v test/e2e
 
       - name: Finalize test
         uses: "./.github/template/finalize-test"
         if: success() || failure()
         with:
           failure: failure()
+          job-name: ${{ github.job }}
 
   PR-Lifecycle-Success:
     needs: manager-upgrade

--- a/hack/gardener-integration-test.sh
+++ b/hack/gardener-integration-test.sh
@@ -17,7 +17,7 @@ function run-tests-with-git-image () {
     make ginkgo
     make deploy
     hack/deploy-istio.sh
-    ${GINKGO} run --junit-report=junit-report --tags istio --label-filter="integration" test/integration/istio
+    ${GINKGO} run --junit-report=junit-report.xml --tags istio --label-filter="integration" test/integration/istio
 }
 
 function main() {

--- a/hack/gardener-integration-test.sh
+++ b/hack/gardener-integration-test.sh
@@ -17,7 +17,7 @@ function run-tests-with-git-image () {
     make ginkgo
     make deploy
     hack/deploy-istio.sh
-    ${GINKGO} run --tags istio --label-filter="integration" test/integration/istio
+    ${GINKGO} run --junit-report=junit-report --tags istio --label-filter="integration" test/integration/istio
 }
 
 function main() {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- to have it trackable what test cases were executed for a commit, junit reports are getting generated and uploaded to the actions
Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
