### PR TITLE
docs: Fixed prometheus guide and aded links to the overview pages

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -72,26 +72,28 @@ For more information, see [Metrics](04-metrics.md) and [Telemetry Gateways](gate
 
 ## Integration Guides
 
-To learn about integration with SAP Cloud Logging, read [SAP Cloud Logging](integration/sap-cloud-logging/README.md). <!--- replace with Help Portal link once published? --->
+To learn about integration with SAP Cloud Logging, read [SAP Cloud Logging](./integration/sap-cloud-logging/README.md). <!--- replace with Help Portal link once published? --->
 
 For integration with other backends, such as Dynatrace, see:
-- [Dynatrace](integration/dynatrace/README.md)
-- [Loki](integration/loki/README.md)
-- [Jaeger](integration/jaeger/README.md)
-- [Amazon CloudWatch and AWS X-Ray](integration/aws-cloudwatch/README.md)
+- [Dynatrace](./integration/dynatrace/README.md)
+- [Prometheus](./integration/prometheus/README.md)
+- [Loki](./integration/loki/README.md)
+- [Jaeger](./integration/jaeger/README.md)
+- [Amazon CloudWatch and AWS X-Ray](./integration/aws-cloudwatch/README.md)
 
-To learn how to collect data from applications based on the OpenTelemetry Demo App, see:
+To learn how to collect data from applications based on the OpenTelemetry SDK, see:
 
-- [OpenTelemetry Demo App](integration/opentelemetry-demo/README.md)
+- [OpenTelemetry Demo App](./integration/opentelemetry-demo/README.md)
+- [Sample App](./integration/sample-app/) 
 
 ## API / Custom Resource Definitions
 
 The API of the Telemetry module is based on Kubernetes Custom Resource Definitions (CRD), which extend the Kubernetes API with custom additions. To inspect the specification of the Telemetry module API, see:
 
-- [Telemetry CRD](resources/01-telemetry.md)
-- [LogPipeline CRD](resources/02-logpipeline.md)
-- [TracePipeline CRD](resources/04-tracepipeline.md)
-- [MetricPipeline CRD](resources/05-metricpipeline.md)
+- [Telemetry CRD](./resources/01-telemetry.md)
+- [LogPipeline CRD](./resources/02-logpipeline.md)
+- [TracePipeline CRD](./resources/04-tracepipeline.md)
+- [MetricPipeline CRD](./resources/05-metricpipeline.md)
 
 ## Resource Usage
 

--- a/docs/user/integration/README.md
+++ b/docs/user/integration/README.md
@@ -2,6 +2,6 @@
 
 Kyma's Telemetry module makes it easy for you to integrate the telemetry services you need. The following guides support you step by step:
 
-If you'd like instructions how to integrate with several backends, check out the guides for [SAP Cloud Logging](./sap-cloud-logging/README.md), a [custom Loki stack](./loki/README.md), a [custom Jaeger stack](./jaeger/README.md), and [Amazon CloudWatch and AWS X-Ray](./aws-cloudwatch/README.md)
+If you'd like instructions how to integrate with several backends, check out the guides for [SAP Cloud Logging](./sap-cloud-logging/README.md), a [custom Prometheus stack](./prometheus/README.md), a [custom Loki stack](./loki/README.md), a [custom Jaeger stack](./jaeger/README.md), and [Amazon CloudWatch and AWS X-Ray](./aws-cloudwatch/README.md)
 
 Learn about OpenTelemetry and the OpenTelemetry SDK in a near real-world environment using the [OpenTelemetry Demo App](./opentelemetry-demo/README.md), or with a simple scenario using a [sample app](./sample-app/) in the Go language.

--- a/docs/user/integration/README.md
+++ b/docs/user/integration/README.md
@@ -4,4 +4,4 @@ Kyma's Telemetry module makes it easy for you to integrate the telemetry service
 
 If you'd like instructions how to integrate with several backends, check out the guides for [SAP Cloud Logging](./sap-cloud-logging/README.md), a [custom Loki stack](./loki/README.md), a [custom Jaeger stack](./jaeger/README.md), and [Amazon CloudWatch and AWS X-Ray](./aws-cloudwatch/README.md)
 
-Learn about OpenTelemetry in a near real-world environment and see it in action with the [OpenTelemetry Demo App](./opentelemetry-demo/README.md).
+Learn about OpenTelemetry and the OpenTelemetry SDK in a near real-world environment using the [OpenTelemetry Demo App](./opentelemetry-demo/README.md), or with a simple scenario using a [sample app](./sample-app/) in the Go language.

--- a/docs/user/integration/prometheus/values.yaml
+++ b/docs/user/integration/prometheus/values.yaml
@@ -54,7 +54,6 @@ prometheus:
   prometheusSpec:
 ####### This block is required to enable OTLP ingestion
     additionalConfig:
-      enableOTLPReceiver: true
       otlp:
         promoteResourceAttributes:
         - service.instance.id


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Removed unsupported flag from prometheus values yaml which caused a warning
- Added links to the overview pages to promote the new guides

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
