### PR TITLE
chore: Revert telemetry manager log test

### DIFF
--- a/test/e2e/telemetry_logs_analysis_test.go
+++ b/test/e2e/telemetry_logs_analysis_test.go
@@ -33,7 +33,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 		otelCollectorLogBackendName = "otel-collector-log-backend"
 		fluentBitLogBackendName     = "fluent-bit-log-backend"
 		selfMonitorLogBackendName   = "self-monitor-log-backend"
-		managerLogBackendName       = "manager-log-backend"
 	)
 
 	var (
@@ -43,7 +42,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 		otelCollectorLogBackendURL string
 		fluentBitLogBackendURL     string
 		selfMonitorLogBackendURL   string
-		managerLogBackendURL       string
 		namespace                  = suite.ID()
 		gomegaMaxLength            = format.MaxLength
 		logLevelsRegexp            = "ERROR|error|WARNING|warning|WARN|warn"
@@ -148,8 +146,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 			k8sObjects = append(k8sObjects, objs...)
 			objs, selfMonitorLogBackendURL = makeResourcesToCollectLogs(selfMonitorLogBackendName, "self-monitor")
 			k8sObjects = append(k8sObjects, objs...)
-			objs, managerLogBackendURL = makeResourcesToCollectLogs(managerLogBackendName, "manager")
-			k8sObjects = append(k8sObjects, objs...)
 
 			DeferCleanup(func() {
 				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
@@ -170,7 +166,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: otelCollectorLogBackendName})
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: fluentBitLogBackendName})
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: selfMonitorLogBackendName})
-			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: managerLogBackendName})
 		})
 
 		It("Should have running agents", func() {
@@ -186,7 +181,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 			assert.LogPipelineHealthy(ctx, k8sClient, otelCollectorLogBackendName)
 			assert.LogPipelineHealthy(ctx, k8sClient, fluentBitLogBackendName)
 			assert.LogPipelineHealthy(ctx, k8sClient, selfMonitorLogBackendName)
-			assert.LogPipelineHealthy(ctx, k8sClient, managerLogBackendName)
 		})
 
 		It("Should push metrics successfully", func() {
@@ -211,10 +205,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 
 		It("Should collect self-monitor component logs successfully", func() {
 			assert.LogsDelivered(proxyClient, "telemetry-", selfMonitorLogBackendURL)
-		})
-
-		It("Should collect manager component logs successfully", func() {
-			assert.LogsDelivered(proxyClient, "telemetry-", managerLogBackendURL)
 		})
 
 		It("Should not have any error/warn logs in the otel collector component containers", func() {
@@ -261,31 +251,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetryLogAnalysis), Ordered, fu
 					HaveFlatLogs(Not(ContainElement(SatisfyAll(
 						HavePodName(ContainSubstring("telemetry-")),
 						HaveLevel(MatchRegexp(logLevelsRegexp)),
-					)))),
-				))
-			}, consistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
-		})
-
-		It("Should not have any error/warn logs in the manager containers", func() {
-			Consistently(func(g Gomega) {
-				resp, err := proxyClient.Get(managerLogBackendURL)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
-				g.Expect(resp).To(HaveHTTPBody(
-					HaveFlatLogs(Not(ContainElement(SatisfyAll(
-						HavePodName(ContainSubstring("telemetry-")),
-						HaveLevel(MatchRegexp(logLevelsRegexp)),
-						HaveLogBody(Not( // whitelist possible (flaky/expected) errors
-							Or(
-								ContainSubstring("failed to get lock"),
-								ContainSubstring("DaemonSet is not yet created"),
-								ContainSubstring("Deployment is not yet created"),
-								ContainSubstring("failed to query Prometheus alerts"),
-								ContainSubstring("failed to update status: "),
-								ContainSubstring("Failed to probe "),
-								ContainSubstring("Reconciler error"),
-							),
-						)),
 					)))),
 				))
 			}, consistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Revert the log analysis test for the manager container itself
- We agreed that this test is not meaningful and will lead to a huge flakiness

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
