### PR TITLE
chore: Add renovate for updating istio dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "labels": [
+        "area/dependency",
+        "kind/chore"
+    ],
+    "gomod": {
+        "enabled": false
+    },
+    "kustomize": {
+        "enabled": false
+    },
+    "dockerfile": {
+        "enabled": false
+    },
+    "helm-values": {
+        "enabled": false
+    },
+    "github-actions": {
+        "enabled": false
+    },
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^\\.env$"
+            ],
+            "matchStrings": [
+                "ENV_ISTIO_VERSION=(?<currentValue>\\d+?\\.\\d+?\\.\\d+?)"
+            ],
+            "datasourceTemplate": "github-releases",
+            "versioningTemplate": "semver",
+            "depNameTemplate": "kyma-project/istio"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Enable renovate for the repo
- Enable a customManager to update the istio module dependency in the env file
- Disable all other managers for now

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
