### PR TITLE
chore: Run hack script from the current branch from which PR has been created

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
 
   manager-upgrade:
-    needs: 
+    needs:
     - check-changed-files
     if: ${{ needs.check-changed-files.outputs.check == 'true' }}
     runs-on: ubuntu-latest
@@ -70,12 +70,12 @@ jobs:
         run: |
           bin/ginkgo run --junit-report=junit-report-latest-version.xml --tags e2e --flake-attempts=5 --label-filter="operational" -v test/e2e
 
+      - name: Switch back to current revision
+        uses: actions/checkout@v4
+
       - name: Wait for cleanup of test run
         shell: bash
         run: hack/wait-for-namespaces.sh
-
-      - name: Switch back to current revision
-        uses: actions/checkout@v4
 
       # wait for the build to complete so that the manager image is available
       - name: Wait for the Build Image workflow to complete


### PR DESCRIPTION

## Description

Changes proposed in this pull request (what was done and why):

- hack scripts are not part of the product. So run the script from current branch from which PR has been created

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
