### PR TITLE
chore: Fix gardener integration job

### DIFF
--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: ${{ github.job }}-report
+        name: ${{ github.job }}-${{ matrix.k8s_version }}-report
         path: junit-report*.xml
 
     - name: Send slack message on failure

--- a/hack/deploy-istio.sh
+++ b/hack/deploy-istio.sh
@@ -139,9 +139,9 @@ function check_istiod_deployment_ready() {
 function main() {
   kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-manager.yaml"
   kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-default-cr.yaml"
+  check_istiod_is_ready
   ensure_istio_telemetry
   ensure_peer_authentication default "$ISTIO_NAMESPACE" STRICT
-  check_istiod_is_ready
 
   kubectl apply -f - <<EOF
 apiVersion: v1

--- a/hack/deploy-istio.sh
+++ b/hack/deploy-istio.sh
@@ -29,6 +29,10 @@ spec:
 EOF
 }
 
+function is_istio_telemetry_crd_available() {
+  kubectl get crd telemetries.telemetry.istio.io &> /dev/null
+}
+
 function is_istio_telemetry_apply_successful() {
   kubectl get telemetries.telemetry.istio.io access-config -n "$ISTIO_NAMESPACE" &> /dev/null
 }
@@ -39,7 +43,11 @@ function ensure_istio_telemetry() {
 
   for ((attempts=1; attempts<=MAX_ATTEMPTS; attempts++)); do
     echo "Attempting to create Istio Telemetry (Attempt $attempts)..."
-    apply_istio_telemetry
+
+    if is_istio_telemetry_crd_available; then
+      echo "Istio crd available, trying to apply telemetry..."
+      apply_istio_telemetry
+    fi
 
     if is_istio_telemetry_apply_successful; then
       echo "Istio Telemetry created successfully!"

--- a/hack/deploy-istio.sh
+++ b/hack/deploy-istio.sh
@@ -137,8 +137,8 @@ function check_istiod_deployment_ready() {
 }
 
 function main() {
-  #kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-manager.yaml"
-  #kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-default-cr.yaml"
+  kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-manager.yaml"
+  kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-default-cr.yaml"
   ensure_istio_telemetry
   ensure_peer_authentication default "$ISTIO_NAMESPACE" STRICT
   check_istiod_is_ready

--- a/hack/deploy-istio.sh
+++ b/hack/deploy-istio.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
 source .env
+
+ISTIOD_DEPLOYMENT_NAME="istiod"
+ISTIO_NAMESPACE="istio-system"
 
 readonly ISTIO_VERSION=${ISTIO_VERSION:-$ENV_ISTIO_VERSION}
 
@@ -9,7 +17,7 @@ apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: access-config
-  namespace: istio-system
+  namespace: "$ISTIO_NAMESPACE"
 spec:
   accessLogging:
     - providers:
@@ -22,7 +30,7 @@ EOF
 }
 
 function is_istio_telemetry_apply_successful() {
-  kubectl get telemetries.telemetry.istio.io access-config -n istio-system &> /dev/null
+  kubectl get telemetries.telemetry.istio.io access-config -n "$ISTIO_NAMESPACE" &> /dev/null
 }
 
 function ensure_istio_telemetry() {
@@ -95,14 +103,54 @@ function ensure_peer_authentication() {
   exit 1
 }
 
-function main() {
-  kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-manager.yaml"
-  kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-default-cr.yaml"
-  ensure_istio_telemetry
-  ensure_peer_authentication default istio-system STRICT
+function check_istiod_is_ready() {
+  MAX_ATTEMPTS=10
+  DELAY_SECONDS=30
 
-  kubectl create namespace istio-permissive-mtls
-  kubectl label namespace istio-permissive-mtls istio-injection=enabled --overwrite
+  for ((attempts=1; attempts<=MAX_ATTEMPTS; attempts++)); do
+    echo "Checking istiod deployment status"
+    check=$(check_istiod_deployment_ready)
+    echo "$check"
+
+    if [ "$check" == "ready" ]; then
+      echo "Isiod running successfully!"
+      return
+    else
+      kubectl get pods -n "$ISTIO_NAMESPACE"
+      echo "Istiod is not ready. Checking again in $DELAY_SECONDS seconds..."
+      sleep $DELAY_SECONDS
+    fi
+  done
+
+  echo "Maximum attempts reached. Telemetry manager is not ready!"
+  exit 1
+}
+
+function check_istiod_deployment_ready() {
+    DESIRED=$(kubectl get deployment "$ISTIOD_DEPLOYMENT_NAME" -n "$ISTIO_NAMESPACE" -o jsonpath='{.spec.replicas}')
+    CURRENT=$(kubectl get deployment "$ISTIOD_DEPLOYMENT_NAME"  -n "$ISTIO_NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+    if [ "$CURRENT" == "$DESIRED" ]; then
+        echo "ready"
+    else
+        echo "not ready"
+    fi
+}
+
+function main() {
+  #kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-manager.yaml"
+  #kubectl apply -f "https://github.com/kyma-project/istio/releases/download/$ISTIO_VERSION/istio-default-cr.yaml"
+  ensure_istio_telemetry
+  ensure_peer_authentication default "$ISTIO_NAMESPACE" STRICT
+  check_istiod_is_ready
+
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-permissive-mtls
+  labels:
+    istio-injection: enabled
+EOF
   ensure_peer_authentication default istio-permissive-mtls PERMISSIVE
 }
 

--- a/hack/wait-for-namespaces.sh
+++ b/hack/wait-for-namespaces.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # must be set if you want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
 
 CURRENT_COMMIT=$(git rev-parse --abbrev-ref HEAD)
 TAG_LIST=$(git tag --sort=-creatordate)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fixed naming of junit report for gardener integration job introduced by https://github.com/kyma-project/telemetry-manager/pull/1365
- Enhanced istio check by waiting for istiod to be ready, so that the istio webhooks are working at anytime when creating test resources

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
