### PR TITLE
chore: bump fluent-bit image version to 4.0.0

### DIFF
--- a/.env
+++ b/.env
@@ -14,8 +14,8 @@ ENV_ISTIO_VERSION=1.17.0
 ENV_GORELEASER_VERSION=v1.23.0
 
 ## Default Docker Images
-DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250326-a6475925"
-DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.10"
+DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250416-c279a85d"
+DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.0"
 DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.123.0-main"
 DEFAULT_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.2.0-825b449"
 DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.123.0"

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -4,8 +4,8 @@
 package images
 
 const (
-	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250326-a6475925"
-	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.10"
+	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250416-c279a85d"
+	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.0"
 	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.123.0-main"
 	DefaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.2.0-825b449"
 )

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,8 +2,8 @@ module-name: telemetry
 kind: kyma
 bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250326-a6475925
-  - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:3.2.10
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250416-c279a85d
+  - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.0
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.123.0-main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.2.0-825b449
 mend:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump  Fluent Bit version to 4.0.0
- Bump directory-size-exporter version to v20250416-c279a85d
 

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/pull/2066

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
