### PR TITLE
fix: Endpoint validation with path and port scenario

### DIFF
--- a/internal/validators/endpoint/endpoint_validator.go
+++ b/internal/validators/endpoint/endpoint_validator.go
@@ -66,7 +66,8 @@ func (v *Validator) Validate(ctx context.Context, endpoint *telemetryv1alpha1.Va
 		return nil
 	}
 
-	if err := validatePort(u.Host, protocol == OtlpProtocolHTTP); err != nil {
+	var hostport = u.Host + u.Path
+	if err := validatePort(hostport, protocol == OtlpProtocolHTTP); err != nil {
 		return err
 	}
 
@@ -116,8 +117,8 @@ func parseEndpoint(endpoint string) (*url.URL, error) {
 	return u, nil
 }
 
-func validatePort(endpoint string, allowMissing bool) error {
-	_, port, err := net.SplitHostPort(endpoint)
+func validatePort(hostport string, allowMissing bool) error {
+	_, port, err := net.SplitHostPort(hostport)
 	if err != nil && strings.Contains(err.Error(), "missing port in address") {
 		if !allowMissing {
 			return &EndpointInvalidError{Err: ErrPortMissing}

--- a/internal/validators/endpoint/endpoint_validator_test.go
+++ b/internal/validators/endpoint/endpoint_validator_test.go
@@ -37,8 +37,8 @@ var testScenarios = []struct {
 	errMsgFluentdHTTP string
 }{
 	{
-		name:     "with scheme: valid endpoint with path",
-		endpoint: "https://this.is.an.example.sap/e/9c631924-e2a7-1f27-00af-10d26bd1a03a:4317",
+		name:     "with scheme: valid endpoint with path and port",
+		endpoint: "https://foo.bar/foo/bar:4317",
 
 		errOtlpGRPC:    nil,
 		errMsgOtlpGRPC: "",

--- a/internal/validators/endpoint/endpoint_validator_test.go
+++ b/internal/validators/endpoint/endpoint_validator_test.go
@@ -37,6 +37,19 @@ var testScenarios = []struct {
 	errMsgFluentdHTTP string
 }{
 	{
+		name:     "with scheme: valid endpoint with path",
+		endpoint: "https://this.is.an.example.sap/e/9c631924-e2a7-1f27-00af-10d26bd1a03a:4317",
+
+		errOtlpGRPC:    nil,
+		errMsgOtlpGRPC: "",
+
+		errOtlpHTTP:    nil,
+		errMsgOtlpHTTP: "",
+
+		errFluentdHTTP:    nil,
+		errMsgFluentdHTTP: "",
+	},
+	{
 		name:     "empty endpoint value",
 		endpoint: "",
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix an untreated scenario in the endpoint validation logic (OTLP GRPC endpoint with path and port)

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
