### PR TITLE
feat: add support for URL parameter annotations in scraping

### DIFF
--- a/docs/user/integration/sample-app/deployment/deployment-prometheus.yaml
+++ b/docs/user/integration/sample-app/deployment/deployment-prometheus.yaml
@@ -48,6 +48,7 @@ metadata:
     app.kubernetes.io/name: sample-app-prom
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/param_format: "prometheus"
 spec:
   selector:
     app.kubernetes.io/name: sample-app-prom

--- a/docs/user/integration/sample-app/main.go
+++ b/docs/user/integration/sample-app/main.go
@@ -271,6 +271,8 @@ func run() error {
 	return nil
 }
 
+// newURLParamCounterMiddleware is a middleware that counts the number of URL parameters passed to the /metrics request.
+// It is used to test prometheus.io/param_{name}={value} annotation.
 func newURLParamCounterMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		urlParams := r.URL.Query()

--- a/docs/user/integration/sample-app/main.go
+++ b/docs/user/integration/sample-app/main.go
@@ -81,7 +81,7 @@ func initMetrics() error {
 	}
 
 	requestURLParamsMeter, err = meter.Int64Counter(
-		"request.url_params",
+		"promhttp.metric.handler.requests.url_params",
 		metric.WithDescription("Number of URL parameters passed to the /metrics request."),
 		metric.WithUnit("{utl_params}"),
 	)

--- a/docs/user/integration/sample-app/main.go
+++ b/docs/user/integration/sample-app/main.go
@@ -28,8 +28,9 @@ const (
 var (
 	logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
-	hdErrorsMeter  metric.Int64Counter
-	cpuEnergyMeter metric.Float64Histogram
+	hdErrorsMeter         metric.Int64Counter
+	cpuEnergyMeter        metric.Float64Histogram
+	requestURLParamsMeter metric.Int64Counter
 
 	hdErrorsAttributeSda = attribute.String("device", "/dev/sda")
 	hdErrorsAttributeSdb = attribute.String("device", "/dev/sdb")
@@ -78,6 +79,16 @@ func initMetrics() error {
 	); err != nil {
 		return fmt.Errorf("error creating cpu.temperature.celsius gauge: %w", err)
 	}
+
+	requestURLParamsMeter, err = meter.Int64Counter(
+		"request.url_params",
+		metric.WithDescription("Number of URL parameters passed to the /metrics request."),
+		metric.WithUnit("{utl_params}"),
+	)
+	if err != nil {
+		return fmt.Errorf("error creating request.url_params counter: %w", err)
+	}
+
 	return nil
 }
 
@@ -245,7 +256,11 @@ func run() error {
 	http.Handle("/", wrappedForwardHandler)
 
 	// Register metrics endpoint in case a prometheus exporter is used
-	http.Handle("/metrics", otelhttp.NewHandler(promhttp.Handler(), "metrics"))
+	http.Handle("/metrics", otelhttp.NewHandler(
+		newURLParamCounterMiddleware(
+			promhttp.Handler(),
+		),
+		"metrics"))
 
 	//Start the HTTP server
 	logger.Info("Starting server on port " + strconv.Itoa(serverPort))
@@ -254,6 +269,20 @@ func run() error {
 		return fmt.Errorf("error starting server: %w", err)
 	}
 	return nil
+}
+
+func newURLParamCounterMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		urlParams := r.URL.Query()
+		for name := range urlParams {
+			requestURLParamsMeter.Add(r.Context(), 1,
+				metric.WithAttributes(
+					attribute.String("name", name),
+				),
+			)
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func main() {

--- a/docs/user/integration/sample-app/main.go
+++ b/docs/user/integration/sample-app/main.go
@@ -82,11 +82,11 @@ func initMetrics() error {
 
 	requestURLParamsMeter, err = meter.Int64Counter(
 		"promhttp.metric.handler.requests.url_params",
-		metric.WithDescription("Number of URL parameters passed to the /metrics request."),
-		metric.WithUnit("{utl_params}"),
+		metric.WithDescription("Total number of requests to the /metrics endpoint with URL parameters."),
+		metric.WithUnit("{requests}"),
 	)
 	if err != nil {
-		return fmt.Errorf("error creating request.url_params counter: %w", err)
+		return fmt.Errorf("error creating promhttp.metric.handler.requests.url_params counter: %w", err)
 	}
 
 	return nil

--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -216,9 +216,10 @@ type RelabelConfig struct {
 type RelabelAction string
 
 const (
-	Replace RelabelAction = "replace"
-	Keep    RelabelAction = "keep"
-	Drop    RelabelAction = "drop"
+	Replace  RelabelAction = "replace"
+	Keep     RelabelAction = "keep"
+	Drop     RelabelAction = "drop"
+	LabelMap RelabelAction = "labelmap"
 )
 
 type Processors struct {

--- a/internal/otelcollector/config/metric/agent/testdata/config_compatibility_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_compatibility_enabled.yaml
@@ -165,6 +165,9 @@ receivers:
                       target_label: __address__
                       replacement: $$1:$$2
                       action: replace
+                    - regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                   kubernetes_sd_configs:
                     - role: pod
                       selectors:
@@ -201,6 +204,9 @@ receivers:
                       regex: (https?)
                       target_label: __scheme__
                       action: replace
+                    - regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                     - source_labels: [__scheme__]
                       regex: (https)
                       action: drop

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -173,6 +173,9 @@ receivers:
                       target_label: __address__
                       replacement: $$1:$$2
                       action: replace
+                    - regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                   kubernetes_sd_configs:
                     - role: pod
                       selectors:
@@ -209,6 +212,9 @@ receivers:
                       regex: (https?)
                       target_label: __scheme__
                       action: replace
+                    - regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                     - source_labels: [__scheme__]
                       regex: (https)
                       action: drop
@@ -257,6 +263,9 @@ receivers:
                       regex: (https?)
                       target_label: __scheme__
                       action: replace
+                    - regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                     - source_labels: [__scheme__]
                       regex: (http)
                       action: drop

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -162,6 +162,9 @@ receivers:
                       target_label: __address__
                       replacement: $$1:$$2
                       action: replace
+                    - regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                   kubernetes_sd_configs:
                     - role: pod
                       selectors:
@@ -198,6 +201,9 @@ receivers:
                       regex: (https?)
                       target_label: __scheme__
                       action: replace
+                    - regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                      replacement: __param_$1
+                      action: labelmap
                     - source_labels: [__scheme__]
                       regex: (https)
                       action: drop


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- add support for `prometheus.io/param_{name}: {value}` annotation for setting URL params when scarping
- update `sample-app` to record such requests, to be used by E2E tests in a follow-up PR

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1938

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
