### PR TITLE
chore: Fix rerun failing workflow

### DIFF
--- a/hack/await_workflow.sh
+++ b/hack/await_workflow.sh
@@ -9,7 +9,7 @@ set -o pipefail # prevents errors in a pipeline from being masked
 # Variables (you need to set these)
 REPO_OWNER="kyma-project"
 REPO_NAME="telemetry-manager"
-CHECK_NAME="build-image"
+CHECK_NAME="build-image / Build Image"
 
 # retry until check conclusion is success and status is completed
 # timeout after 15 minutes


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Change from waiting for a workflow runs to [check runs](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28), checks are persisted longer and can be queried even after workflow is done.
- This fixes the issue where triggering a failed flaky e2e test long after the "Build Image" workflow finished constantly fails because the `await_workflow` script doesn't find the "Build Image" workflow associated with the commit hash anymore.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
