### PR TITLE
feat: add tolerations to DaemonSet pod specs

### DIFF
--- a/internal/resources/common/pod_spec.go
+++ b/internal/resources/common/pod_spec.go
@@ -32,6 +32,21 @@ var (
 	}
 )
 
+var (
+	// CriticalDaemonSetTolerations is to be used for critical DaemonSets (e.g. log or metric collectors) that must run on all nodes,
+	// even on nodes with NoSchedule or NoExecute taints.
+	CriticalDaemonSetTolerations = []corev1.Toleration{
+		{
+			Effect:   corev1.TaintEffectNoExecute,
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		},
+	}
+)
+
 type PodSpecOption func(*corev1.PodSpec)
 
 type ContainerOption func(*corev1.Container)
@@ -79,6 +94,12 @@ func WithPriorityClass(priorityClassName string) PodSpecOption {
 func WithTerminationGracePeriodSeconds(seconds int64) PodSpecOption {
 	return func(pod *corev1.PodSpec) {
 		pod.TerminationGracePeriodSeconds = &seconds
+	}
+}
+
+func WithTolerations(tolerations []corev1.Toleration) PodSpecOption {
+	return func(pod *corev1.PodSpec) {
+		pod.Tolerations = append(pod.Tolerations, tolerations...)
 	}
 }
 

--- a/internal/resources/fluentbit/resources.go
+++ b/internal/resources/fluentbit/resources.go
@@ -298,6 +298,7 @@ func (aad *AgentApplierDeleter) makeDaemonSet(namespace string, checksum string)
 				},
 				Spec: commonresources.MakePodSpec(LogAgentName,
 					commonresources.WithPriorityClass(aad.priorityClassName),
+					commonresources.WithTolerations(commonresources.CriticalDaemonSetTolerations),
 					commonresources.WithVolumes(aad.fluentBitVolumes()),
 					commonresources.WithContainer("fluent-bit", aad.fluentBitImage,
 						commonresources.WithCapabilities("FOWNER"),

--- a/internal/resources/fluentbit/testdata/fluentbit.yaml
+++ b/internal/resources/fluentbit/testdata/fluentbit.yaml
@@ -360,6 +360,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-fluent-bit
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           name: telemetry-fluent-bit

--- a/internal/resources/otelcollector/testdata/log-agent.yaml
+++ b/internal/resources/otelcollector/testdata/log-agent.yaml
@@ -154,6 +154,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-log-agent
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:

--- a/internal/resources/otelcollector/testdata/metric-agent.yaml
+++ b/internal/resources/otelcollector/testdata/metric-agent.yaml
@@ -153,6 +153,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-metric-agent
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- add tolerations to Fluent Bit, OTel Collector metric and log agents

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/1962

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
