### PR TITLE
fix: e2e tests no input should not be upgrade tests

### DIFF
--- a/test/e2e/logs_otlp_no_input_test.go
+++ b/test/e2e/logs_otlp_no_input_test.go
@@ -66,17 +66,17 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogs, suite.LabelExperimental), Or
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.LogGatewayName)
 		})
 
-		It("Should have a logs backend running", Label(suite.LabelUpgrade), func() {
+		It("Should have a logs backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})
 
-		It("Should have running pipelines", Label(suite.LabelUpgrade), func() {
+		It("Should have running pipelines", func() {
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineNameNoInput)
 			assert.LogPipelineHealthy(ctx, k8sClient, pipelineNameWithInput)
 		})
 
-		It("Pipeline with no input should have AgentNotRequired condition", Label(suite.LabelUpgrade), func() {
+		It("Pipeline with no input should have AgentNotRequired condition", func() {
 			assert.LogPipelineHasCondition(ctx, k8sClient, pipelineNameNoInput, metav1.Condition{
 				Type:   conditions.TypeAgentHealthy,
 				Status: metav1.ConditionTrue,

--- a/test/e2e/metrics_no_input_test.go
+++ b/test/e2e/metrics_no_input_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
 
-var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), Ordered, func() {
+var _ = Describe(suite.ID(), Label(suite.LabelMetrics, suite.LabelSetA), Ordered, func() {
 	var (
 		mockNs                = suite.ID()
 		pipelineNameNoInput   = suite.ID() + "-no-input"
@@ -70,17 +70,17 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 			assert.DeploymentReady(ctx, k8sClient, kitkyma.MetricGatewayName)
 		})
 
-		It("Should have a metrics backend running", Label(suite.LabelUpgrade), func() {
+		It("Should have a metrics backend running", func() {
 			assert.DeploymentReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(ctx, k8sClient, types.NamespacedName{Name: backend.DefaultName, Namespace: mockNs})
 		})
 
-		It("Should have running pipelines", Label(suite.LabelUpgrade), func() {
+		It("Should have running pipelines", func() {
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineNameNoInput)
 			assert.MetricPipelineHealthy(ctx, k8sClient, pipelineNameWithInput)
 		})
 
-		It("Pipeline with no input should have AgentNotRequired condition", Label(suite.LabelUpgrade), func() {
+		It("Pipeline with no input should have AgentNotRequired condition", func() {
 			assert.MetricPipelineHasCondition(ctx, k8sClient, pipelineNameNoInput, metav1.Condition{
 				Type:   conditions.TypeAgentHealthy,
 				Status: metav1.ConditionTrue,


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- e2e tests "no input" should not be upgrade tests

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
