### PR TITLE
chore: update Fluent Bit image in cache to version 4.0.0

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,3 +1,3 @@
 images:
-  - source: "fluent/fluent-bit@sha256:d6dec000c4929a439562525728c708f6e99800d7ddc82efd6aa4f45f3a20b562"
-    tag: "3.2.10" # used by the kyma telemetry module 
+  - source: "fluent/fluent-bit@sha256:3cabd4bd59596931cd99d812c99200e12fa08758fd08dfb0549c96ae97a70ddd"
+    tag: "4.0.0" # used by the kyma telemetry module


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump fluent-bit image in cache to version 4.0.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
