### PR TITLE
chore: Fix workflow not sleeping after output results

### DIFF
--- a/hack/await_workflow.sh
+++ b/hack/await_workflow.sh
@@ -80,6 +80,8 @@ until [[ $found == true && $status == "completed" ]]; do
     echo "Job URL: $html_url"
     echo ""
 
+    sleep $QUERY_INTERVAL
+
 done
 
 if [ "$conclusion" != "success" ]; then


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Workflow script was not sleeping after outputting results, which continuously polled the GitHub API without any intervals and caused API rate limite errors

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
