### PR TITLE
docs: Updated deprecated otel docs link

### DIFF
--- a/docs/contributor/arch/003-integrate-prometheus-with-telemetry-manager-using-alerting.md
+++ b/docs/contributor/arch/003-integrate-prometheus-with-telemetry-manager-using-alerting.md
@@ -25,7 +25,7 @@ Our current reconciliation strategy triggers either when a change occurs or ever
 
 #### Flakiness Mitigation
 
-To ensure reliability and avoid false alerts, it's crucial to introduce a delay before signaling a problem. As suggested in [OTel Collector monitoring best practices](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/monitoring.md):
+To ensure reliability and avoid false alerts, it's crucial to introduce a delay before signaling a problem. As suggested in [OTel Collector monitoring best practices](https://opentelemetry.io/docs/collector/internal-telemetry/#use-internal-telemetry-to-monitor-the-collector):
 
 > Use the rate of otelcol_processor_dropped_spans > 0 and otelcol_processor_dropped_metric_points > 0 to detect data loss. Depending on requirements, set up a minimal time window before alerting to avoid notifications for minor losses that fall within acceptable levels of reliability.
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Change deprecated link for otel-collector in Alerting ADR

Changes refer to particular issues, PRs or documents:

- https://github.com/open-telemetry/opentelemetry-collector/pull/11483

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
