### PR TITLE
fix: reset forbidden github actions to allowed values

### DIFF
--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate title
-        uses: amannn/action-semantic-pull-request@40166f00814508ec3201fc8595b393d451c8cd80
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -123,7 +123,7 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Check kustomization.yaml changes
-        uses: tj-actions/changed-files@251f07ed5250f0c01a1745b77a54289a678b3928
+        uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
         id: changed-kustomization
         with:
           files: "config/manager/kustomization.yaml"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- 

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
