### PR TITLE
feat: Enable all memory metrics for nodes

### DIFF
--- a/docs/user/04-metrics.md
+++ b/docs/user/04-metrics.md
@@ -463,6 +463,8 @@ If Node metrics are enabled, the following metrics are collected:
   - `k8s.node.memory.usage`
   - `k8s.node.network.errors`
   - `k8s.node.network.io`
+  - `k8s.node.memory.rss`
+  - `k8s.node.memory.working_set`
 
 
 ### 6. Activate Istio Metrics

--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -45,8 +45,6 @@ type KubeletStatsMetricsConfig struct {
 	K8sNodeCPUTime               MetricConfig `yaml:"k8s.node.cpu.time"`
 	K8sNodeMemoryMajorPageFaults MetricConfig `yaml:"k8s.node.memory.major_page_faults"`
 	K8sNodeMemoryPageFaults      MetricConfig `yaml:"k8s.node.memory.page_faults"`
-	K8sNodeMemoryRSS             MetricConfig `yaml:"k8s.node.memory.rss"`
-	K8sNodeMemoryWorkingSet      MetricConfig `yaml:"k8s.node.memory.working_set"`
 }
 
 type MetricGroupType string

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -49,8 +49,6 @@ func makeKubeletStatsConfig() *KubeletStatsReceiver {
 			K8sNodeCPUTime:               MetricConfig{Enabled: false},
 			K8sNodeMemoryMajorPageFaults: MetricConfig{Enabled: false},
 			K8sNodeMemoryPageFaults:      MetricConfig{Enabled: false},
-			K8sNodeMemoryRSS:             MetricConfig{Enabled: false},
-			K8sNodeMemoryWorkingSet:      MetricConfig{Enabled: false},
 		},
 	}
 }

--- a/internal/otelcollector/config/metric/agent/receivers_test.go
+++ b/internal/otelcollector/config/metric/agent/receivers_test.go
@@ -52,8 +52,6 @@ func TestReceivers(t *testing.T) {
 				K8sNodeCPUTime:               MetricConfig{Enabled: false},
 				K8sNodeMemoryMajorPageFaults: MetricConfig{Enabled: false},
 				K8sNodeMemoryPageFaults:      MetricConfig{Enabled: false},
-				K8sNodeMemoryRSS:             MetricConfig{Enabled: false},
-				K8sNodeMemoryWorkingSet:      MetricConfig{Enabled: false},
 			},
 		}
 		require.Equal(t, expectedKubeletStatsReceiver, *collectorConfig.Receivers.KubeletStats)

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -76,10 +76,6 @@ receivers:
                 enabled: false
             k8s.node.memory.page_faults:
                 enabled: false
-            k8s.node.memory.rss:
-                enabled: false
-            k8s.node.memory.working_set:
-                enabled: false
     prometheus/app-pods:
         config:
             scrape_configs:

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -65,10 +65,6 @@ receivers:
                 enabled: false
             k8s.node.memory.page_faults:
                 enabled: false
-            k8s.node.memory.rss:
-                enabled: false
-            k8s.node.memory.working_set:
-                enabled: false
     prometheus/app-pods:
         config:
             scrape_configs:

--- a/test/testkit/metrics/runtime/node.go
+++ b/test/testkit/metrics/runtime/node.go
@@ -12,6 +12,8 @@ var (
 		"k8s.node.memory.usage",
 		"k8s.node.network.errors",
 		"k8s.node.network.io",
+		"k8s.node.memory.rss",
+		"k8s.node.memory.working_set",
 	}
 
 	NodeMetricsResourceAttributes = []string{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- enable working set and rss memory for the nodes

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [x] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
