### PR TITLE
fix: Adjust Self Monitor storage size

### DIFF
--- a/docs/contributor/arch/014-telemetry-self-monitor-storage.md
+++ b/docs/contributor/arch/014-telemetry-self-monitor-storage.md
@@ -16,7 +16,7 @@ The Telemetry self-monitoring data is stored in the Prometheus TSDB, which is de
 ### Storage and Retention with TSDB
 
 The TSDB storage size-based retention works as follows: It includes data blocks like the write-ahead-log (WAL), the checkpoints, the m-mapped chunks, and the persistent blocks. The TSDB counts all those data blocks to decide performing any retention.
-Even if the size of all those data blocks exceeds the configured retention size, only persistence blocks are deleted because the WAL, checkpoints, and m-mapped chunks are needed for normal operation of TSDB. The WAL segments can grow up to 128MB before compacting, and Prometheus will keep at least 3 WAL files; [so-called 2/3 rules](https://ganeshvernekar.com/blog/prometheus-tsdb-wal-and-checkpoint/#wal-truncation). To ensure that Telemetry self-monitoring doesn't exceed the storage limit, minimum storage volume size should be calculated to be at least 3 * WAL segment size + some more space for the other data types.  
+Even if the size of all those data blocks exceeds the configured retention size, only persistence blocks are deleted because the WAL, checkpoints, and m-mapped chunks are needed for normal operation of TSDB. The WAL segments can grow up to 128MB before compacting, and Prometheus will keep at least 3 WAL files; [so-called 2/3 rules](https://ganeshvernekar.com/blog/prometheus-tsdb-wal-and-checkpoint/#wal-truncation). To ensure that Telemetry self-monitoring doesn't exceed the storage limit, minimum storage volume size should be calculated to be at least 3 * WAL segment size * 2 + some more space for the other data types.  
 
 ### TSDB Storage architecture and retention
 
@@ -26,4 +26,4 @@ For the TSDB WAL and checkpoint architecture, see [Prometheus TSDB: WAL and Chec
 
 ## Consequences
 
-Even though the Telemetry self-monitoring collects very little data for operation (currently, a few MBytes), the storage size must be at least 500MByte for a normal and safe operation.
+Even though the Telemetry self-monitoring collects very little data for operation (currently, a few MBytes), the storage size must be at least 1000MByte for a normal and safe operation.

--- a/internal/resources/selfmonitor/resources.go
+++ b/internal/resources/selfmonitor/resources.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	storageVolumeSize = resource.MustParse("500Mi")
+	storageVolumeSize = resource.MustParse("1000Mi")
 	cpuRequest        = resource.MustParse("0.1")
 	memoryRequest     = resource.MustParse("50Mi")
 	cpuLimit          = resource.MustParse("0.2")


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- In some clusters, we observed Self Monitor local storage runs out of space, Self Monitor local storage size doubled to cover storage requirements in such cases.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
