### PR TITLE
chore: Revert removed Telemetry override e2e test

### DIFF
--- a/test/e2e/overrides_test.go
+++ b/test/e2e/overrides_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,6 +69,23 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 		Consistently(func(g Gomega) {
 			g.Expect(k8sClient.Get(ctx, configMapNamespacedName, &configMap)).To(Succeed())
 			g.Expect(configMap.ObjectMeta.Labels[labelKey]).To(BeZero())
+		}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
+	}
+
+	assertTelemetryReconciliationDisabled := func(ctx context.Context, k8sClient client.Client, webhookName string) {
+		key := types.NamespacedName{
+			Name: webhookName,
+		}
+		var validatingWebhookConfiguration admissionregistrationv1.ValidatingWebhookConfiguration
+		Expect(k8sClient.Get(ctx, key, &validatingWebhookConfiguration)).To(Succeed())
+
+		validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle = []byte{}
+		Expect(k8sClient.Update(ctx, &validatingWebhookConfiguration)).To(Succeed())
+
+		// The deleted CA bundle should not be restored, since the reconciliation is disabled by the overrides configmap
+		Consistently(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, key, &validatingWebhookConfiguration)).To(Succeed())
+			g.Expect(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle).To(BeEmpty())
 		}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 	}
 
@@ -170,6 +188,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 
 		It("Should disable the reconciliation of the tracepipeline", func() {
 			assertPipelineReconciliationDisabled(ctx, k8sClient, kitkyma.TraceGatewayConfigMap, appNameLabelKey)
+		})
+
+		It("Should disable the reconciliation of the telemetry CR", func() {
+			assertTelemetryReconciliationDisabled(ctx, k8sClient, kitkyma.ValidatingWebhookName)
 		})
 	})
 })


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Revert removed Telemetry e2e test after fixed flakiness with https://github.com/kyma-project/telemetry-manager/pull/1702

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
