### PR TITLE
fix: remove level attribute after parsing, support log.level as well

### DIFF
--- a/internal/otelcollector/config/log/agent/config.go
+++ b/internal/otelcollector/config/log/agent/config.go
@@ -31,7 +31,7 @@ type FileLog struct {
 
 type Operator struct {
 	ID                      string            `yaml:"id,omitempty"`
-	Type                    string            `yaml:"type,omitempty"`
+	Type                    OperatorType      `yaml:"type,omitempty"`
 	AddMetadataFromFilePath *bool             `yaml:"add_metadata_from_file_path,omitempty"`
 	Format                  string            `yaml:"format,omitempty"`
 	From                    string            `yaml:"from,omitempty"`
@@ -45,10 +45,24 @@ type Operator struct {
 	TraceFlags              OperatorAttribute `yaml:"trace_flags,omitempty"`
 	Regex                   string            `yaml:"regex,omitempty"`
 	Trace                   TraceAttribute    `yaml:"trace,omitempty"`
-	Routes                  []Router          `yaml:"routes,omitempty"`
+	Routes                  []Route           `yaml:"routes,omitempty"`
 	Default                 string            `yaml:"default,omitempty"`
 	Output                  string            `yaml:"output,omitempty"`
 }
+
+type OperatorType string
+
+const (
+	Move           OperatorType = "move"
+	SeverityParser OperatorType = "severity_parser"
+	RegexParser    OperatorType = "regex_parser"
+	Remove         OperatorType = "remove"
+	Router         OperatorType = "router"
+	TraceParser    OperatorType = "trace_parser"
+	Noop           OperatorType = "noop"
+	JsonParser     OperatorType = "json_parser"
+	Container      OperatorType = "container"
+)
 
 type TraceAttribute struct {
 	TraceID    OperatorAttribute `yaml:"trace_id,omitempty"`
@@ -56,7 +70,7 @@ type TraceAttribute struct {
 	TraceFlags OperatorAttribute `yaml:"trace_flags,omitempty"`
 }
 
-type Router struct {
+type Route struct {
 	Expression string `yaml:"expr,omitempty"`
 	Output     string `yaml:"output,omitempty"`
 }

--- a/internal/otelcollector/config/log/agent/receivers.go
+++ b/internal/otelcollector/config/log/agent/receivers.go
@@ -8,6 +8,7 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/namespaces"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config"
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/ottlexpr"
 	commonresources "github.com/kyma-project/telemetry-manager/internal/resources/common"
 	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
 )
@@ -18,10 +19,17 @@ const (
 	// Time after which logs will not be discarded. Retrying never stops if value is 0.
 	maxElapsedTime        = "300s"
 	traceParentExpression = "^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$"
-	attributeTraceID      = "attributes.trace_id"
-	attributeSpanID       = "attributes.span_id"
-	attributeTraceFlags   = "attributes.trace_flags"
-	attributeTraceParent  = "attributes.traceparent"
+
+	attributeKeyLevel        = "level"
+	attributeKeyLogLevel     = "log.level"
+	attributeKeyStream       = "stream"
+	attributeKeyMsg          = "msg"
+	attributeKeyMessage      = "message"
+	attributeKeyTraceID      = "trace_id"
+	attributeKeySpanID       = "span_id"
+	attributeKeyTraceFlags   = "trace_flags"
+	attributeKeyTraceParent  = "traceparent"
+	attributeKeySeverityText = "severityText"
 )
 
 func makeFileLogReceiver(logpipeline telemetryv1alpha1.LogPipeline) *FileLog {
@@ -136,7 +144,10 @@ func makeOperators(logPipeline telemetryv1alpha1.LogPipeline) []Operator {
 	operators = append(operators,
 		makeMoveMessageToBody(),
 		makeMoveMsgToBody(),
-		makeSeverityParser(),
+		makeSeverityParserFromLevel(),
+		makeRemoveLevel(),
+		makeSeverityParserFromLogLevel(),
+		makeRemoveLogLevel(),
 		makeTraceRouter(),
 		makeTraceParentParser(),
 		makeTraceParser(),
@@ -154,7 +165,7 @@ func makeOperators(logPipeline telemetryv1alpha1.LogPipeline) []Operator {
 func makeContainerParser() Operator {
 	return Operator{
 		ID:                      "containerd-parser",
-		Type:                    "container",
+		Type:                    Container,
 		AddMetadataFromFilePath: ptr.To(true),
 		Format:                  "containerd",
 	}
@@ -164,18 +175,18 @@ func makeContainerParser() Operator {
 func makeMoveToLogStream() Operator {
 	return Operator{
 		ID:     "move-to-log-stream",
-		Type:   "move",
-		From:   "attributes.stream",
-		To:     "attributes[\"log.iostream\"]",
-		IfExpr: "attributes.stream != nil",
+		Type:   Move,
+		From:   ottlexpr.Attribute(attributeKeyStream),
+		To:     ottlexpr.Attribute("log.iostream"),
+		IfExpr: ottlexpr.AttributeNotNil(attributeKeyStream),
 	}
 }
 
 func makeDropAttributeLogTag() Operator {
 	return Operator{
 		ID:    "drop-attribute-log-tag",
-		Type:  "remove",
-		Field: "attributes[\"logtag\"]",
+		Type:  Remove,
+		Field: ottlexpr.Attribute("logtag"),
 	}
 }
 
@@ -185,7 +196,7 @@ func makeJSONParser() Operator {
 
 	return Operator{
 		ID:        "json-parser",
-		Type:      "json_parser",
+		Type:      JsonParser,
 		ParseFrom: "body",
 		ParseTo:   "attributes",
 		IfExpr:    fmt.Sprintf("body matches '%s'", regexPattern),
@@ -196,9 +207,9 @@ func makeJSONParser() Operator {
 func makeMoveBodyToLogOriginal() Operator {
 	return Operator{
 		ID:   "move-body-to-attributes-log-original",
-		Type: "move",
+		Type: Move,
 		From: "body",
-		To:   "attributes[\"log.original\"]",
+		To:   ottlexpr.Attribute("log.original"),
 	}
 }
 
@@ -206,10 +217,10 @@ func makeMoveBodyToLogOriginal() Operator {
 func makeMoveMessageToBody() Operator {
 	return Operator{
 		ID:     "move-message-to-body",
-		Type:   "move",
-		From:   "attributes.message",
+		Type:   Move,
+		From:   ottlexpr.Attribute(attributeKeyMessage),
 		To:     "body",
-		IfExpr: "attributes.message != nil",
+		IfExpr: ottlexpr.AttributeNotNil(attributeKeyMessage),
 	}
 }
 
@@ -217,35 +228,65 @@ func makeMoveMessageToBody() Operator {
 func makeMoveMsgToBody() Operator {
 	return Operator{
 		ID:     "move-msg-to-body",
-		Type:   "move",
-		From:   "attributes.msg",
+		Type:   Move,
+		From:   ottlexpr.Attribute(attributeKeyMsg),
 		To:     "body",
-		IfExpr: "attributes.msg != nil",
+		IfExpr: ottlexpr.AttributeNotNil(attributeKeyMsg),
 	}
 }
 
-// set the severity level
-func makeSeverityParser() Operator {
+// parse severity from level attribute
+func makeSeverityParserFromLevel() Operator {
 	return Operator{
-		ID:        "severity-parser",
-		Type:      "severity_parser",
-		ParseFrom: "attributes.level",
-		IfExpr:    "attributes.level != nil",
+		ID:        "parse-level",
+		Type:      SeverityParser,
+		ParseFrom: ottlexpr.Attribute(attributeKeyLevel),
+		IfExpr:    ottlexpr.JoinWithAnd(ottlexpr.AttributeNil(attributeKeySeverityText), ottlexpr.AttributeNotNil(attributeKeyLevel)),
+	}
+}
+
+// Remove level attribute after parsing severity
+func makeRemoveLevel() Operator {
+	return Operator{
+		ID:     "remove-level",
+		Type:   Remove,
+		Field:  ottlexpr.Attribute(attributeKeyLevel),
+		IfExpr: ottlexpr.JoinWithAnd(ottlexpr.AttributeNotNil(attributeKeySeverityText), ottlexpr.AttributeNotNil(attributeKeyLevel)),
+	}
+}
+
+// parse severity from log level attribute
+func makeSeverityParserFromLogLevel() Operator {
+	return Operator{
+		ID:        "parse-log-level",
+		Type:      SeverityParser,
+		ParseFrom: ottlexpr.Attribute(attributeKeyLogLevel),
+		IfExpr:    ottlexpr.JoinWithAnd(ottlexpr.AttributeNil(attributeKeySeverityText), ottlexpr.AttributeNotNil(attributeKeyLogLevel)),
+	}
+}
+
+// Remove log level attribute after parsing severity
+func makeRemoveLogLevel() Operator {
+	return Operator{
+		ID:     "remove-log-level",
+		Type:   Remove,
+		Field:  ottlexpr.Attribute(attributeKeyLogLevel),
+		IfExpr: ottlexpr.JoinWithAnd(ottlexpr.AttributeNotNil(attributeKeySeverityText), ottlexpr.AttributeNotNil(attributeKeyLogLevel)),
 	}
 }
 
 func makeTraceRouter() Operator {
 	return Operator{
 		ID:      "trace-router",
-		Type:    "router",
+		Type:    Router,
 		Default: "noop",
-		Routes: []Router{
+		Routes: []Route{
 			{
-				Expression: fmt.Sprintf("%s != nil", attributeTraceID),
+				Expression: ottlexpr.AttributeNotNil(attributeKeyTraceID),
 				Output:     "trace-parser",
 			},
 			{
-				Expression: fmt.Sprintf("%s == nil and %s != nil and attributes.traceparent matches '%s'", attributeTraceID, attributeTraceParent, traceParentExpression),
+				Expression: ottlexpr.JoinWithAnd(ottlexpr.AttributeNil(attributeKeyTraceID), ottlexpr.AttributeNotNil(attributeKeyTraceParent), fmt.Sprintf("%s matches '%s'", ottlexpr.Attribute(attributeKeyTraceParent), traceParentExpression)),
 				Output:     "trace-parent-parser",
 			},
 		},
@@ -256,16 +297,16 @@ func makeTraceRouter() Operator {
 func makeTraceParser() Operator {
 	return Operator{
 		ID:     "trace-parser",
-		Type:   "trace_parser",
+		Type:   TraceParser,
 		Output: "remove-trace-id",
 		TraceID: OperatorAttribute{
-			ParseFrom: attributeTraceID,
+			ParseFrom: ottlexpr.Attribute(attributeKeyTraceID),
 		},
 		SpanID: OperatorAttribute{
-			ParseFrom: attributeSpanID,
+			ParseFrom: ottlexpr.Attribute(attributeKeySpanID),
 		},
 		TraceFlags: OperatorAttribute{
-			ParseFrom: attributeTraceFlags,
+			ParseFrom: ottlexpr.Attribute(attributeKeyTraceFlags),
 		},
 	}
 }
@@ -273,19 +314,19 @@ func makeTraceParser() Operator {
 func makeTraceParentParser() Operator {
 	return Operator{
 		ID:        "trace-parent-parser",
-		Type:      "regex_parser",
+		Type:      RegexParser,
 		Regex:     traceParentExpression,
-		ParseFrom: attributeTraceParent,
+		ParseFrom: ottlexpr.Attribute(attributeKeyTraceParent),
 		Output:    "remove-trace-parent",
 		Trace: TraceAttribute{
 			TraceID: OperatorAttribute{
-				ParseFrom: attributeTraceID,
+				ParseFrom: ottlexpr.Attribute(attributeKeyTraceID),
 			},
 			SpanID: OperatorAttribute{
-				ParseFrom: attributeSpanID,
+				ParseFrom: ottlexpr.Attribute(attributeKeySpanID),
 			},
 			TraceFlags: OperatorAttribute{
-				ParseFrom: attributeTraceFlags,
+				ParseFrom: ottlexpr.Attribute(attributeKeyTraceFlags),
 			},
 		},
 	}
@@ -294,8 +335,8 @@ func makeTraceParentParser() Operator {
 func makeRemoveTraceParent() Operator {
 	return Operator{
 		ID:     "remove-trace-parent",
-		Type:   "remove",
-		Field:  attributeTraceParent,
+		Type:   Remove,
+		Field:  ottlexpr.Attribute(attributeKeyTraceParent),
 		Output: "remove-trace-id",
 	}
 }
@@ -303,8 +344,8 @@ func makeRemoveTraceParent() Operator {
 func makeRemoveTraceID() Operator {
 	return Operator{
 		ID:     "remove-trace-id",
-		Type:   "remove",
-		Field:  attributeTraceID,
+		Type:   Remove,
+		Field:  ottlexpr.Attribute(attributeKeyTraceID),
 		Output: "remove-span-id",
 	}
 }
@@ -312,8 +353,8 @@ func makeRemoveTraceID() Operator {
 func makeRemoveSpanID() Operator {
 	return Operator{
 		ID:     "remove-span-id",
-		Type:   "remove",
-		Field:  attributeSpanID,
+		Type:   Remove,
+		Field:  ottlexpr.Attribute(attributeKeySpanID),
 		Output: "remove-trace-flags",
 	}
 }
@@ -321,8 +362,8 @@ func makeRemoveSpanID() Operator {
 func makeRemoveTraceFlags() Operator {
 	return Operator{
 		ID:    "remove-trace-flags",
-		Type:  "remove",
-		Field: attributeTraceFlags,
+		Type:  Remove,
+		Field: ottlexpr.Attribute(attributeKeyTraceFlags),
 	}
 }
 
@@ -330,6 +371,6 @@ func makeRemoveTraceFlags() Operator {
 func makeNoop() Operator {
 	return Operator{
 		ID:   "noop",
-		Type: "noop",
+		Type: Noop,
 	}
 }

--- a/internal/otelcollector/config/log/agent/testdata/config.yaml
+++ b/internal/otelcollector/config/log/agent/testdata/config.yaml
@@ -63,9 +63,9 @@ receivers:
               format: containerd
             - id: move-to-log-stream
               type: move
-              from: attributes.stream
+              from: attributes["stream"]
               to: attributes["log.iostream"]
-              if: attributes.stream != nil
+              if: attributes["stream"] != nil
             - id: drop-attribute-log-tag
               type: remove
               field: attributes["logtag"]
@@ -80,62 +80,74 @@ receivers:
               to: attributes["log.original"]
             - id: move-message-to-body
               type: move
-              from: attributes.message
+              from: attributes["message"]
               to: body
-              if: attributes.message != nil
+              if: attributes["message"] != nil
             - id: move-msg-to-body
               type: move
-              from: attributes.msg
+              from: attributes["msg"]
               to: body
-              if: attributes.msg != nil
-            - id: severity-parser
+              if: attributes["msg"] != nil
+            - id: parse-level
               type: severity_parser
-              if: attributes.level != nil
-              parse_from: attributes.level
+              if: attributes["severityText"] == nil and attributes["level"] != nil
+              parse_from: attributes["level"]
+            - id: remove-level
+              type: remove
+              if: attributes["severityText"] != nil and attributes["level"] != nil
+              field: attributes["level"]
+            - id: parse-log-level
+              type: severity_parser
+              if: attributes["severityText"] == nil and attributes["log.level"] != nil
+              parse_from: attributes["log.level"]
+            - id: remove-log-level
+              type: remove
+              if: attributes["severityText"] != nil and attributes["log.level"] != nil
+              field: attributes["log.level"]
             - id: trace-router
               type: router
               routes:
-                - expr: attributes.trace_id != nil
+                - expr: attributes["trace_id"] != nil
                   output: trace-parser
-                - expr: attributes.trace_id == nil and attributes.traceparent != nil and attributes.traceparent matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
+                - expr: attributes["trace_id"] == nil and attributes["traceparent"] != nil and attributes["traceparent"] matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
                   output: trace-parent-parser
               default: noop
             - id: trace-parent-parser
               type: regex_parser
-              parse_from: attributes.traceparent
+              parse_from: attributes["traceparent"]
               regex: ^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$
               trace:
                 trace_id:
-                    parse_from: attributes.trace_id
+                    parse_from: attributes["trace_id"]
                 span_id:
-                    parse_from: attributes.span_id
+                    parse_from: attributes["span_id"]
                 trace_flags:
-                    parse_from: attributes.trace_flags
+                    parse_from: attributes["trace_flags"]
               output: remove-trace-parent
             - id: trace-parser
               type: trace_parser
               trace_id:
-                parse_from: attributes.trace_id
+                parse_from: attributes["trace_id"]
               span_id:
-                parse_from: attributes.span_id
+                parse_from: attributes["span_id"]
               trace_flags:
-                parse_from: attributes.trace_flags
+                parse_from: attributes["trace_flags"]
               output: remove-trace-id
             - id: remove-trace-parent
               type: remove
-              field: attributes.traceparent
+              field: attributes["traceparent"]
               output: remove-trace-id
             - id: remove-trace-id
               type: remove
-              field: attributes.trace_id
+              field: attributes["trace_id"]
               output: remove-span-id
             - id: remove-span-id
               type: remove
-              field: attributes.span_id
+              field: attributes["span_id"]
               output: remove-trace-flags
             - id: remove-trace-flags
               type: remove
-              field: attributes.trace_flags
+              field: attributes["trace_flags"]
             - id: noop
               type: noop
 processors:

--- a/internal/otelcollector/config/log/agent/testdata/config_compatibility_enabled.yaml
+++ b/internal/otelcollector/config/log/agent/testdata/config_compatibility_enabled.yaml
@@ -66,9 +66,9 @@ receivers:
               format: containerd
             - id: move-to-log-stream
               type: move
-              from: attributes.stream
+              from: attributes["stream"]
               to: attributes["log.iostream"]
-              if: attributes.stream != nil
+              if: attributes["stream"] != nil
             - id: drop-attribute-log-tag
               type: remove
               field: attributes["logtag"]
@@ -83,62 +83,74 @@ receivers:
               to: attributes["log.original"]
             - id: move-message-to-body
               type: move
-              from: attributes.message
+              from: attributes["message"]
               to: body
-              if: attributes.message != nil
+              if: attributes["message"] != nil
             - id: move-msg-to-body
               type: move
-              from: attributes.msg
+              from: attributes["msg"]
               to: body
-              if: attributes.msg != nil
-            - id: severity-parser
+              if: attributes["msg"] != nil
+            - id: parse-level
               type: severity_parser
-              if: attributes.level != nil
-              parse_from: attributes.level
+              if: attributes["severityText"] == nil and attributes["level"] != nil
+              parse_from: attributes["level"]
+            - id: remove-level
+              type: remove
+              if: attributes["severityText"] != nil and attributes["level"] != nil
+              field: attributes["level"]
+            - id: parse-log-level
+              type: severity_parser
+              if: attributes["severityText"] == nil and attributes["log.level"] != nil
+              parse_from: attributes["log.level"]
+            - id: remove-log-level
+              type: remove
+              if: attributes["severityText"] != nil and attributes["log.level"] != nil
+              field: attributes["log.level"]
             - id: trace-router
               type: router
               routes:
-                - expr: attributes.trace_id != nil
+                - expr: attributes["trace_id"] != nil
                   output: trace-parser
-                - expr: attributes.trace_id == nil and attributes.traceparent != nil and attributes.traceparent matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
+                - expr: attributes["trace_id"] == nil and attributes["traceparent"] != nil and attributes["traceparent"] matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
                   output: trace-parent-parser
               default: noop
             - id: trace-parent-parser
               type: regex_parser
-              parse_from: attributes.traceparent
+              parse_from: attributes["traceparent"]
               regex: ^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$
               trace:
                 trace_id:
-                    parse_from: attributes.trace_id
+                    parse_from: attributes["trace_id"]
                 span_id:
-                    parse_from: attributes.span_id
+                    parse_from: attributes["span_id"]
                 trace_flags:
-                    parse_from: attributes.trace_flags
+                    parse_from: attributes["trace_flags"]
               output: remove-trace-parent
             - id: trace-parser
               type: trace_parser
               trace_id:
-                parse_from: attributes.trace_id
+                parse_from: attributes["trace_id"]
               span_id:
-                parse_from: attributes.span_id
+                parse_from: attributes["span_id"]
               trace_flags:
-                parse_from: attributes.trace_flags
+                parse_from: attributes["trace_flags"]
               output: remove-trace-id
             - id: remove-trace-parent
               type: remove
-              field: attributes.traceparent
+              field: attributes["traceparent"]
               output: remove-trace-id
             - id: remove-trace-id
               type: remove
-              field: attributes.trace_id
+              field: attributes["trace_id"]
               output: remove-span-id
             - id: remove-span-id
               type: remove
-              field: attributes.span_id
+              field: attributes["span_id"]
               output: remove-trace-flags
             - id: remove-trace-flags
               type: remove
-              field: attributes.trace_flags
+              field: attributes["trace_flags"]
             - id: noop
               type: noop
 processors:

--- a/internal/otelcollector/config/ottlexpr/expressions.go
+++ b/internal/otelcollector/config/ottlexpr/expressions.go
@@ -14,16 +14,32 @@ func NamespaceEquals(name string) string {
 }
 
 func ResourceAttributeEquals(key, value string) string {
-	return fmt.Sprintf("resource.attributes[\"%s\"] == \"%s\"", key, value)
+	return fmt.Sprintf("%s == \"%s\"", ResourceAttribute(key), value)
 }
 
 func ResourceAttributeNotEquals(key, value string) string {
-	return fmt.Sprintf("resource.attributes[\"%s\"] != \"%s\"", key, value)
+	return fmt.Sprintf("%s != \"%s\"", ResourceAttribute(key), value)
 }
 
 // ResourceAttributeNotNil returns an OTel expression that checks if the resource attribute exists
 func ResourceAttributeNotNil(key string) string {
-	return fmt.Sprintf("resource.attributes[\"%s\"] != nil", key)
+	return fmt.Sprintf("%s != nil", ResourceAttribute(key))
+}
+
+func ResourceAttribute(key string) string {
+	return fmt.Sprintf("resource.attributes[\"%s\"]", key)
+}
+
+func AttributeNotNil(key string) string {
+	return fmt.Sprintf("%s != nil", Attribute(key))
+}
+
+func AttributeNil(key string) string {
+	return fmt.Sprintf("%s == nil", Attribute(key))
+}
+
+func Attribute(key string) string {
+	return fmt.Sprintf("attributes[\"%s\"]", key)
 }
 
 func NameAttributeEquals(name string) string {

--- a/test/e2e/logs/otel/application/trace_and_severity_parser_test.go
+++ b/test/e2e/logs/otel/application/trace_and_severity_parser_test.go
@@ -100,9 +100,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsOtel, suite.LabelSignalPull, s
 				g.Expect(bodyContent).To(HaveFlatOtelLogs(ContainElement(SatisfyAll(
 					HaveOtelTimestamp(Not(BeEmpty())),
 					HaveObservedTimestamp(Not(BeEmpty())),
-					HaveTraceId(Not(BeEmpty())),
-					HaveSpanId(Not(BeEmpty())),
 					HaveTraceId(Equal("255c2212dd02c02ac59a923ff07aec74")),
+					HaveSpanId(Equal("c5c735f175ad06a6")),
+					HaveTraceFlags(Equal("01")),
+					HaveAttributes(Not(HaveKey("trace_id"))),
+					HaveAttributes(Not(HaveKey("span_id"))),
+					HaveAttributes(Not(HaveKey("trace_flags"))),
+					HaveAttributes(Not(HaveKey("traceparent"))),
 				))))
 			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
@@ -120,31 +124,15 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsOtel, suite.LabelSignalPull, s
 				g.Expect(bodyContent).To(HaveFlatOtelLogs(ContainElement(SatisfyAll(
 					HaveOtelTimestamp(Not(BeEmpty())),
 					HaveObservedTimestamp(Not(BeEmpty())),
-					HaveSpanId(Not(BeEmpty())),
 					HaveTraceId(Equal("80e1afed08e019fc1110464cfa66635c")),
-				))))
-			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
-		})
-
-		It("Should remove trace_id, span_id, trace_flags, and traceparent attributes", func() {
-			Consistently(func(g Gomega) {
-				resp, err := suite.ProxyClient.Get(backendExportURL)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
-
-				bodyContent, err := io.ReadAll(resp.Body)
-				defer resp.Body.Close()
-				g.Expect(err).NotTo(HaveOccurred())
-
-				g.Expect(bodyContent).To(HaveFlatOtelLogs(ContainElement(SatisfyAll(
-					HaveOtelTimestamp(Not(BeEmpty())),
-					HaveObservedTimestamp(Not(BeEmpty())),
+					HaveSpanId(Equal("7a085853722dc6d2")),
+					HaveTraceFlags(Equal("01")),
 					HaveAttributes(Not(HaveKey("trace_id"))),
 					HaveAttributes(Not(HaveKey("span_id"))),
 					HaveAttributes(Not(HaveKey("trace_flags"))),
 					HaveAttributes(Not(HaveKey("traceparent"))),
 				))))
-			}, periodic.ConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
+			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
 		It("Should have span_id log attribute but no trace data, not parsable", func() {
@@ -165,6 +153,32 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsOtel, suite.LabelSignalPull, s
 					HaveAttributes(HaveKey("span_id")),
 				))))
 			}, periodic.ConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
+		})
+
+		It("Should have severityText and severityNumber in logs", func() {
+			Eventually(func(g Gomega) {
+				resp, err := suite.ProxyClient.Get(backendExportURL)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+
+				bodyContent, err := io.ReadAll(resp.Body)
+				defer resp.Body.Close()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(bodyContent).To(HaveFlatOtelLogs(ContainElement(SatisfyAll(
+					HaveTraceId(Equal("80e1afed08e019fc1110464cfa66635c")),
+					HaveSeverityNumber(Equal(6)),
+					HaveSeverityText(Equal("WARN")),
+					aveAttributes(Not(HaveKey("log.level"))),
+				))))
+
+				g.Expect(bodyContent).To(HaveFlatOtelLogs(ContainElement(SatisfyAll(
+					HaveTraceId(Equal("255c2212dd02c02ac59a923ff07aec74")),
+					HaveSeverityNumber(Equal(8)),
+					HaveSeverityText(Equal("INFO")),
+					HaveAttributes(Not(HaveKey("level"))),
+				))))
+			}, periodic.EventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 	})
 })

--- a/test/testkit/matchers/log/log_otel_matchers.go
+++ b/test/testkit/matchers/log/log_otel_matchers.go
@@ -67,3 +67,11 @@ func HaveTraceId(matcher types.GomegaMatcher) types.GomegaMatcher {
 func HaveSpanId(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return gomega.WithTransform(func(fl FlatLogOtel) string { return fl.SpanId }, matcher)
 }
+
+func HaveSeverityText(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.WithTransform(func(fl FlatLogOtel) string { return fl.SeverityText }, matcher)
+}
+
+func HaveSeverityNumber(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.WithTransform(func(fl FlatLogOtel) int { return fl.SeverityNumber }, matcher)
+}

--- a/test/testkit/matchers/log/plog_otel_utils.go
+++ b/test/testkit/matchers/log/plog_otel_utils.go
@@ -16,6 +16,8 @@ type FlatLogOtel struct {
 	Name, ScopeName, ScopeVersion                                string
 	ResourceAttributes, ScopeAttributes, Attributes              map[string]string
 	LogRecordBody, ObservedTimestamp, Timestamp, TraceId, SpanId string
+	SeverityText                                                 string
+	SeverityNumber                                               int
 }
 
 func unmarshalOtelLogs(jsonlMetrics []byte) ([]plog.Logs, error) {
@@ -58,6 +60,8 @@ func flattenOtelLogs(ld plog.Logs) []FlatLogOtel {
 					Timestamp:          lr.Timestamp().String(),
 					TraceId:            lr.TraceID().String(),
 					SpanId:             lr.SpanID().String(),
+					SeverityText:       lr.SeverityText(),
+					SeverityNumber:     int(lr.SeverityNumber()),
 				})
 			}
 		}

--- a/test/testkit/mocks/loggen/log_producer.go
+++ b/test/testkit/mocks/loggen/log_producer.go
@@ -110,9 +110,9 @@ done`
 	if lp.useJSON {
 		logCmd = `while true
 do
-	echo '{"name": "John Doe", "age": 30, "city": "Munich", "trace_id": "255c2212dd02c02ac59a923ff07aec74", "span_id": "c5c735f175ad06a6", "trace_flags": "01"}'
+	echo '{"name": "John Doe", "level": "INFO", "age": 30, "city": "Munich", "trace_id": "255c2212dd02c02ac59a923ff07aec74", "span_id": "c5c735f175ad06a6", "trace_flags": "01"}'
     sleep 1
-    echo '{"name": "John Doe", "age": 30, "city": "Munich", "traceparent": "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01"}'
+    echo '{"name": "John Doe", "log.level":"WARN", "age": 30, "city": "Munich", "traceparent": "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01"}'
     sleep 1
     echo '{"name": "John Doe", "age": 30, "city": "Munich", "span_id": "123456789"}'
 	sleep 10


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- remove "level" after successful severity parsing
- add support for "log.level"
- unifirm attribute syntax across all operators
- add missing test cases for severity parsing

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
