### PR TITLE
chore: Cleanup unused crd functions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,14 +53,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/controllers/telemetry/metricpipeline_controller.go
+++ b/controllers/telemetry/metricpipeline_controller.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -155,28 +154,10 @@ func (r *MetricPipelineController) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return b.Watches(
-		&apiextensionsv1.CustomResourceDefinition{},
-		handler.EnqueueRequestsFromMapFunc(r.mapCRDChanges),
-		ctrlbuilder.WithPredicates(predicate.CreateOrDelete()),
-	).Watches(
 		&operatorv1alpha1.Telemetry{},
 		handler.EnqueueRequestsFromMapFunc(r.mapTelemetryChanges),
 		ctrlbuilder.WithPredicates(predicate.CreateOrUpdateOrDelete()),
 	).Complete(r)
-}
-
-func (r *MetricPipelineController) mapCRDChanges(ctx context.Context, object client.Object) []reconcile.Request {
-	_, ok := object.(*apiextensionsv1.CustomResourceDefinition)
-	if !ok {
-		logf.FromContext(ctx).V(1).Error(nil, "Unexpected type: expected CRD")
-		return nil
-	}
-
-	requests, err := r.createRequestsForAllPipelines(ctx)
-	if err != nil {
-		logf.FromContext(ctx).Error(err, "Unable to create reconcile requests")
-	}
-	return requests
 }
 
 func (r *MetricPipelineController) mapTelemetryChanges(ctx context.Context, object client.Object) []reconcile.Request {

--- a/main.go
+++ b/main.go
@@ -197,8 +197,6 @@ func getEnvOrDefault(envVar string, defaultValue string) string {
 //+kubebuilder:rbac:urls=/metrics,verbs=get
 //+kubebuilder:rbac:urls=/metrics/cadvisor,verbs=get
 
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
-
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,namespace=system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove CRDs from MetricPipeline watched resources
- Remove RBAC annotations for CRDs
- Regenerate RBAC manifests

Changes refer to particular issues, PRs or documents:

- With #1452, the istio status check implementation was changed to not search for CRDs anymore, but the metric pipeline still watches for CRDs, which is not useful anymore

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
