### PR TITLE
chore: Bump directory-size-exporter image

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ var (
 )
 
 const (
-	defaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241001-21f80ba0"
+	defaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241024-8bc3f6a8"
 	defaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.1.9"
 	defaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.111.0-main"
 	defaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.2-cc4f64c"
@@ -395,7 +395,7 @@ func setupLogPipelineController(mgr manager.Manager, reconcileTriggerChan <-chan
 	}
 
 	setupLog.Info("Setting up logparser controller")
-
+	ZZ
 	logParserController := telemetrycontrollers.NewLogParserController(
 		mgr.GetClient(),
 		telemetrycontrollers.LogParserControllerConfig{

--- a/main.go
+++ b/main.go
@@ -395,7 +395,7 @@ func setupLogPipelineController(mgr manager.Manager, reconcileTriggerChan <-chan
 	}
 
 	setupLog.Info("Setting up logparser controller")
-	ZZ
+
 	logParserController := telemetrycontrollers.NewLogParserController(
 		mgr.GetClient(),
 		telemetrycontrollers.LogParserControllerConfig{

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -3,7 +3,7 @@ protecode:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.111.0-main
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.1.9
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241001-21f80ba0
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241024-8bc3f6a8
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:2.53.2-cc4f64c
 whitesource:
   language: golang-mod


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump directory-size-exporter image to fix the rolling upgrade problem

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1545

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
