### PR TITLE
fix: The gateway status should be shown in beta api

### DIFF
--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -37,7 +37,6 @@ type LogPipelineList struct {
 // +kubebuilder:resource:scope=Cluster,categories={kyma-telemetry,kyma-telemetry-pipelines}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Configuration Generated",type=string,JSONPath=`.status.conditions[?(@.type=="ConfigurationGenerated")].status`
-// +kubebuilder:printcolumn:name="Gateway Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="GatewayHealthy")].status`
 // +kubebuilder:printcolumn:name="Agent Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="AgentHealthy")].status`
 // +kubebuilder:printcolumn:name="Flow Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="TelemetryFlowHealthy")].status`
 // +kubebuilder:printcolumn:name="Unsupported Mode",type=boolean,JSONPath=`.status.unsupportedMode`

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -44,6 +44,7 @@ type LogPipelineList struct {
 // +kubebuilder:resource:scope=Cluster,categories={kyma-telemetry,kyma-telemetry-pipelines}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Configuration Generated",type=string,JSONPath=`.status.conditions[?(@.type=="ConfigurationGenerated")].status`
+// +kubebuilder:printcolumn:name="Gateway Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="GatewayHealthy")].status`
 // +kubebuilder:printcolumn:name="Agent Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="AgentHealthy")].status`
 // +kubebuilder:printcolumn:name="Flow Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="TelemetryFlowHealthy")].status`
 // +kubebuilder:printcolumn:name="Unsupported Mode",type=boolean,JSONPath=`.status.unsupportedMode`

--- a/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -21,9 +21,6 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="ConfigurationGenerated")].status
       name: Configuration Generated
       type: string
-    - jsonPath: .status.conditions[?(@.type=="GatewayHealthy")].status
-      name: Gateway Healthy
-      type: string
     - jsonPath: .status.conditions[?(@.type=="AgentHealthy")].status
       name: Agent Healthy
       type: string

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -21,9 +21,6 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="ConfigurationGenerated")].status
       name: Configuration Generated
       type: string
-    - jsonPath: .status.conditions[?(@.type=="GatewayHealthy")].status
-      name: Gateway Healthy
-      type: string
     - jsonPath: .status.conditions[?(@.type=="AgentHealthy")].status
       name: Agent Healthy
       type: string
@@ -729,6 +726,9 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=="ConfigurationGenerated")].status
       name: Configuration Generated
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="GatewayHealthy")].status
+      name: Gateway Healthy
       type: string
     - jsonPath: .status.conditions[?(@.type=="AgentHealthy")].status
       name: Agent Healthy


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Dont show gateway status for log alpha api
It was introduced via this [PR](https://github.com/kyma-project/telemetry-manager/pull/1786/files)
Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
