### PR TITLE
chore: Cherry pick RBAC errors and bump version to 1.26.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ### Default Environment Variables
 ## General
 ENV_K3S_K8S_VERSION=1.30.5 # refers to the version of kubernetes used in K3s
-ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.26.0 # Image URL to use all building/pushing image targets
+ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.26.1 # Image URL to use all building/pushing image targets
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.30

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: 1.26.0
+  newTag: 1.26.1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func init() {
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 // +kubebuilder:rbac:urls=/metrics/cadvisor,verbs=get
 
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;patch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;patch
 
 // +kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,namespace=system,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ var (
 	setupLog           = ctrl.Log.WithName("setup")
 	telemetryNamespace string
 	//TODO: replace with build version based on git revision
-	version = "1.26.0"
+	version = "1.26.1"
 
 	// Operator flags
 	certDir                   string

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: telemetry
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.26.0
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.26.1
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.111.0-1.26.0
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.1.9
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241001-21f80ba0


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Cherry-picked: [fix: Get rid of spammy RBAC log (#1548)](https://github.com/kyma-project/telemetry-manager/commit/1afb87b4205d50d660f47b3b03b0d921c9a4e156)
- Bump images for the 1.26.1 version

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
