### PR TITLE
chore: Unblock docs-only PRs

### DIFF
--- a/.github/workflows/skip-on-docu-paths.yml
+++ b/.github/workflows/skip-on-docu-paths.yml
@@ -1,0 +1,30 @@
+#  If a workflow is skipped due to path filtering, branch filtering or a commit message, then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.
+# This workflow implements a workaround that runs if only docu files were changed and makes nesessary coding and e2e required checks succeed.
+# https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Skip On Docu Paths
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "**.md"
+
+PR-Integration-Success:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Success
+      run: |
+        echo "PR Integration is not required"
+
+PR-Lifecycle-Success:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Success
+      run: |
+        echo "PR Lifecycle is not required"
+
+PR-Code-Checks-Success:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Success
+      run: echo "PR Code Checks is not required"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add a workload that runs for docs-only PRs and satisfies the coding and e2e-test required checks

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
