### PR TITLE
test: Revert the err check for namespace deletion

### DIFF
--- a/hack/wait-for-namespaces.sh
+++ b/hack/wait-for-namespaces.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-# standard bash error handling
-set -o nounset  # treat unset variables as an error and exit immediately.
-set -o errexit  # exit immediately when a command fails.
-set -E          # must be set if you want the ERR trap
-set -o pipefail # prevents errors in a pipeline from being masked
 
 CURRENT_COMMIT=$(git rev-parse --abbrev-ref HEAD)
 TAG_LIST=$(git tag --sort=-creatordate)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The step is executed at the end of the pipeline execution and then the cluster is deleted. So revert the change

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
