### PR TITLE
chore: Rename security-scanners-config fields

### DIFF
--- a/internal/tools/populateimages/main.go
+++ b/internal/tools/populateimages/main.go
@@ -16,8 +16,8 @@ import (
 type secScanConfig struct {
 	ModuleName   string       `yaml:"module-name"`
 	Kind         string       `yaml:"kind"`
-	Protecode    []string     `yaml:"protecode"`
-	WhiteSource  whiteSource  `yaml:"whitesource"`
+	Protecode    []string     `yaml:"bdba"`
+	WhiteSource  whiteSource  `yaml:"mend"`
 	CheckmarxOne checkmarxOne `yaml:"checkmarx-one"`
 }
 

--- a/internal/tools/populateimages/main.go
+++ b/internal/tools/populateimages/main.go
@@ -16,12 +16,12 @@ import (
 type secScanConfig struct {
 	ModuleName   string       `yaml:"module-name"`
 	Kind         string       `yaml:"kind"`
-	Protecode    []string     `yaml:"bdba"`
-	WhiteSource  whiteSource  `yaml:"mend"`
+	BDBA         []string     `yaml:"bdba"`
+	Mend         mend  `yaml:"mend"`
 	CheckmarxOne checkmarxOne `yaml:"checkmarx-one"`
 }
 
-type whiteSource struct {
+type mend struct {
 	Language string   `yaml:"language"`
 	Exclude  []string `yaml:"exclude"`
 }
@@ -183,8 +183,8 @@ func generateSecScanConfig(data map[string]string) error {
 	secScanCfg := secScanConfig{
 		ModuleName: "telemetry",
 		Kind:       "kyma",
-		Protecode:  imgs,
-		WhiteSource: whiteSource{
+		BDBA:       imgs,
+		Mend:       mend{
 			Language: "golang-mod",
 			Exclude:  []string{"**/mocks/**", "**/stubs/**", "**/test/**", "**/*_test.go"},
 		},

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,12 +1,12 @@
 module-name: telemetry
 kind: kyma
-protecode:
+bdba:
 - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
 - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f
 - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.4
 - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.118.0-main
 - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.1.0-98bf175
-whitesource:
+mend:
   language: golang-mod
   exclude:
   - '**/mocks/**'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

With recent tool naming change, we want to keep the same names in security-scanner-config

Changes proposed in this pull request:

- Rename `protecode` to `bdba`
- Rename `whitesource` to `mend`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma/test-infra#491