### PR TITLE
chore: Revert "chore: Implement pr-prevent-kustomization GHA"

### DIFF
--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Validate title
         uses: amannn/action-semantic-pull-request@47b15d52c5c30e94a17ec87eb8dd51ff5221fed9
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             deps
@@ -70,24 +70,8 @@ jobs:
           requireScope: false
           subjectPattern: ^([A-Z].*[^.]|bump .*)$
 
-  pr-prevent-kustomization:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check-out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Prevent kustomization.yaml changes
-        run: |
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
-          if echo $FILES | grep -q "config/manager/kustomization.yaml"; then
-            echo "kustomization.yaml file changed!"
-            exit 1
-          fi
-
   PR-Github-Checks-Success:
-    needs: [pr-milestone-check, pr-label-check, pr-title-check, pr-prevent-kustomization]
+    needs: [pr-milestone-check, pr-label-check, pr-title-check]
     runs-on: ubuntu-latest
     steps:
       - name: PR Github Checks Success


### PR DESCRIPTION
This reverts commit 8cb7eeb73744d35fc37618e1944d192b1201100f.

## Description

Changes proposed in this pull request (what was done and why):

- Revert [PR](https://github.com/kyma-project/telemetry-manager/pull/1344)
- As during the release we have to update the `kustomization` file so that the image name is in sync with the release branch name.


Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
