### PR TITLE
chore: add additional permissions for image builder

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,12 +8,12 @@ on:
       - "main"
       - "release-[0-9]+.[0-9]+"
     paths-ignore:
-      - 'docs/**'
-      - 'dependencies/**'
-      - '**/*.md'
-      - 'OWNERS'
-      - 'CODEOWNERS'
-      - 'external-images.yaml'
+      - "docs/**"
+      - "dependencies/**"
+      - "**/*.md"
+      - "OWNERS"
+      - "CODEOWNERS"
+      - "external-images.yaml"
   push:
     branches:
       - "main"
@@ -21,12 +21,17 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
-      - 'docs/**'
-      - 'dependencies/**'
-      - '**/*.md'
-      - 'OWNERS'
-      - 'CODEOWNERS'
-      - 'external-images.yaml'
+      - "docs/**"
+      - "dependencies/**"
+      - "**/*.md"
+      - "OWNERS"
+      - "CODEOWNERS"
+      - "external-images.yaml"
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   envs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     paths:
       - "docs/user/integration/sample-app/**"
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -12,6 +12,10 @@ on:
     paths:
       - "docs/user/integration/sample-app/**"
   workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   envs:

--- a/.github/workflows/build-telemetry-self-monitor-image.yml
+++ b/.github/workflows/build-telemetry-self-monitor-image.yml
@@ -4,13 +4,17 @@ on:
   pull_request_target:
     paths:
       - "dependencies/telemetry-self-monitor/**"
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
     paths:
       - "dependencies/telemetry-self-monitor/**"
   workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   envs:
@@ -33,7 +37,7 @@ jobs:
         id: prepare-envs
         run: |
           {
-          # this creates a multiline string with the envs. 
+          # this creates a multiline string with the envs.
           # Everything between `build-args<<BUILD_ARGS` and BUILD_ARGS will be content of the build-args variable.
           echo 'build-args<<BUILD_ARGS'
           cat dependencies/telemetry-self-monitor/envs


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- due to changes on org level we need additional permissions for the tokens used in our image builder workflows

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
