### PR TITLE
chore: checkout code to be accessible in github action

### DIFF
--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -21,6 +21,7 @@ env:
   GH_REPO: ${{ github.repository }}
   NUMBER: ${{ github.event.number }}
   TITLE: ${{ github.event.pull_request.title }}
+  GH_HOST: github.com
 
 permissions: write-all
 
@@ -51,6 +52,9 @@ jobs:
   pr-label-check:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Add kind label based on PR title prefix
         if: always()
         run: |


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- we need to checkout the code so that it can read its configuration

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
