### PR TITLE
chore: Switch integration testing to k8s 1.31

### DIFF
--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
         fail-fast: false # if one version is not working, continue tests on other versions
         matrix:
-          k8s_version: [1.29, 1.30]
+          k8s_version: [1.30, 1.31]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- K8s 1.31 is available in a supported mode on gardener -> start testing on it
- K8s 1.29 is not used anymore -> stop testing on it

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
