### PR TITLE
docs: Improve  dynatrace config to drop empty attributes and resource attributes

### DIFF
--- a/docs/user/integration/dynatrace/exporter-values.yaml
+++ b/docs/user/integration/dynatrace/exporter-values.yaml
@@ -6,6 +6,7 @@ mode: "deployment"
 
 image:
   repository: "otel/opentelemetry-collector-contrib"
+  tag: "0.107.0"
 
 config:
   exporters:
@@ -42,15 +43,15 @@ config:
       - context: metric
         statements:
           # Remove empty resource attributes
-          - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["k8s.node.name"] = ""
-          - delete_key(resource.attributes, "k8s.namespace.name") where resource.attributes["k8s.namespace.name"] = ""
-          - delete_key(resource.attributes, "k8s.cluster.name") where resource.attributes["k8s.cluster.name"] = ""
-      - context: metric
+          - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["k8s.node.name"] == ""
+          - delete_key(resource.attributes, "k8s.namespace.name") where resource.attributes["k8s.namespace.name"] == ""
+          - delete_key(resource.attributes, "k8s.cluster.name") where resource.attributes["k8s.cluster.name"] == ""
+      - context: resource
         statements:
           # Remove empty attributes
-          - delete_key(attributes, "k8s.node.name") where resource.attributes["k8s.node.name"] = ""
-          - delete_key(attributes, "k8s.namespace.name") where resource.attributes["k8s.namespace.name"] = ""
-          - delete_key(attributes, "k8s.cluster.name") where resource.attributes["k8s.cluster.name"] = ""
+          - delete_key(attributes, "k8s.node.name") where attributes["k8s.node.name"] == ""
+          - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] == ""
+          - delete_key(attributes, "k8s.cluster.name") where attributes["k8s.cluster.name"] == ""
 
     # Selects only one metric for the current collector pod
     filter:

--- a/docs/user/integration/dynatrace/exporter-values.yaml
+++ b/docs/user/integration/dynatrace/exporter-values.yaml
@@ -45,15 +45,8 @@ config:
           # Remove empty resource attributes
           - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["k8s.node.name"] == ""
           - delete_key(resource.attributes, "k8s.namespace.name") where resource.attributes["k8s.namespace.name"] == ""
-          - delete_key(resource.attributes, "k8s.cluster.name") where resource.attributes["k8s.cluster.name"] == ""
-      - context: resource
-        statements:
-          # Remove empty attributes
-          - delete_key(attributes, "k8s.node.name") where attributes["k8s.node.name"] == ""
-          - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"] == ""
-          - delete_key(attributes, "k8s.cluster.name") where attributes["k8s.cluster.name"] == ""
 
-    # Selects only one metric for the current collector pod
+    # Selects only one metric for the current collector Pod
     filter:
       error_mode: ignore
       metrics:

--- a/docs/user/integration/dynatrace/exporter-values.yaml
+++ b/docs/user/integration/dynatrace/exporter-values.yaml
@@ -39,8 +39,20 @@ config:
         statements:
           # convert the <histogram_name>_sum metrics to gauges.
           - convert_sum_to_gauge() where IsMatch(metric.name, ".*_sum")
+      - context: metric
+        statements:
+          # Remove empty resource attributes
+          - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["k8s.node.name"] = ""
+          - delete_key(resource.attributes, "k8s.namespace.name") where resource.attributes["k8s.namespace.name"] = ""
+          - delete_key(resource.attributes, "k8s.cluster.name") where resource.attributes["k8s.cluster.name"] = ""
+      - context: metric
+        statements:
+          # Remove empty attributes
+          - delete_key(attributes, "k8s.node.name") where resource.attributes["k8s.node.name"] = ""
+          - delete_key(attributes, "k8s.namespace.name") where resource.attributes["k8s.namespace.name"] = ""
+          - delete_key(attributes, "k8s.cluster.name") where resource.attributes["k8s.cluster.name"] = ""
 
-    # Selects only one metric for the current collector pod 
+    # Selects only one metric for the current collector pod
     filter:
       error_mode: ignore
       metrics:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- There can be a case where attributes/resource attribute keys might have empty values. In such case these keys are dropped by the dynatrace backend (accepting the metric). There is warning in such a case which can cause confusion.

Unfortunately ottl does not support generic way of finding all the keys with values so currently hardcoding the keys which can have possible issue. 

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1317

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
