### PR TITLE
chore: Update to golang 1.23.6

### DIFF
--- a/.env
+++ b/.env
@@ -15,8 +15,8 @@ ENV_K3D_VERSION=v5.4.7
 ENV_GORELEASER_VERSION=v1.23.0
 
 ## Default Docker Images
-DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f"
+DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250206-00da07e7"
 DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.4"
 DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.118.0-main"
 DEFAULT_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.1.0-98bf175"
-DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0"
+DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.118.0"

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ### Default Environment Variables
 ## General
-ENV_K3S_K8S_VERSION=1.30.5 # refers to the version of kubernetes used in K3s
+ENV_K3S_K8S_VERSION=1.30.9 # refers to the version of kubernetes used in K3s
 ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main # Image URL to use all building/pushing image targets
 
 ## Gardener
@@ -11,7 +11,6 @@ ENV_GARDENER_MAX_NODES=2
 
 ## Dependencies
 ENV_ISTIO_VERSION=1.14.0
-ENV_K3D_VERSION=v5.4.7
 ENV_GORELEASER_VERSION=v1.23.0
 
 ## Default Docker Images

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,6 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-    labels:
-      - "area/dependency"
-      - "kind/chore"
-    ignore:
-      - dependency-name: "kyma-project/prod/tpi/fluent-bit"
-
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.5-alpine3.21 AS builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.23.6-alpine3.21 AS builder
 
 WORKDIR /telemetry-manager-workspace
 # Copy the Go Modules manifests

--- a/docs/user/integration/sample-app/Dockerfile
+++ b/docs/user/integration/sample-app/Dockerfile
@@ -1,5 +1,5 @@
 # Build the app binary
-FROM golang:1.23.5 AS builder
+FROM golang:1.23.6 AS builder
 
 # Copy the project
 WORKDIR /app

--- a/docs/user/integration/sample-app/go.mod
+++ b/docs/user/integration/sample-app/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/telemetry-manager/docs/user/integration/sample-app
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/prometheus/client_golang v1.20.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/telemetry-manager
 
-go 1.23.4
+go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -4,7 +4,7 @@
 package images
 
 const (
-	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f"
+	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250206-00da07e7"
 	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.4"
 	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.118.0-main"
 	DefaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.1.0-98bf175"

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/telemetry-manager/internal/tools
 
-go 1.23.4
+go 1.23.0
 
 require (
 	github.com/bombsimon/wsl/v4 v4.5.0

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,18 @@
             "datasourceTemplate": "github-releases",
             "versioningTemplate": "semver",
             "depNameTemplate": "kyma-project/istio"
-        }
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^\\.env$"
+            ],
+            "matchStrings": [
+                "ENV_K3D_VERSION=(?<currentValue>\\d+?\\.\\d+?\\.\\d+?)"
+            ],
+            "datasourceTemplate": "github-releases",
+            "versioningTemplate": "semver",
+            "depNameTemplate": "k3d-io/k3d"
+        },
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -35,18 +35,6 @@
             "datasourceTemplate": "github-releases",
             "versioningTemplate": "semver",
             "depNameTemplate": "kyma-project/istio"
-        },
-        {
-            "customType": "regex",
-            "fileMatch": [
-                "^\\.env$"
-            ],
-            "matchStrings": [
-                "ENV_K3D_VERSION=(?<currentValue>\\d+?\\.\\d+?\\.\\d+?)"
-            ],
-            "datasourceTemplate": "github-releases",
-            "versioningTemplate": "semver",
-            "depNameTemplate": "k3d-io/k3d"
-        },
+        }
     ]
 }

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,7 @@ module-name: telemetry
 kind: kyma
 protecode:
 - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-- europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20241212-e4adf27f
+- europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250206-00da07e7
 - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.4
 - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.118.0-main
 - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.1.0-98bf175

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -4,5 +4,5 @@
 package testkit
 
 const (
-	DefaultTelemetryGenImage = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0"
+	DefaultTelemetryGenImage = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.118.0"
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Update to golang 1.23.6
- Enabled renovate for dockerfiles
- Update exporter image
- Updated telemetrygen
- Configured renovate for k3d update

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
