### PR TITLE
chore: use synced image for k3s

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ### Default Environment Variables
 ## General
-ENV_K3S_K8S_VERSION=1.31.6 # refers to the version of kubernetes used in K3s
+ENV_K3S_IMAGE=europe-docker.pkg.dev/kyma-project/prod/external/rancher/k3s:v1.31.6-k3s1 # refers to the image used by k3d
 ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main # Image URL to use all building/pushing image targets
 
 ## Gardener

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include .env
 
 # Environment Variables
 IMG ?= $(ENV_IMG)
-K3S_K8S_VERSION ?= $(ENV_K3S_K8S_VERSION)
+K3S_IMAGE ?= $(ENV_K3S_IMAGE)
 
 # Operating system architecture
 OS_ARCH ?= $(shell uname -m)

--- a/hack/make/provision.mk
+++ b/hack/make/provision.mk
@@ -1,7 +1,7 @@
 ##@ k3d
 .PHONY: provision-k3d
 provision-k3d: $(K3D)
-	$(K3D) cluster create --image rancher/k3s:v$(strip $(K3S_IMAGE))-k3s1 --config .k3d-kyma.yaml
+	$(K3D) cluster create --image $(K3S_IMAGE)) --config .k3d-kyma.yaml
 	kubectl create ns kyma-system
 
 .PHONY: provision-k3d-istio

--- a/hack/make/provision.mk
+++ b/hack/make/provision.mk
@@ -1,7 +1,7 @@
 ##@ k3d
 .PHONY: provision-k3d
 provision-k3d: $(K3D)
-	$(K3D) cluster create --image $(K3S_IMAGE)) --config .k3d-kyma.yaml
+	$(K3D) cluster create --image $(K3S_IMAGE) --config .k3d-kyma.yaml
 	kubectl create ns kyma-system
 
 .PHONY: provision-k3d-istio

--- a/hack/make/provision.mk
+++ b/hack/make/provision.mk
@@ -1,7 +1,7 @@
 ##@ k3d
 .PHONY: provision-k3d
 provision-k3d: $(K3D)
-	$(K3D) cluster create --image rancher/k3s:v$(strip $(K3S_K8S_VERSION))-k3s1 --config .k3d-kyma.yaml
+	$(K3D) cluster create --image rancher/k3s:v$(strip $(K3S_IMAGE))-k3s1 --config .k3d-kyma.yaml
 	kubectl create ns kyma-system
 
 .PHONY: provision-k3d-istio


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- to avoid rate limiting from docker use synced k3s image

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
