### PR TITLE
chore: exclude sample-app and all docs from security scanning

### DIFF
--- a/internal/tools/populateimages/main.go
+++ b/internal/tools/populateimages/main.go
@@ -187,11 +187,11 @@ func generateSecScanConfig(data map[string]string) error {
 		BDBA:       imgs,
 		Mend: mend{
 			Language: "golang-mod",
-			Exclude:  []string{"**/mocks/**", "**/stubs/**", "**/test/**", "**/*_test.go"},
+			Exclude:  []string{"**/mocks/**", "**/stubs/**", "**/test/**", "**/*_test.go", "docs/**"},
 		},
 		CheckmarxOne: checkmarxOne{
 			Preset:  "go-default",
-			Exclude: []string{"**/mocks/**", "**/stubs/**", "**/test/**", "**/*_test.go"},
+			Exclude: []string{"**/mocks/**", "**/stubs/**", "**/test/**", "**/*_test.go", "docs/**"},
 		},
 	}
 

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -13,6 +13,7 @@ mend:
     - '**/stubs/**'
     - '**/test/**'
     - '**/*_test.go'
+    - 'docs/**'
 checkmarx-one:
   preset: go-default
   exclude:
@@ -20,3 +21,4 @@ checkmarx-one:
     - '**/stubs/**'
     - '**/test/**'
     - '**/*_test.go'
+    - 'docs/**'

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -13,7 +13,7 @@ mend:
     - '**/stubs/**'
     - '**/test/**'
     - '**/*_test.go'
-    - 'docs/**'
+    - docs/**
 checkmarx-one:
   preset: go-default
   exclude:
@@ -21,4 +21,4 @@ checkmarx-one:
     - '**/stubs/**'
     - '**/test/**'
     - '**/*_test.go'
-    - 'docs/**'
+    - docs/**


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- exclude sample-app and all docs from security scanning

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
