### PR TITLE
chore: Prepare images for 1.30.0 release

### DIFF
--- a/.env
+++ b/.env
@@ -17,6 +17,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f"
 DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.2"
-DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.115.0-main"
+DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.115.0-1.30.0"
 DEFAULT_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.0.1-857b814"
 DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.115.0"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: main
+  newTag: 1.30.0

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -6,6 +6,6 @@ package images
 const (
 	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f"
 	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.2"
-	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.115.0-main"
+	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.115.0-1.30.0"
 	DefaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.0.1-857b814"
 )

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ var (
 	setupLog           = ctrl.Log.WithName("setup")
 	telemetryNamespace string
 	// TODO: replace with build version based on git revision
-	version = "main"
+	version = "1.30.0"
 
 	// Operator flags
 	certDir                   string

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,9 +1,9 @@
 module-name: telemetry
 protocode:
-- europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+- europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.30.0
 - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f
 - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.2
-- europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.115.0-main
+- europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.115.0-1.30.0
 - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.0.1-857b814
 whitesource:
   language: golang-mod

--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,23 +68,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 		Consistently(func(g Gomega) {
 			g.Expect(k8sClient.Get(ctx, configMapNamespacedName, &configMap)).To(Succeed())
 			g.Expect(configMap.ObjectMeta.Labels[labelKey]).To(BeZero())
-		}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
-	}
-
-	assertTelemetryReconciliationDisabled := func(ctx context.Context, k8sClient client.Client, webhookName string) {
-		key := types.NamespacedName{
-			Name: webhookName,
-		}
-		var validatingWebhookConfiguration admissionregistrationv1.ValidatingWebhookConfiguration
-		Expect(k8sClient.Get(ctx, key, &validatingWebhookConfiguration)).To(Succeed())
-
-		validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle = []byte{}
-		Expect(k8sClient.Update(ctx, &validatingWebhookConfiguration)).To(Succeed())
-
-		// The deleted CA bundle should not be restored, since the reconciliation is disabled by the overrides configmap
-		Consistently(func(g Gomega) {
-			g.Expect(k8sClient.Get(ctx, key, &validatingWebhookConfiguration)).To(Succeed())
-			g.Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(BeEmpty())
 		}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 	}
 
@@ -188,10 +170,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 
 		It("Should disable the reconciliation of the tracepipeline", func() {
 			assertPipelineReconciliationDisabled(ctx, k8sClient, kitkyma.TraceGatewayConfigMap, appNameLabelKey)
-		})
-
-		It("Should disable the reconciliation of the telemetry CR", func() {
-			assertTelemetryReconciliationDisabled(ctx, k8sClient, kitkyma.ValidatingWebhookName)
 		})
 	})
 })


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Prepare images for 1.30.0 release
- Cherry-pick https://github.com/kyma-project/telemetry-manager/pull/1690 to address the flaky test that blocks the release. Since "Overrides" is an internal, non-user-facing feature, this change is acceptable.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
