### PR TITLE
chore: Bump fluentbit image in cache to 3.2.8

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,3 +1,3 @@
 images:
-  - source: "fluent/fluent-bit@sha256:bfce64b4b2027dfb3819dce82da776ff439e2e4197359e7aa18ec5b3c478c651"
-    tag: "3.2.7" # used by the kyma telemetry module
+  - source: "fluent/fluent-bit@sha256:14da4a52ecdbb9bd9cb7a16ff6b4c7f391a4006cb13f84b5957e4608cc613e2c"
+    tag: "3.2.8" # used by the kyma telemetry module


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump fluentbit image in cache to 3.2.8

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
