### PR TITLE
fix: logs with only a trace_id field are causing errors in operator chain

### DIFF
--- a/internal/otelcollector/config/log/agent/receivers.go
+++ b/internal/otelcollector/config/log/agent/receivers.go
@@ -314,15 +314,17 @@ func makeRemoveSpanID() Operator {
 		ID:     "remove-span-id",
 		Type:   "remove",
 		Field:  attributeSpanID,
+		IfExpr: "attributes.span_id != nil",
 		Output: "remove-trace-flags",
 	}
 }
 
 func makeRemoveTraceFlags() Operator {
 	return Operator{
-		ID:    "remove-trace-flags",
-		Type:  "remove",
-		Field: attributeTraceFlags,
+		ID:     "remove-trace-flags",
+		Type:   "remove",
+		IfExpr: "attributes.trace_flags != nil",
+		Field:  attributeTraceFlags,
 	}
 }
 

--- a/internal/otelcollector/config/log/agent/receivers_test.go
+++ b/internal/otelcollector/config/log/agent/receivers_test.go
@@ -315,6 +315,7 @@ func TestMakeRemoveSpanID(t *testing.T) {
 		ID:     "remove-span-id",
 		Type:   "remove",
 		Field:  attributeSpanID,
+		IfExpr: "attributes.span_id != nil",
 		Output: "remove-trace-flags",
 	}
 	assert.Equal(t, expectedSP, sp)
@@ -323,9 +324,10 @@ func TestMakeRemoveSpanID(t *testing.T) {
 func TestMakeRemoveTraceFlags(t *testing.T) {
 	sp := makeRemoveTraceFlags()
 	expectedSP := Operator{
-		ID:    "remove-trace-flags",
-		Type:  "remove",
-		Field: attributeTraceFlags,
+		ID:     "remove-trace-flags",
+		Type:   "remove",
+		Field:  attributeTraceFlags,
+		IfExpr: "attributes.trace_flags != nil",
 	}
 	assert.Equal(t, expectedSP, sp)
 }

--- a/internal/otelcollector/config/log/agent/testdata/config.yaml
+++ b/internal/otelcollector/config/log/agent/testdata/config.yaml
@@ -133,9 +133,11 @@ receivers:
               type: remove
               field: attributes.span_id
               output: remove-trace-flags
+              if: attributes.span_id != nil
             - id: remove-trace-flags
               type: remove
               field: attributes.trace_flags
+              if: attributes.trace_flags != nil
             - id: noop
               type: noop
 processors:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Having a log with only a "trace_id" attribute leads to an exception in the remove operator for span_id and trace_flags
- PR fixes this by adding additional if expressions

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
