### PR TITLE
chore: Revert running branch integration only on merge group

### DIFF
--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -1,12 +1,10 @@
 name: Branch Integration
 
 on:
-  merge_group:
-    branches:
-      - "release-*"
   push:
     branches:
       - "main"
+      - "release-*"
     paths-ignore:
       - 'docs/**'
       - 'dependencies/**'


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Merge queue isn't available for rulesets with wildcard patterns, and our release branch rulesets uses the `release-*` name pattern
- Revert the change that branch-integration should run only in merge_group events for release branch

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
