### PR TITLE
chore: Add a check for adjusting Busola in the PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -12,6 +12,7 @@ Changes refer to particular issues, PRs or documents:
 - [ ] The PR is linked to a GitHub issue.
 - [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
 - [ ] If the change is user-facing, the documentation has been adjusted.
+- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
 - [ ] The feature is unit-tested.
 - [ ] The feature is e2e-tested.
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add a check for adjusting Busola in the PR template

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
