### PR TITLE
fix: Get rid of spammy RBAC log

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func init() {
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 // +kubebuilder:rbac:urls=/metrics/cadvisor,verbs=get
 
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;patch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;patch
 
 // +kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,namespace=system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Operator container was printing the following log message:
```
{"level":"ERROR","timestamp":"2024-10-22T15:15:54Z","caller":"cache/reflector.go:158","message":"Unhandled Error","logger":"UnhandledError","error":"pkg/mod/k8s.io/client-go@v0.31.1/tools/
cache/reflector.go:243: Failed to watch *v1.CustomResourceDefinition: unknown (get customresourcedefinitions.apiextensions.k8s.io)"
```
Even though the `watch` permissions is not required, the operator is already granted `get` and `list` permissions, so adding `watch` to satisfy controller-runtime is fine.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
