### PR TITLE
feat: expose container restarts metric when runtime input for container is enabled 

### DIFF
--- a/docs/user/04-metrics.md
+++ b/docs/user/04-metrics.md
@@ -477,6 +477,7 @@ If container metrics are enabled, the following metrics are collected:
   - `k8s.container.cpu_limit`
   - `k8s.container.memory_request`
   - `k8s.container.memory_limit`
+  - `k8s.container.restarts`
 
 If Node metrics are enabled, the following metrics are collected:
 

--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -76,7 +76,6 @@ type K8sClusterDefaultMetricsToDrop struct {
 	K8sContainerStorageLimit            MetricConfig `yaml:"k8s.container.storage_limit"`
 	K8sContainerEphemeralStorageRequest MetricConfig `yaml:"k8s.container.ephemeralstorage_request"`
 	K8sContainerEphemeralStorageLimit   MetricConfig `yaml:"k8s.container.ephemeralstorage_limit"`
-	K8sContainerRestarts                MetricConfig `yaml:"k8s.container.restarts"`
 	K8sContainerReady                   MetricConfig `yaml:"k8s.container.ready"`
 	// Disable Namespace metrics by default
 	K8sNamespacePhase MetricConfig `yaml:"k8s.namespace.phase"`
@@ -134,6 +133,7 @@ type K8sClusterContainerMetricsToDrop struct {
 	K8sContainerCPULimit      MetricConfig `yaml:"k8s.container.cpu_limit"`
 	K8sContainerMemoryRequest MetricConfig `yaml:"k8s.container.memory_request"`
 	K8sContainerMemoryLimit   MetricConfig `yaml:"k8s.container.memory_limit"`
+	K8sContainerRestarts      MetricConfig `yaml:"k8s.container.restarts"`
 }
 
 type K8sClusterReceiver struct {

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -83,7 +83,6 @@ func makeK8sClusterMetricsToDrop(runtimeResources runtimeResourcesEnabled) K8sCl
 		K8sContainerStorageLimit:            MetricConfig{Enabled: false},
 		K8sContainerEphemeralStorageRequest: MetricConfig{Enabled: false},
 		K8sContainerEphemeralStorageLimit:   MetricConfig{Enabled: false},
-		K8sContainerRestarts:                MetricConfig{Enabled: false},
 		K8sContainerReady:                   MetricConfig{Enabled: false},
 		K8sNamespacePhase:                   MetricConfig{Enabled: false},
 		K8sHPACurrentReplicas:               MetricConfig{Enabled: false},
@@ -113,6 +112,7 @@ func makeK8sClusterMetricsToDrop(runtimeResources runtimeResourcesEnabled) K8sCl
 			K8sContainerCPULimit:      MetricConfig{false},
 			K8sContainerMemoryRequest: MetricConfig{false},
 			K8sContainerMemoryLimit:   MetricConfig{false},
+			K8sContainerRestarts:      MetricConfig{false},
 		}
 	}
 

--- a/internal/otelcollector/config/metric/agent/receivers_test.go
+++ b/internal/otelcollector/config/metric/agent/receivers_test.go
@@ -303,7 +303,6 @@ func getExpectedK8sClusterMetricsToDrop(disabledMetricResource metricResource) K
 		K8sContainerStorageLimit:            MetricConfig{Enabled: false},
 		K8sContainerEphemeralStorageRequest: MetricConfig{Enabled: false},
 		K8sContainerEphemeralStorageLimit:   MetricConfig{Enabled: false},
-		K8sContainerRestarts:                MetricConfig{Enabled: false},
 		K8sContainerReady:                   MetricConfig{Enabled: false},
 		K8sNamespacePhase:                   MetricConfig{Enabled: false},
 		K8sHPACurrentReplicas:               MetricConfig{Enabled: false},
@@ -325,6 +324,7 @@ func getExpectedK8sClusterMetricsToDrop(disabledMetricResource metricResource) K
 		K8sContainerCPULimit:      MetricConfig{false},
 		K8sContainerMemoryRequest: MetricConfig{false},
 		K8sContainerMemoryLimit:   MetricConfig{false},
+		K8sContainerRestarts:      MetricConfig{false},
 	}
 	statefulMetricsToDrop := &K8sClusterStatefulSetMetricsToDrop{
 		K8sStatefulSetCurrentPods: MetricConfig{false},

--- a/internal/otelcollector/config/metric/agent/testdata/config_compatibility_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_compatibility_enabled.yaml
@@ -101,8 +101,6 @@ receivers:
                         enabled: false
                     k8s.container.ephemeralstorage_limit:
                         enabled: false
-                    k8s.container.restarts:
-                        enabled: false
                     k8s.container.ready:
                         enabled: false
                     k8s.namespace.phase:

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -109,8 +109,6 @@ receivers:
                         enabled: false
                     k8s.container.ephemeralstorage_limit:
                         enabled: false
-                    k8s.container.restarts:
-                        enabled: false
                     k8s.container.ready:
                         enabled: false
                     k8s.namespace.phase:

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -98,8 +98,6 @@ receivers:
                         enabled: false
                     k8s.container.ephemeralstorage_limit:
                         enabled: false
-                    k8s.container.restarts:
-                        enabled: false
                     k8s.container.ready:
                         enabled: false
                     k8s.namespace.phase:

--- a/test/testkit/metrics/runtime/container.go
+++ b/test/testkit/metrics/runtime/container.go
@@ -24,6 +24,7 @@ var (
 		"k8s.container.cpu_limit",
 		"k8s.container.memory_request",
 		"k8s.container.memory_limit",
+		"k8s.container.restarts",
 	}
 
 	ContainerMetricsResourceAttributes = []string{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- When runtime input for containers is enabled, the metric `k8s.container.restarts` will now be delivered.

Changes refer to particular issues, PRs or documents:

- #1882  

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
