### PR TITLE
test: Fix flaky tests by really waiting for manager readiness

### DIFF
--- a/.github/template/prepare-test/action.yaml
+++ b/.github/template/prepare-test/action.yaml
@@ -43,7 +43,7 @@ runs:
 
     - name: Wait for manager readiness
       shell: bash
-      run: kubectl -n kyma-system rollout status deployment telemetry-manager --timeout=90s
+      run: kubectl wait pods -l app.kubernetes.io/instance=telemetry,app.kubernetes.io/name=manager --for=condition=Ready=true --timeout=90s
 
     - name: Print cluster info
       shell: bash

--- a/.github/template/prepare-test/action.yaml
+++ b/.github/template/prepare-test/action.yaml
@@ -47,7 +47,7 @@ runs:
 
     - name: Wait for manager readiness
       shell: bash
-      run: kubectl wait pods -l app.kubernetes.io/instance=telemetry,app.kubernetes.io/name=manager --for=condition=Ready=true --timeout=90s
+      run: kubectl -n kyma-system wait pods -l app.kubernetes.io/instance=telemetry,app.kubernetes.io/name=manager --for=condition=Ready=true --timeout=90s
 
     - name: Print cluster info
       shell: bash

--- a/.github/template/prepare-test/action.yaml
+++ b/.github/template/prepare-test/action.yaml
@@ -41,6 +41,10 @@ runs:
       shell: bash
       run: make --debug deploy-experimental
 
+    - name: Wait for manager deployment rollout
+      shell: bash
+      run: kubectl -n kyma-system rollout status deployment telemetry-manager --timeout=90s
+
     - name: Wait for manager readiness
       shell: bash
       run: kubectl wait pods -l app.kubernetes.io/instance=telemetry,app.kubernetes.io/name=manager --for=condition=Ready=true --timeout=90s


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Wait for readiness probe to succeed which ensures that the webhook certs are generated and the webhooks are configured

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
