### PR TITLE
docs: Improve runtime resources metrics example

### DIFF
--- a/docs/user/04-metrics.md
+++ b/docs/user/04-metrics.md
@@ -396,7 +396,7 @@ spec:
 By default, container and Pod metrics are collected.
 To enable or disable the collection of metrics for a specific resource, use the `resources` section in the `runtime` input.
 
-The following example collects only the Pod metrics:
+The following example collects only Deployment, DaemonSet, StatefulSet and Job metrics:
 
   ```yaml
   apiVersion: telemetry.kyma-project.io/v1alpha1
@@ -409,7 +409,7 @@ The following example collects only the Pod metrics:
         enabled: true
         resources:
           pod:
-            enabled: true
+            enabled: false
           container:
             enabled: false
           node:
@@ -417,13 +417,13 @@ The following example collects only the Pod metrics:
           volume:
             enabled: false
           daemonset:
-            enabled: false
+            enabled: true
           deployment:
-            enabled: false
+            enabled: true
           statefulset:
-            enabled: false
+            enabled: true
           job:
-            enabled: false
+            enabled: true
     output:
       otlp:
         endpoint:

--- a/docs/user/04-metrics.md
+++ b/docs/user/04-metrics.md
@@ -396,7 +396,7 @@ spec:
 By default, container and Pod metrics are collected.
 To enable or disable the collection of metrics for a specific resource, use the `resources` section in the `runtime` input.
 
-The following example collects only Deployment, DaemonSet, StatefulSet and Job metrics:
+The following example collects only DaemonSet, Deployment, StatefulSet and Job metrics:
 
   ```yaml
   apiVersion: telemetry.kyma-project.io/v1alpha1


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Improve the example for runtime resources metrics, so that some metrics which are not enabled by default are explicitly enabled in the example

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
