### PR TITLE
chore: Prevent references to images from main on release-branch

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,0 +1,21 @@
+name: Check Release Branch
+
+on:
+  pull_request:
+    branches:
+      - "release-*"
+jobs:
+  validate-envs:
+    name: Validate .env file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # check that the .env file does not contain references to the main branch
+      - name: Check .env file
+        run: |
+          if grep -q "main" .env; then
+            echo "The .env file contains references to the main branch"
+            exit 1
+          fi


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- check that .env file does not contain image references to the main branch

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
