### PR TITLE
chore: Exclude docs from integration test workflows

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -16,6 +16,7 @@ on:
     # test files in the test/e2e directory
     # test files in the istio directory
     # exclude go files that end with _test.go
+    # exclude (go) files in the doc folder
     # include the workflow definition itself
     # include dependencies of the workflow definition
     paths:
@@ -24,6 +25,7 @@ on:
       - "**.go"
       - "config/**"
       - "!**_test.go"
+      - "!docs/**"
       - "test/e2e/*.go"
       - "test/integration/istio/*.go"
       - ".github/workflows/pr-integration.yml"

--- a/.github/workflows/pr-upgrade.yml
+++ b/.github/workflows/pr-upgrade.yml
@@ -12,6 +12,7 @@ on:
     # test files in the test/e2e directory
     # test files in the istio directory
     # exclude go files that end with _test.go
+    # exclude (go) files in the doc folder
     # include the workflow definition itself
     # include dependencies of the workflow definition
     paths:
@@ -20,6 +21,7 @@ on:
       - "**.go"
       - "config/**"
       - "!**_test.go"
+      - "!docs/**"
       - "test/e2e/*.go"
       - "test/integration/istio/*.go"
       - ".github/workflows/pr-upgrade.yml"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Exclude docs from integration test workflows

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
