### PR TITLE
chore: Fix build-image after introducing merge queue

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,7 +40,6 @@ jobs:
           if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
             echo 'TAGS=${{ github.ref_name }}' >> "$GITHUB_OUTPUT"
           elif [[ $GITHUB_EVENT_NAME == 'merge_group' ]]; then
-            {
               echo 'TAGS=${{ github.event.merge_group.head_sha }}' >> "$GITHUB_OUTPUT"
           else
             {

--- a/hack/await_image.sh
+++ b/hack/await_image.sh
@@ -20,7 +20,7 @@ START_TIME=$SECONDS
 
 until $(skopeo list-tags ${PROTOCOL}${IMAGE_REPO} | jq '.Tags|any(. == env.TRIGGER)'); do
   if (( SECONDS - START_TIME > TIMEOUT )); then
-    echo "Timeout reached: ${IMAGE_REPO}:${COMMIT_SHA} not found within $(( TIMEOUT/60 )) minutes"
+    echo "Timeout reached: ${IMAGE_REPO}:${TRIGGER} not found within $(( TIMEOUT/60 )) minutes"
     exit 1
   fi
   echo "Waiting for binary image: ${IMAGE_REPO}:${TRIGGER}"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix bad shell script in build-image create tag step
- Fix outdated variable name COMMIT_SHA in await_image.sh script

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
