### PR TITLE
chore: limit alerts payload size

### DIFF
--- a/internal/selfmonitor/webhook/handler.go
+++ b/internal/selfmonitor/webhook/handler.go
@@ -92,6 +92,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	var alerts []Alert
+
 	decoder := json.NewDecoder(io.LimitReader(r.Body, 1*MB))
 	if err := decoder.Decode(&alerts); err != nil {
 		h.logger.Error(err, "Failed to unmarshal request body")

--- a/internal/selfmonitor/webhook/handler_test.go
+++ b/internal/selfmonitor/webhook/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -21,12 +20,6 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
 )
-
-type errReader struct{}
-
-func (errReader) Read(p []byte) (n int, err error) {
-	return 0, assert.AnError
-}
 
 // hugeJSONFake is a fake reader that generates a huge JSON `file`. It starts like a JSON array and fills it with `a` to `z` characters, but it never ends the array.
 type hugeJSONFake struct {

--- a/internal/selfmonitor/webhook/handler_test.go
+++ b/internal/selfmonitor/webhook/handler_test.go
@@ -38,10 +38,13 @@ func (f *hugeJSONFake) Read(p []byte) (n int, err error) {
 	if f.Bytes < 2 {
 		return 0, io.EOF
 	}
+
 	if f.Bytes == f.offset {
 		return 0, io.EOF
 	}
+
 	header := []byte(`["`)
+
 	bytesLeft := len(p)
 	if (f.Bytes - f.offset) < bytesLeft {
 		bytesLeft = f.Bytes - f.offset
@@ -49,20 +52,24 @@ func (f *hugeJSONFake) Read(p []byte) (n int, err error) {
 	// If this is the first read, copy the header and fill the rest with characters
 	if f.offset == 0 {
 		copy(p, header)
+
 		remainder := bytesLeft - len(header)
-		for i := 0; i < remainder; i++ {
+		for i := range remainder {
 			p[i+len(header)] = byte('a' + (f.offset+i)%26)
 		}
+
 		f.offset += bytesLeft
+
 		return bytesLeft, nil
 	}
 
 	// Fill the rest with characters
-	for i := 0; i < bytesLeft; i++ {
+	for i := range bytesLeft {
 		p[i] = byte('a' + (f.offset+i)%26)
 	}
 
 	f.offset += bytesLeft
+
 	return bytesLeft, nil
 }
 


### PR DESCRIPTION

## Description

Changes proposed in this pull request (what was done and why):

- use decoder to unmarshall json in non-greedy-way
- add test for huge request body

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
