### PR TITLE
fix: Empty array in LogPipeline CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ manifests: $(CONTROLLER_GEN) $(YQ) $(YAMLFMT) ## Generate WebhookConfiguration, 
 	$(CONTROLLER_GEN) crd paths="./apis/telemetry/v1alpha1" output:crd:artifacts:config=config/crd/bases
 	$(YQ) eval 'del(.. | select(has("otlp")).otlp)' -i ./config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
 	$(YQ) eval 'del(.. | select(has("x-kubernetes-validations"))."x-kubernetes-validations"[] | select(.rule|contains("otlp")) )' -i ./config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
-
+	## Remove empty arrays from logpipeline crd that can be caused by previous yq manipulations
+	$(YQ) eval 'del(.. | select(tag == "!!seq" and length == 0))' -i ./config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
 
 .PHONY: manifests-dev
 manifests-dev: $(CONTROLLER_GEN) ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition for v1alpha1 and v1beta1.

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -371,7 +371,6 @@ spec:
                     type: object
                   type: array
               type: object
-              x-kubernetes-validations: []
             status:
               description: Shows the observed state of the LogPipeline
               properties:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add a `yq` command to trim empty arrays in the LogPipeline CRD

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
