### PR TITLE
docs: Add a deprecation note for OTel internal metrics

### DIFF
--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -86,10 +86,8 @@ metadata:
     telemetry.kyma-project.io/internal-metrics-compatibility-mode: "true"
 ```
 
-> [! WARNING]
-> By default, the backward compatibility mode is disabled. 
-> It is recommended to keep backward compatibility mode disabled, as old metrics have been deprecated. 
-> This mode is scheduled for removal in a future update.
+> [!CAUTION]
+> By default, the backward compatibility mode is disabled. It is recommended to keep backward compatibility mode disabled, as old metrics have been deprecated. This mode is scheduled for removal in a future update.
 
 <!-- The table below was generated automatically -->
 <!-- Some special tags (html comments) are at the end of lines due to markdown requirements. -->

--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -87,7 +87,9 @@ metadata:
 ```
 
 > [! WARNING]
-> By default, the backward compatibility mode is disabled.
+> By default, the backward compatibility mode is disabled. 
+> It is recommended to keep backward compatibility mode disabled, as older metrics have been deprecated. 
+> This mode is scheduled for removal in a future update.
 
 <!-- The table below was generated automatically -->
 <!-- Some special tags (html comments) are at the end of lines due to markdown requirements. -->

--- a/docs/user/resources/01-telemetry.md
+++ b/docs/user/resources/01-telemetry.md
@@ -88,7 +88,7 @@ metadata:
 
 > [! WARNING]
 > By default, the backward compatibility mode is disabled. 
-> It is recommended to keep backward compatibility mode disabled, as older metrics have been deprecated. 
+> It is recommended to keep backward compatibility mode disabled, as old metrics have been deprecated. 
 > This mode is scheduled for removal in a future update.
 
 <!-- The table below was generated automatically -->


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add a deprecation note for old OTel internal metrics

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
