### PR TITLE
chore: use latest sample-app in E2E tests

### DIFF
--- a/test/testkit/mocks/prommetricgen/metric_producer.go
+++ b/test/testkit/mocks/prommetricgen/metric_producer.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	metricProducerImage = "europe-docker.pkg.dev/kyma-project/prod/samples/telemetry-sample-app:v20250214-f68343ee"
+	metricProducerImage = "europe-docker.pkg.dev/kyma-project/prod/samples/telemetry-sample-app:v20250313-27827878"
 )
 
 type Metric struct {
@@ -38,7 +38,7 @@ var (
 	}
 	MetricHardDiskErrorsTotal = Metric{
 		Type:   pmetric.MetricTypeSum,
-		Name:   "hd_errors_total",
+		Name:   "hd_errors_total_total",
 		Labels: []string{"device"},
 	}
 	MetricCPUEnergyHistogram = Metric{

--- a/test/testkit/mocks/prommetricgen/metric_producer.go
+++ b/test/testkit/mocks/prommetricgen/metric_producer.go
@@ -34,16 +34,16 @@ const (
 var (
 	MetricCPUTemperature = Metric{
 		Type: pmetric.MetricTypeGauge,
-		Name: "cpu_temperature_celsius",
+		Name: "cpu.temperature.celsius",
 	}
 	MetricHardDiskErrorsTotal = Metric{
 		Type:   pmetric.MetricTypeSum,
-		Name:   "hd_errors_total_total",
+		Name:   "hd.errors_total",
 		Labels: []string{"device"},
 	}
 	MetricCPUEnergyHistogram = Metric{
 		Type:   pmetric.MetricTypeHistogram,
-		Name:   "cpu_energy_watt",
+		Name:   "cpu.energy.watt",
 		Labels: []string{"core"},
 	}
 	MetricNames = []string{

--- a/test/testkit/mocks/prommetricgen/metric_producer.go
+++ b/test/testkit/mocks/prommetricgen/metric_producer.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	metricProducerImage = "europe-docker.pkg.dev/kyma-project/prod/samples/telemetry-sample-app:v20250313-27827878"
+	metricProducerImage = "europe-docker.pkg.dev/kyma-project/prod/samples/telemetry-sample-app:latest"
 )
 
 type Metric struct {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

-  Use latest sample-app in E2E tests
- Fix metric names to be compatible with the latest with the latest OTel SDK

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
