### PR TITLE
chore: Bump directory-size-exporter

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ var (
 )
 
 const (
-	defaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240605-7743c77e"
+	defaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241001-21f80ba0"
 	defaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.1.8"
 	defaultOtelImage              = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.109.0-main"
 	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.2-cc4f64c"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -3,7 +3,7 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.109.0-main
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.1.8
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20240605-7743c77e
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241001-21f80ba0
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.2-cc4f64c
 whitesource:
   language: golang-mod


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump the image of the directory-size-exporter to latest version

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
