### PR TITLE
chore: Fix wrong sec-scanner-config.yaml file path

### DIFF
--- a/internal/tools/populateimages/main.go
+++ b/internal/tools/populateimages/main.go
@@ -165,7 +165,7 @@ package testkit
 }
 
 func generateSecScanConfig(data map[string]string) error {
-	file, err := os.Create("../../sec-scanners-config.yaml")
+	file, err := os.Create("./sec-scanners-config.yaml")
 	if err != nil {
 		return fmt.Errorf("error opening/creating file: %w", err)
 	}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix the wrong path of `sec-scanner-config.yaml`

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
