### PR TITLE
fix: Delete OTLP log agent resources when no longer needed

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -6,7 +6,7 @@ Telemetry Manager has been bootstrapped with [Kubebuilder](https://github.com/ku
 
 - Install [kubebuilder 3.6.0](https://github.com/kubernetes-sigs/kubebuilder), which is the base framework for Telemetry Manager. Required to add new APIs.
 - Install [Golang 1.20](https://golang.org/dl/) or newer (for development and local execution).
-- Install [Docker](https://www.docker.com/get-started).
+- Install [Docker](https://www.docker.com/get-started/).
 - Install [golangci-lint](https://golangci-lint.run).
 - Install [ginkgo CLI](https://pkg.go.dev/github.com/onsi/ginkgo/ginkgo) to run the E2E test commands straight from your terminal.
 

--- a/internal/reconciler/logpipeline/otel/reconciler.go
+++ b/internal/reconciler/logpipeline/otel/reconciler.go
@@ -134,6 +134,16 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1alpha
 		return fmt.Errorf("failed to fetch deployable log pipelines: %w", err)
 	}
 
+	var reconcilablePipelinesRequiringAgents = r.getPipelinesRequiringAgents(reconcilablePipelines)
+
+	if len(reconcilablePipelinesRequiringAgents) == 0 {
+		logf.FromContext(ctx).V(1).Info("cleaning up log agent resources: no log pipelines require an agent")
+
+		if err = r.agentApplierDeleter.DeleteResources(ctx, r.Client); err != nil {
+			return fmt.Errorf("failed to delete agent resources: %w", err)
+		}
+	}
+
 	if len(reconcilablePipelines) == 0 {
 		logf.FromContext(ctx).V(1).Info("cleaning up log pipeline resources: all log pipelines are non-reconcilable")
 
@@ -315,6 +325,18 @@ func getAgentPorts() []int32 {
 		ports.Metrics,
 		ports.HealthCheck,
 	}
+}
+
+func (r *Reconciler) getPipelinesRequiringAgents(allPipelines []telemetryv1alpha1.LogPipeline) []telemetryv1alpha1.LogPipeline {
+	var pipelinesRequiringAgents []telemetryv1alpha1.LogPipeline
+
+	for i := range allPipelines {
+		if isLogAgentRequired(&allPipelines[i]) {
+			pipelinesRequiringAgents = append(pipelinesRequiringAgents, allPipelines[i])
+		}
+	}
+
+	return pipelinesRequiringAgents
 }
 
 func isLogAgentRequired(pipeline *telemetryv1alpha1.LogPipeline) bool {

--- a/internal/reconciler/logpipeline/otel/reconciler_test.go
+++ b/internal/reconciler/logpipeline/otel/reconciler_test.go
@@ -360,7 +360,7 @@ func TestReconcile(t *testing.T) {
 
 		agentConfigBuilderMock := &mocks.AgentConfigBuilder{}
 		agentConfigBuilderMock.On("Build", containsPipelines([]telemetryv1alpha1.LogPipeline{pipeline1, pipeline2}), mock.Anything).Return(&agent.Config{}, nil, nil).Times(1)
-		
+
 		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
 		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
 
@@ -388,7 +388,7 @@ func TestReconcile(t *testing.T) {
 			&conditions.ErrorToMessageConverter{})
 		err1 := sut.Reconcile(context.Background(), &pipeline1)
 		err2 := sut.Reconcile(context.Background(), &pipeline2)
-		
+
 		require.NoError(t, err1)
 		require.NoError(t, err2)
 
@@ -438,12 +438,14 @@ func TestReconcile(t *testing.T) {
 			&conditions.ErrorToMessageConverter{})
 		err1 := sut.Reconcile(context.Background(), &pipeline1)
 		err2 := sut.Reconcile(context.Background(), &pipeline2)
-		
+
 		require.NoError(t, err1)
 		require.NoError(t, err2)
 
 		var updatedPipeline1 telemetryv1alpha1.LogPipeline
+
 		var updatedPipeline2 telemetryv1alpha1.LogPipeline
+
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline1)
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline2)
 

--- a/internal/reconciler/logpipeline/otel/reconciler_test.go
+++ b/internal/reconciler/logpipeline/otel/reconciler_test.go
@@ -44,7 +44,7 @@ func TestReconcile(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline).WithStatusSubresource(&pipeline).Build()
 
 		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
-		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		agentApplierDeleterMock.On("DeleteResources", mock.Anything, mock.Anything).Return(nil).Times(1)
 
 		agentConfigBuilderMock := &mocks.AgentConfigBuilder{}
 		agentConfigBuilderMock.On("Build", mock.Anything).Return(&gateway.Config{}, nil, nil).Times(1)
@@ -97,7 +97,7 @@ func TestReconcile(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline).WithStatusSubresource(&pipeline).Build()
 
 		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
-		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		agentApplierDeleterMock.On("DeleteResources", mock.Anything, mock.Anything).Return(nil).Times(1)
 
 		agentConfigBuilderMock := &mocks.AgentConfigBuilder{}
 		agentConfigBuilderMock.On("Build", containsPipeline(pipeline), mock.Anything).Return(&gateway.Config{}, nil, nil).Times(1)
@@ -150,7 +150,7 @@ func TestReconcile(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline).WithStatusSubresource(&pipeline).Build()
 
 		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
-		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		agentApplierDeleterMock.On("DeleteResources", mock.Anything, mock.Anything).Return(nil).Times(1)
 
 		agentConfigBuilderMock := &mocks.AgentConfigBuilder{}
 		agentConfigBuilderMock.On("Build", containsPipeline(pipeline), mock.Anything).Return(&gateway.Config{}, nil, nil).Times(1)
@@ -196,6 +196,7 @@ func TestReconcile(t *testing.T) {
 
 		gatewayConfigBuilderMock.AssertExpectations(t)
 	})
+
 	t.Run("log agent daemonset is not ready", func(t *testing.T) {
 		pipeline := testutils.NewLogPipelineBuilder().WithName("pipeline").WithOTLPOutput().WithApplicationInput(true).Build()
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline).WithStatusSubresource(&pipeline).Build()
@@ -299,12 +300,167 @@ func TestReconcile(t *testing.T) {
 		agentConfigBuilderMock.AssertExpectations(t)
 		gatewayConfigBuilderMock.AssertExpectations(t)
 	})
+
 	// TODO: "referenced secret missing" (requires SecretRefValidator to be implemented)
 	// TODO: "referenced secret exists" (requires SecretRefValidator to be implemented)
 	// TODO: "flow healthy" (requires SelfMonitoring to be implemented)
 	// TODO: "tls conditions" (requires TLSCertValidator to be implemented)
 	// TODO: "all log pipelines are non-reconcilable" (requires SecretRefValidator to be implemented)
 	// TODO: "Check different Pod Error Conditions" (requires SecretRefValidator to be implemented)
+
+	t.Run("one log pipeline does not require an agent", func(t *testing.T) {
+		pipeline := testutils.NewLogPipelineBuilder().WithName("pipeline").WithOTLPOutput().WithApplicationInput(false).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline).WithStatusSubresource(&pipeline).Build()
+
+		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
+		agentApplierDeleterMock.On("DeleteResources", mock.Anything, mock.Anything).Return(nil).Times(1)
+
+		gatewayConfigBuilderMock := &mocks.GatewayConfigBuilder{}
+		gatewayConfigBuilderMock.On("Build", mock.Anything, containsPipeline(pipeline), mock.Anything).Return(&gateway.Config{}, nil, nil).Times(1)
+
+		gatewayApplierDeleterMock := &mocks.GatewayApplierDeleter{}
+		gatewayApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		gatewayProberStub := commonStatusStubs.NewDeploymentSetProber(nil)
+		agentProberStub := commonStatusStubs.NewDaemonSetProber(nil)
+
+		sut := New(
+			fakeClient,
+			telemetryNamespace,
+			moduleVersion,
+			&mocks.AgentConfigBuilder{},
+			agentApplierDeleterMock,
+			agentProberStub,
+			gatewayApplierDeleterMock,
+			gatewayConfigBuilderMock,
+			gatewayProberStub,
+			istioStatusCheckerStub,
+			&Validator{},
+			&conditions.ErrorToMessageConverter{})
+		err := sut.Reconcile(context.Background(), &pipeline)
+		require.NoError(t, err)
+
+		var updatedPipeline telemetryv1alpha1.LogPipeline
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline.Name}, &updatedPipeline)
+
+		requireHasStatusCondition(t, updatedPipeline,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonLogAgentNotRequired,
+			"")
+
+		agentApplierDeleterMock.AssertExpectations(t)
+		gatewayConfigBuilderMock.AssertExpectations(t)
+	})
+
+	t.Run("some log pipelines do not require an agent", func(t *testing.T) {
+		pipeline1 := testutils.NewLogPipelineBuilder().WithName("pipeline1").WithOTLPOutput().WithApplicationInput(false).Build()
+		pipeline2 := testutils.NewLogPipelineBuilder().WithName("pipeline2").WithOTLPOutput().WithApplicationInput(true).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline1, &pipeline2).WithStatusSubresource(&pipeline1, &pipeline2).Build()
+
+		agentConfigBuilderMock := &mocks.AgentConfigBuilder{}
+		agentConfigBuilderMock.On("Build", containsPipelines([]telemetryv1alpha1.LogPipeline{pipeline1, pipeline2}), mock.Anything).Return(&agent.Config{}, nil, nil).Times(1)
+		
+		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
+		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
+
+		gatewayConfigBuilderMock := &mocks.GatewayConfigBuilder{}
+		gatewayConfigBuilderMock.On("Build", mock.Anything, containsPipelines([]telemetryv1alpha1.LogPipeline{pipeline1, pipeline2}), mock.Anything).Return(&gateway.Config{}, nil, nil)
+
+		gatewayApplierDeleterMock := &mocks.GatewayApplierDeleter{}
+		gatewayApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		gatewayProberStub := commonStatusStubs.NewDeploymentSetProber(nil)
+		agentProberStub := commonStatusStubs.NewDaemonSetProber(nil)
+
+		sut := New(
+			fakeClient,
+			telemetryNamespace,
+			moduleVersion,
+			agentConfigBuilderMock,
+			agentApplierDeleterMock,
+			agentProberStub,
+			gatewayApplierDeleterMock,
+			gatewayConfigBuilderMock,
+			gatewayProberStub,
+			istioStatusCheckerStub,
+			&Validator{},
+			&conditions.ErrorToMessageConverter{})
+		err1 := sut.Reconcile(context.Background(), &pipeline1)
+		err2 := sut.Reconcile(context.Background(), &pipeline2)
+		
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+
+		var updatedPipeline1 telemetryv1alpha1.LogPipeline
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline1)
+
+		requireHasStatusCondition(t, updatedPipeline1,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonLogAgentNotRequired,
+			"")
+
+		agentConfigBuilderMock.AssertExpectations(t)
+		agentApplierDeleterMock.AssertExpectations(t)
+		gatewayConfigBuilderMock.AssertExpectations(t)
+	})
+
+	t.Run("all log pipelines do not require an agent", func(t *testing.T) {
+		pipeline1 := testutils.NewLogPipelineBuilder().WithName("pipeline1").WithOTLPOutput().WithApplicationInput(false).Build()
+		pipeline2 := testutils.NewLogPipelineBuilder().WithName("pipeline2").WithOTLPOutput().WithApplicationInput(false).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&pipeline1, &pipeline2).WithStatusSubresource(&pipeline1, &pipeline2).Build()
+
+		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
+		agentApplierDeleterMock.On("DeleteResources", mock.Anything, mock.Anything).Return(nil).Times(2)
+
+		gatewayConfigBuilderMock := &mocks.GatewayConfigBuilder{}
+		gatewayConfigBuilderMock.On("Build", mock.Anything, containsPipelines([]telemetryv1alpha1.LogPipeline{pipeline1, pipeline2}), mock.Anything).Return(&gateway.Config{}, nil, nil)
+
+		gatewayApplierDeleterMock := &mocks.GatewayApplierDeleter{}
+		gatewayApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		gatewayProberStub := commonStatusStubs.NewDeploymentSetProber(nil)
+		agentProberStub := commonStatusStubs.NewDaemonSetProber(nil)
+
+		sut := New(
+			fakeClient,
+			telemetryNamespace,
+			moduleVersion,
+			&mocks.AgentConfigBuilder{},
+			agentApplierDeleterMock,
+			agentProberStub,
+			gatewayApplierDeleterMock,
+			gatewayConfigBuilderMock,
+			gatewayProberStub,
+			istioStatusCheckerStub,
+			&Validator{},
+			&conditions.ErrorToMessageConverter{})
+		err1 := sut.Reconcile(context.Background(), &pipeline1)
+		err2 := sut.Reconcile(context.Background(), &pipeline2)
+		
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+
+		var updatedPipeline1 telemetryv1alpha1.LogPipeline
+		var updatedPipeline2 telemetryv1alpha1.LogPipeline
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline1)
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline2)
+
+		requireHasStatusCondition(t, updatedPipeline1,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonLogAgentNotRequired,
+			"")
+		requireHasStatusCondition(t, updatedPipeline2,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonLogAgentNotRequired,
+			"")
+
+		agentApplierDeleterMock.AssertExpectations(t)
+		gatewayConfigBuilderMock.AssertExpectations(t)
+	})
 }
 
 func requireHasStatusCondition(t *testing.T, pipeline telemetryv1alpha1.LogPipeline, condType string, status metav1.ConditionStatus, reason, message string) {
@@ -320,5 +476,26 @@ func requireHasStatusCondition(t *testing.T, pipeline telemetryv1alpha1.LogPipel
 func containsPipeline(p telemetryv1alpha1.LogPipeline) any {
 	return mock.MatchedBy(func(pipelines []telemetryv1alpha1.LogPipeline) bool {
 		return len(pipelines) == 1 && pipelines[0].Name == p.Name
+	})
+}
+
+func containsPipelines(pp []telemetryv1alpha1.LogPipeline) any {
+	return mock.MatchedBy(func(pipelines []telemetryv1alpha1.LogPipeline) bool {
+		if len(pipelines) != len(pp) {
+			return false
+		}
+
+		pipelineMap := make(map[string]bool)
+		for _, p := range pipelines {
+			pipelineMap[p.Name] = true
+		}
+
+		for _, p := range pp {
+			if !pipelineMap[p.Name] {
+				return false
+			}
+		}
+
+		return true
 	})
 }

--- a/internal/reconciler/metricpipeline/reconciler_test.go
+++ b/internal/reconciler/metricpipeline/reconciler_test.go
@@ -1581,6 +1581,39 @@ func TestReconcile(t *testing.T) {
 	})
 }
 
+func TestGetPipelinesRequiringAgents(t *testing.T) {
+	r := Reconciler{}
+
+	t.Run("no pipelines", func(t *testing.T) {
+		pipelines := []telemetryv1alpha1.MetricPipeline{}
+		require.Empty(t, r.getPipelinesRequiringAgents(pipelines))
+	})
+
+	t.Run("no pipeline requires an agent", func(t *testing.T) {
+		pipeline1 := testutils.NewMetricPipelineBuilder().WithRuntimeInput(false).WithPrometheusInput(false).WithIstioInput(false).Build()
+		pipeline2 := testutils.NewMetricPipelineBuilder().WithRuntimeInput(false).WithPrometheusInput(false).WithIstioInput(false).Build()
+		pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2}
+		require.Empty(t, r.getPipelinesRequiringAgents(pipelines))
+	})
+
+	t.Run("some pipelines require an agent", func(t *testing.T) {
+		pipeline1 := testutils.NewMetricPipelineBuilder().WithRuntimeInput(true).Build()
+		pipeline2 := testutils.NewMetricPipelineBuilder().WithPrometheusInput(true).WithIstioInput(true).Build()
+		pipeline3 := testutils.NewMetricPipelineBuilder().WithRuntimeInput(true).WithPrometheusInput(true).WithIstioInput(true).Build()
+		pipeline4 := testutils.NewMetricPipelineBuilder().WithRuntimeInput(false).WithPrometheusInput(false).WithIstioInput(false).Build()
+		pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2, pipeline3, pipeline4}
+		require.ElementsMatch(t, []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2, pipeline3}, r.getPipelinesRequiringAgents(pipelines))
+	})
+
+	t.Run("all pipelines require an agent", func(t *testing.T) {
+		pipeline1 := testutils.NewMetricPipelineBuilder().WithRuntimeInput(true).Build()
+		pipeline2 := testutils.NewMetricPipelineBuilder().WithPrometheusInput(true).Build()
+		pipeline3 := testutils.NewMetricPipelineBuilder().WithIstioInput(true).Build()
+		pipelines := []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2, pipeline3}
+		require.ElementsMatch(t, []telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2, pipeline3}, r.getPipelinesRequiringAgents(pipelines))
+	})
+}
+
 func requireHasStatusCondition(t *testing.T, pipeline telemetryv1alpha1.MetricPipeline, condType string, status metav1.ConditionStatus, reason, message string) {
 	cond := meta.FindStatusCondition(pipeline.Status.Conditions, condType)
 	require.NotNil(t, cond, "could not find condition of type %s", condType)

--- a/internal/reconciler/metricpipeline/reconciler_test.go
+++ b/internal/reconciler/metricpipeline/reconciler_test.go
@@ -1417,7 +1417,9 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err2)
 
 		var updatedPipeline1 telemetryv1alpha1.MetricPipeline
+
 		var updatedPipeline2 telemetryv1alpha1.MetricPipeline
+
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline1)
 		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline2.Name}, &updatedPipeline2)
 

--- a/internal/reconciler/metricpipeline/reconciler_test.go
+++ b/internal/reconciler/metricpipeline/reconciler_test.go
@@ -1248,6 +1248,15 @@ func TestReconcile(t *testing.T) {
 		_, err := sut.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: pipeline.Name}})
 		require.NoError(t, err)
 
+		var updatedPipeline telemetryv1alpha1.MetricPipeline
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline.Name}, &updatedPipeline)
+
+		requireHasStatusCondition(t, updatedPipeline,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonMetricAgentNotRequired,
+			"")
+
 		agentApplierDeleterMock.AssertExpectations(t)
 		gatewayApplierDeleterMock.AssertExpectations(t)
 	})
@@ -1276,7 +1285,7 @@ func TestReconcile(t *testing.T) {
 		agentConfigBuilderMock.On("Build", containsPipelines([]telemetryv1alpha1.MetricPipeline{pipeline1, pipeline2}), mock.Anything).Return(&agent.Config{}, nil, nil)
 
 		agentApplierDeleterMock := &mocks.AgentApplierDeleter{}
-		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		agentApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(1)
 
 		gatewayApplierDeleterMock := &mocks.GatewayApplierDeleter{}
 		gatewayApplierDeleterMock.On("ApplyResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -1324,6 +1333,16 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err1)
 		require.NoError(t, err2)
 
+		var updatedPipeline1 telemetryv1alpha1.MetricPipeline
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline1)
+
+		requireHasStatusCondition(t, updatedPipeline1,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonMetricAgentNotRequired,
+			"")
+
+		agentConfigBuilderMock.AssertExpectations(t)
 		agentApplierDeleterMock.AssertExpectations(t)
 		gatewayApplierDeleterMock.AssertExpectations(t)
 	})
@@ -1396,6 +1415,22 @@ func TestReconcile(t *testing.T) {
 
 		require.NoError(t, err1)
 		require.NoError(t, err2)
+
+		var updatedPipeline1 telemetryv1alpha1.MetricPipeline
+		var updatedPipeline2 telemetryv1alpha1.MetricPipeline
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline1.Name}, &updatedPipeline1)
+		_ = fakeClient.Get(context.Background(), types.NamespacedName{Name: pipeline2.Name}, &updatedPipeline2)
+
+		requireHasStatusCondition(t, updatedPipeline1,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonMetricAgentNotRequired,
+			"")
+		requireHasStatusCondition(t, updatedPipeline2,
+			conditions.TypeAgentHealthy,
+			metav1.ConditionTrue,
+			conditions.ReasonMetricAgentNotRequired,
+			"")
 
 		agentApplierDeleterMock.AssertExpectations(t)
 		gatewayApplierDeleterMock.AssertExpectations(t)

--- a/test/e2e/logs_otlp_no_input_test.go
+++ b/test/e2e/logs_otlp_no_input_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
+	"github.com/kyma-project/telemetry-manager/internal/conditions"
+	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
+	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
+)
+
+var _ = Describe(suite.ID(), Label(suite.LabelLogs, suite.LabelExperimental), Ordered, func() {
+	var (
+		mockNs                = suite.ID()
+		pipelineNameNoInput   = suite.ID() + "-no-input"
+		pipelineNameWithInput = suite.ID() + "-with-input"
+	)
+
+	var logPipelineWithInput telemetryv1alpha1.LogPipeline
+
+	makeResources := func() []client.Object {
+		var objs []client.Object
+		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
+
+		backend := backend.New(mockNs, backend.SignalTypeLogs)
+		objs = append(objs, backend.K8sObjects()...)
+
+		logPipelineNoInput := testutils.NewLogPipelineBuilder().
+			WithName(pipelineNameNoInput).
+			WithApplicationInput(false).
+			WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+			Build()
+		objs = append(objs, &logPipelineNoInput)
+		logPipelineWithInput = testutils.NewLogPipelineBuilder().
+			WithName(pipelineNameWithInput).
+			WithApplicationInput(true).
+			WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+			Build()
+
+		return objs
+	}
+
+	Context("When a logpipeline with no input enabled exists", Ordered, func() {
+		BeforeAll(func() {
+			k8sObjects := makeResources()
+
+			DeferCleanup(func() {
+				Expect(kitk8s.DeleteObjects(ctx, k8sClient, k8sObjects...)).Should(Succeed())
+			})
+
+			k8sObjectsToCreate := append(k8sObjects, &logPipelineWithInput)
+			Expect(kitk8s.CreateObjects(ctx, k8sClient, k8sObjectsToCreate...)).Should(Succeed())
+		})
+
+		It("Ensures the log gateway deployment is ready", func() {
+			assert.DeploymentReady(ctx, k8sClient, kitkyma.LogGatewayName)
+		})
+
+		It("Should have a logs backend running", Label(suite.LabelUpgrade), func() {
+			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
+			assert.ServiceReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
+		})
+
+		It("Should have running pipelines", Label(suite.LabelUpgrade), func() {
+			assert.LogPipelineHealthy(ctx, k8sClient, pipelineNameNoInput)
+			assert.LogPipelineHealthy(ctx, k8sClient, pipelineNameWithInput)
+		})
+
+		It("Pipeline with no input should have AgentNotRequired condition", Label(suite.LabelUpgrade), func() {
+			assert.LogPipelineHasCondition(ctx, k8sClient, pipelineNameNoInput, metav1.Condition{
+				Type:   conditions.TypeAgentHealthy,
+				Status: metav1.ConditionTrue,
+				Reason: conditions.ReasonLogAgentNotRequired,
+			})
+		})
+
+		It("Ensures the log agent DaemonSet is running", func() {
+			assert.DaemonSetReady(ctx, k8sClient, kitkyma.LogAgentName)
+		})
+
+		It("Should delete the pipeline with input", func() {
+			Expect(kitk8s.DeleteObjects(ctx, k8sClient, &logPipelineWithInput)).Should(Succeed())
+		})
+
+		It("Ensures the log agent DaemonSet is no longer running", func() {
+			assert.DaemonSetNotFound(ctx, k8sClient, kitkyma.LogAgentName)
+		})
+	})
+})


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Delete OTLP log agent resources when no longer needed

Changes refer to particular issues, PRs or documents:

- Resolves https://github.com/kyma-project/telemetry-manager/issues/336

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [x] The feature is unit-tested.
- [x] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
