### PR TITLE
chore: Await build-image instead of Build-Image-Success job

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -56,3 +56,11 @@ jobs:
           payload-file-path: ".github/workflows/slack-message.json"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HUSKIES_NOTIF_WEBHOOK_URL }}
+
+  Build-Image-Success:
+    needs: build-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: List images
+        run: |
+          echo "${{ needs.build-image.outputs.images }}"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -56,11 +56,3 @@ jobs:
           payload-file-path: ".github/workflows/slack-message.json"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_HUSKIES_NOTIF_WEBHOOK_URL }}
-
-  Build-Image-Success:
-    needs: build-image
-    runs-on: ubuntu-latest
-    steps:
-      - name: List images
-        run: |
-          echo "${{ needs.build-image.outputs.images }}"

--- a/hack/await_workflow.sh
+++ b/hack/await_workflow.sh
@@ -9,7 +9,7 @@ set -o pipefail # prevents errors in a pipeline from being masked
 # Variables (you need to set these)
 REPO_OWNER="kyma-project"
 REPO_NAME="telemetry-manager"
-CHECK_NAME="Build-Image-Success"
+CHECK_NAME="build-image"
 
 # retry until check is found and status is completed
 # timeout after 15 minutes


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Revert Build-Image-Success job deletion, since `await_workflow.sh` depends on it

Changes refer to particular issues, PRs or documents:

- Fixes https://github.com/kyma-project/telemetry-manager/pull/1439

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
