### PR TITLE
docs: Add cloud provider attributes for OTel based gateways

### DIFF
--- a/docs/user/gateways.md
+++ b/docs/user/gateways.md
@@ -37,6 +37,13 @@ The Telemetry gateways automatically enrich your data by adding the following at
   - Deployment/DaemonSet/StatefulSet/Job name
   - Namespace
   - Cluster name
+- Cloud provider attributes: The gateway automatically adds [cloud provider](https://opentelemetry.io/docs/specs/semconv/resource/cloud/) attributes to the telemetry data when data is available. The attribute values are mostly based on the well-known kubernetes labels, which are available on the nodes.
+  - `cloud.provider`: The cloud provider name.
+  - `k8s.cluster.name`: The name of the cluster, when the information not available, the value is the API-Server URL.
+  - `cloud.region`: The region where the node is running, value retrieved from node label `topology.kubernetes.io/region` 
+  - `cloud.availability_zone`: The zone where the node is running, value retrieved from node label `topology.kubernetes.io/zone`
+  - `host.type`: The machine type of the node, value retrieved from node label `node.kubernetes.io/instance-type`
+  - `host.arch`: The architecture of the node, value retrieved from node label `kubernetes.io/arch`
 
 ## Istio Support
 

--- a/internal/utils/k8s/cluster_info_getter.go
+++ b/internal/utils/k8s/cluster_info_getter.go
@@ -14,7 +14,7 @@ const (
 	gardenerShootNameAttributeName     = "shootName"
 	gardenerCloudProviderAttributeName = "provider"
 	CloudProviderOpenStack             = "openstack"
-	CloudProviderSAPConvergedCloud     = "sap-converged-cloud"
+	CloudProviderSAPConvergedCloud     = "sap"
 )
 
 var defaultGardenerShootInfoCM = types.NamespacedName{

--- a/internal/utils/k8s/cluster_info_getter_test.go
+++ b/internal/utils/k8s/cluster_info_getter_test.go
@@ -42,7 +42,7 @@ func TestClusterInfoGetter(t *testing.T) {
 		clusterInfo := GetGardenerShootInfo(context.Background(), fakeClient)
 
 		require.Equal(t, clusterInfo.ClusterName, "test-cluster")
-		require.Equal(t, clusterInfo.CloudProvider, "sap-converged-cloud")
+		require.Equal(t, clusterInfo.CloudProvider, "sap")
 	})
 
 	t.Run("Non Gardener cluster", func(t *testing.T) {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Documents cloud provider attributes
- The cloud provider name for SAP Converged Cloud will be `sap` 

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1685

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
