### PR TITLE
chore: prepare images for 1.36.0 release

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ### Default Environment Variables
 ## General
 ENV_K3S_K8S_VERSION=1.30.9 # refers to the version of kubernetes used in K3s
-ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main # Image URL to use all building/pushing image targets
+ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.36.0 # Image URL to use all building/pushing image targets
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.30
@@ -16,6 +16,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250312-f7941911"
 DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.8"
-DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.120.0-main"
+DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.120.0-1.36.0"
 DEFAULT_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.2.0-825b449"
 DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.120.0"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: main
+  newTag: 1.36.0

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -6,6 +6,6 @@ package images
 const (
 	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250312-f7941911"
 	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.8"
-	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.120.0-main"
+	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.120.0-1.36.0"
 	DefaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.2.0-825b449"
 )

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ var (
 	setupLog           = ctrl.Log.WithName("setup")
 	telemetryNamespace string
 	// TODO: replace with build version based on git revision
-	version = "main"
+	version = "1.36.0"
 
 	// Operator flags
 	certDir                   string

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,10 +1,10 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.36.0
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250312-f7941911
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.8
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.120.0-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.120.0-1.36.0
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.2.0-825b449
 mend:
   language: golang-mod


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump images to 1.36.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
