### PR TITLE
chore: Extract operator ports into constants

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,8 +99,12 @@ const (
 	metricOTLPServiceName     = "telemetry-otlp-metrics"
 	selfMonitorName           = "telemetry-self-monitor"
 	traceOTLPServiceName      = "telemetry-otlp-traces"
-	webhookServerPort         = 9443
 	webhookServiceName        = "telemetry-manager-webhook"
+
+	healthProbePort = 8081
+	metricsPort     = 8080
+	pprofPort       = 6060
+	webhookPort     = 9443
 )
 
 //nolint:gochecknoinits // Runtime's scheme addition is required.
@@ -238,14 +242,14 @@ func run() error {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
-		Metrics:                 metricsserver.Options{BindAddress: ":8080"},
-		HealthProbeBindAddress:  ":8081",
-		PprofBindAddress:        ":6060",
+		Metrics:                 metricsserver.Options{BindAddress: fmt.Sprintf(":%d", metricsPort)},
+		HealthProbeBindAddress:  fmt.Sprintf(":%d", healthProbePort),
+		PprofBindAddress:        fmt.Sprintf(":%d", pprofPort),
 		LeaderElection:          true,
 		LeaderElectionNamespace: telemetryNamespace,
 		LeaderElectionID:        "cdd7ef0b.kyma-project.io",
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port:    webhookServerPort,
+			Port:    webhookPort,
 			CertDir: certDir,
 		}),
 		Cache: cache.Options{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Extract operator ports into constants to improve code glanceability

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
