### PR TITLE
feat: set observed time in log gateway if not present

### DIFF
--- a/internal/otelcollector/config/log/gateway/config.go
+++ b/internal/otelcollector/config/log/gateway/config.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/log"
 )
 
 type Config struct {
@@ -19,9 +20,10 @@ type Receivers struct {
 type Processors struct {
 	config.BaseProcessors `yaml:",inline"`
 
-	K8sAttributes           *config.K8sAttributesProcessor `yaml:"k8sattributes,omitempty"`
-	InsertClusterAttributes *config.ResourceProcessor      `yaml:"resource/insert-cluster-attributes,omitempty"`
-	DropKymaAttributes      *config.ResourceProcessor      `yaml:"resource/drop-kyma-attributes,omitempty"`
+	K8sAttributes            *config.K8sAttributesProcessor `yaml:"k8sattributes,omitempty"`
+	InsertClusterAttributes  *config.ResourceProcessor      `yaml:"resource/insert-cluster-attributes,omitempty"`
+	DropKymaAttributes       *config.ResourceProcessor      `yaml:"resource/drop-kyma-attributes,omitempty"`
+	SetObsTimeWhenNotPresent *log.TransformProcessor        `yaml:"transform/set-observed-time-when-not-present,omitempty"`
 }
 
 type Exporters map[string]Exporter

--- a/internal/otelcollector/config/log/gateway/config_builder.go
+++ b/internal/otelcollector/config/log/gateway/config_builder.go
@@ -108,6 +108,7 @@ func makePipelineConfig(exporterIDs ...string) config.Pipeline {
 			"memory_limiter",
 			"k8sattributes",
 			"resource/insert-cluster-attributes",
+			"transform/set-observed-time-when-not-present",
 			"batch",
 		},
 		Exporters: exporterIDs,

--- a/internal/otelcollector/config/log/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/log/gateway/config_builder_test.go
@@ -210,7 +210,8 @@ func TestBuildConfig(t *testing.T) {
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test"].Processors[0], "memory_limiter")
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test"].Processors[1], "k8sattributes")
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test"].Processors[2], "resource/insert-cluster-attributes")
-		require.Equal(t, collectorConfig.Service.Pipelines["logs/test"].Processors[3], "batch")
+		require.Equal(t, collectorConfig.Service.Pipelines["logs/test"].Processors[3], "transform/set-observed-time-when-not-present")
+		require.Equal(t, collectorConfig.Service.Pipelines["logs/test"].Processors[4], "batch")
 
 		require.Contains(t, collectorConfig.Service.Pipelines["logs/test"].Exporters, "otlp/test")
 	})
@@ -233,7 +234,8 @@ func TestBuildConfig(t *testing.T) {
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-1"].Processors[0], "memory_limiter")
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-1"].Processors[1], "k8sattributes")
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-1"].Processors[2], "resource/insert-cluster-attributes")
-		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-1"].Processors[3], "batch")
+		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-1"].Processors[3], "transform/set-observed-time-when-not-present")
+		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-1"].Processors[4], "batch")
 
 		require.Contains(t, collectorConfig.Service.Pipelines, "logs/test-2")
 		require.Contains(t, collectorConfig.Service.Pipelines["logs/test-2"].Exporters, "otlp/test-2")
@@ -241,7 +243,9 @@ func TestBuildConfig(t *testing.T) {
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-2"].Processors[0], "memory_limiter")
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-2"].Processors[1], "k8sattributes")
 		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-2"].Processors[2], "resource/insert-cluster-attributes")
-		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-2"].Processors[3], "batch")
+		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-2"].Processors[3], "transform/set-observed-time-when-not-present")
+
+		require.Equal(t, collectorConfig.Service.Pipelines["logs/test-2"].Processors[4], "batch")
 
 		require.Contains(t, envVars, "OTLP_ENDPOINT_TEST_1")
 		require.Contains(t, envVars, "OTLP_ENDPOINT_TEST_2")

--- a/internal/otelcollector/config/log/gateway/processors_test.go
+++ b/internal/otelcollector/config/log/gateway/processors_test.go
@@ -85,4 +85,18 @@ func TestProcessors(t *testing.T) {
 
 		require.Equal(t, "connection", collectorConfig.Processors.K8sAttributes.PodAssociation[2].Sources[0].From)
 	})
+
+	t.Run("Set Observerd time when not present", func(t *testing.T) {
+		collectorConfig, _, err := sut.Build(ctx, []telemetryv1alpha1.LogPipeline{testutils.NewLogPipelineBuilder().WithOTLPOutput().Build()}, BuildOptions{
+			ClusterName:   "test-cluster",
+			CloudProvider: "test-cloud-provider",
+		})
+		require.NoError(t, err)
+
+		require.Len(t, collectorConfig.Processors.SetObsTimeWhenNotPresent.LogStatements[0].Conditions, 1)
+		require.Equal(t, "log.observed_time_unix_nano == 0", collectorConfig.Processors.SetObsTimeWhenNotPresent.LogStatements[0].Conditions[0])
+
+		require.Len(t, collectorConfig.Processors.SetObsTimeWhenNotPresent.LogStatements[0].Statements, 1)
+		require.Equal(t, "set(log.observed_time, Now())", collectorConfig.Processors.SetObsTimeWhenNotPresent.LogStatements[0].Statements[0])
+	})
 }

--- a/internal/otelcollector/config/log/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/log/gateway/testdata/config.yaml
@@ -12,6 +12,7 @@ service:
                 - memory_limiter
                 - k8sattributes
                 - resource/insert-cluster-attributes
+                - transform/set-observed-time-when-not-present
                 - batch
             exporters:
                 - otlp/test
@@ -94,6 +95,13 @@ processors:
             - action: insert
               key: cloud.provider
               value: test-cloud-provider
+    transform/set-observed-time-when-not-present:
+        error_mode: ignore
+        log_statements:
+            - statements:
+                - set(log.observed_time, Now())
+              conditions:
+                - log.observed_time_unix_nano == 0
 exporters:
     otlp/test:
         endpoint: ${OTLP_ENDPOINT_TEST}

--- a/internal/otelcollector/config/log/gateway/testdata/config_compatibility_enabled.yaml
+++ b/internal/otelcollector/config/log/gateway/testdata/config_compatibility_enabled.yaml
@@ -12,6 +12,7 @@ service:
                 - memory_limiter
                 - k8sattributes
                 - resource/insert-cluster-attributes
+                - transform/set-observed-time-when-not-present
                 - batch
             exporters:
                 - otlp/test
@@ -97,6 +98,13 @@ processors:
             - action: insert
               key: cloud.provider
               value: test-cloud-provider
+    transform/set-observed-time-when-not-present:
+        error_mode: ignore
+        log_statements:
+            - statements:
+                - set(log.observed_time, Now())
+              conditions:
+                - log.observed_time_unix_nano == 0
 exporters:
     otlp/test:
         endpoint: ${OTLP_ENDPOINT_TEST}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- sometimes when logs are pushed to log gateway the observed time is not set. In such a case set the observed time.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
