### PR TITLE
chore: ensure PR titel subject doesn't start with an uppercase character

### DIFF
--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -111,7 +111,9 @@ jobs:
             feat
             fix
             test
-          requireScope: false
+          # ensures the subject doesn't start with an uppercase character
+          subjectPattern: ^(?![A-Z]).+$
+          requireScope: true
 
   pr-prevent-kustomization:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- As agreed with the team, PR titles should conform to conventional commits (https://www.conventionalcommits.org/en/v1.0.0/) since it will be taken as a commit message of the squashed PR

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
