### PR TITLE
chore: Bump fluent-bit image to 3.2.7 in image cache

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,3 +1,3 @@
 images:
-  - source: "fluent/fluent-bit@sha256:a185ac0516e1f35568ff0662f12c4ada0ea38c4300ed223d0fde485599dff5b5"
-    tag: "3.2.4" # used by the kyma telemetry module
+  - source: "fluent/fluent-bit@sha256:bfce64b4b2027dfb3819dce82da776ff439e2e4197359e7aa18ec5b3c478c651"
+    tag: "3.2.7" # used by the kyma telemetry module


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump fluent-bit image to 3.2.7 in image cache

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
