### PR TITLE
chore: configure permissions for all gh actions

### DIFF
--- a/.github/template/finalize-test/action.yaml
+++ b/.github/template/finalize-test/action.yaml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Upload Report
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.job-name }}-report
         path: junit-report*.xml

--- a/.github/template/setup-golang/action.yaml
+++ b/.github/template/setup-golang/action.yaml
@@ -8,14 +8,14 @@ runs:
     # uses the go version from go.mod.
     # Run this step after the checkout step!
     - name: Setup Golang
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: "go.mod"
         cache: false
 
     - name: Cache Go
       id: go-cache
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ~/go/bin

--- a/.github/workflows/branch-integration.yml
+++ b/.github/workflows/branch-integration.yml
@@ -1,5 +1,8 @@
 name: Branch Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -23,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup Golang
       uses: "./.github/template/setup-golang"
@@ -56,7 +59,7 @@ jobs:
         GARDENER_K8S_VERSION: ${{ matrix.k8s_version }}
 
     - name: Upload Report
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: success() || failure()
       with:
         name: ${{ github.job }}-${{ matrix.k8s_version }}-report

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,7 +58,7 @@ jobs:
 
   build-image:
     permissions:
-      id-token: write
+      id-token: write # Required for requesting the JWT token
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,5 +1,8 @@
 name: Build Image
 
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request_target:
@@ -28,9 +31,7 @@ on:
       - "CODEOWNERS"
       - "external-images.yaml"
 
-permissions:
-  id-token: write
-  contents: read
+
 
 jobs:
   envs:
@@ -56,6 +57,9 @@ jobs:
           fi
 
   build-image:
+    permissions:
+      id-token: write
+      contents: read
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
@@ -70,7 +74,7 @@ jobs:
     if: ${{ always() && (needs.build-image.result == 'failure') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Send slack message on failure
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -59,7 +59,6 @@ jobs:
   build-image:
     permissions:
       id-token: write
-      contents: read
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -1,5 +1,8 @@
 name: Build Sample App Image
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     paths:
@@ -12,10 +15,6 @@ on:
     paths:
       - "docs/user/integration/sample-app/**"
   workflow_dispatch:
-
-permissions:
-  id-token: write
-  contents: read
 
 jobs:
   envs:
@@ -39,6 +38,9 @@ jobs:
           fi
 
   build-image:
+    permissions:
+      id-token: write
+      contents: read
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -40,7 +40,6 @@ jobs:
   build-image:
     permissions:
       id-token: write
-      contents: read
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -39,7 +39,7 @@ jobs:
 
   build-image:
     permissions:
-      id-token: write
+      id-token: write # Required for requesting the JWT token
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-telemetry-self-monitor-image.yml
+++ b/.github/workflows/build-telemetry-self-monitor-image.yml
@@ -1,5 +1,9 @@
 name: Build Telemetry Self Monitor Image
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   pull_request_target:
     paths:
@@ -12,10 +16,6 @@ on:
       - "dependencies/telemetry-self-monitor/**"
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   envs:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Fetch new env file
         run: |
@@ -60,6 +60,9 @@ jobs:
         if: github.event_name == 'push'
 
   build-image:
+    permissions:
+      id-token: write
+      contents: read
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-telemetry-self-monitor-image.yml
+++ b/.github/workflows/build-telemetry-self-monitor-image.yml
@@ -1,7 +1,6 @@
 name: Build Telemetry Self Monitor Image
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -62,7 +61,6 @@ jobs:
   build-image:
     permissions:
       id-token: write
-      contents: read
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/build-telemetry-self-monitor-image.yml
+++ b/.github/workflows/build-telemetry-self-monitor-image.yml
@@ -60,7 +60,7 @@ jobs:
 
   build-image:
     permissions:
-      id-token: write
+      id-token: write # Required for requesting the JWT token
     needs: envs
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:

--- a/.github/workflows/periodic-github-checks.yml
+++ b/.github/workflows/periodic-github-checks.yml
@@ -1,5 +1,8 @@
 name: 'Periodic Github Checks'
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs daily at midnight
@@ -9,7 +12,7 @@ jobs:
   stale-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 60
           days-before-close: 7

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -1,4 +1,8 @@
 name: All Checks passed
+
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -26,7 +26,7 @@ jobs:
   all-checks:
     runs-on: ubuntu-latest
     permissions:
-      checks: read
+      checks: read # Required for checking the status of actions
     steps:
       - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1 # v1.2.0
         with:

--- a/.github/workflows/pr-all-checks-passed.yml
+++ b/.github/workflows/pr-all-checks-passed.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
-      contents: read
     steps:
       - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1 # v1.2.0
         with:

--- a/.github/workflows/pr-code-checks.yml
+++ b/.github/workflows/pr-code-checks.yml
@@ -1,5 +1,8 @@
 name: PR Code Checks
 
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request:
@@ -23,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -35,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -47,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -59,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -70,7 +73,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Fetch gitleaks ${{ env.GITLEAKS_VERSION }}

--- a/.github/workflows/pr-docu-checks.yml
+++ b/.github/workflows/pr-docu-checks.yml
@@ -1,5 +1,8 @@
 name: PR Docu Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -17,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -29,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -1,5 +1,8 @@
 name: PR Github Checks
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     branches:
@@ -23,10 +26,10 @@ env:
   TITLE: ${{ github.event.pull_request.title }}
   GH_HOST: github.com
 
-permissions: write-all
-
 jobs:
   pr-milestone-project-check:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Set milestone
@@ -45,10 +48,12 @@ jobs:
           gh pr edit ${{ github.event.number }} --milestone "${latest_milestone}"
 
   pr-label-check:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Add kind label based on PR title prefix
         if: always()
@@ -124,7 +129,7 @@ jobs:
     if: ${{ github.event.pull_request.base.ref == 'main' }}
     steps:
       - name: Check-out code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   pr-milestone-project-check:
     permissions:
-      pull-requests: write
+      pull-requests: write # Required for setting the milestone
     runs-on: ubuntu-latest
     steps:
       - name: Set milestone
@@ -49,7 +49,7 @@ jobs:
 
   pr-label-check:
     permissions:
-      pull-requests: write
+      pull-requests: write # Required for setting the labels
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -1,5 +1,8 @@
 name: PR Integration
 
+permissions:
+  contents: read
+
 env:
   # add the tag PR-<number> to the image if it is a PR, if the trigger is merge_group, then add the sha as the tag
   IMG: europe-docker.pkg.dev/kyma-project/dev/telemetry-manager:${{ github.event_name == 'pull_request' && 'PR-' || '' }}${{ github.event.number || github.event.merge_group.head_sha }}
@@ -40,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: ./.github/template/setup-golang
@@ -63,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare test
         uses: "./.github/template/prepare-test"
@@ -97,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare test
         uses: "./.github/template/prepare-test"
@@ -122,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare Test
         uses: "./.github/template/prepare-test"
@@ -163,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare Test
         uses: "./.github/template/prepare-test"
@@ -217,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare Test
         uses: "./.github/template/prepare-test"

--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -1,5 +1,8 @@
 name: PR Load Test
 
+permissions:
+  contents: read
+
 # Trigger the test Manually additionally provide PR number.
 on:
   workflow_dispatch:
@@ -34,7 +37,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
           repository: ${{ github.repository }}
@@ -57,7 +60,7 @@ jobs:
         run: echo "input = ${{ github.event.inputs.image }}, matrix = ${{ matrix.image }}"
 
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
           repository: ${{ github.repository }}
@@ -100,7 +103,7 @@ jobs:
         run: hack/load-tests/run-load-test.sh -n ${{ matrix.name }} -t ${{ matrix.type }} -m ${{ matrix.multi }} -b ${{ matrix.backpressure }} -d ${{ github.event.inputs.duration }} -o "${{ matrix.overlay }}"
 
       - name: Upload Results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: Results-${{ matrix.name }}
@@ -119,12 +122,12 @@ jobs:
     if: always()
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
           repository: ${{ github.repository }}
       - name: Download Results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       - name: Print Results
         run: |
           ls -la

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,5 +1,8 @@
 name: Check Release Branch
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -10,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # check that the .env file does not contain references to the main branch
       - name: Check .env file

--- a/.github/workflows/pr-upgrade.yml
+++ b/.github/workflows/pr-upgrade.yml
@@ -1,5 +1,8 @@
 name: PR Upgrade
 
+permissions:
+  contents: read
+
 on:
   merge_group:
   pull_request:
@@ -33,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
@@ -72,7 +75,7 @@ jobs:
           bin/ginkgo run --junit-report=junit-report-latest-version.xml --tags e2e --flake-attempts=5 --label-filter="upgrade || operational" -v -r test/e2e
 
       - name: Switch back to current revision
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Wait for cleanup of test run
         shell: bash

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   sync-external-images:
     permissions:
-      id-token: write # This is required for requesting the JWT token
+      id-token: write # Required for requesting the JWT token
     uses: kyma-project/test-infra/.github/workflows/image-syncer.yml@main
     with:
       debug: true

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -1,5 +1,8 @@
 name: sync-external-images
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -13,12 +16,13 @@ on:
     paths:
       - "external-images.yaml"
 
-permissions:
-  id-token: write # This is required for requesting the JWT token
-  contents: read # This is required for actions/checkout
+
 
 jobs:
   sync-external-images:
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-syncer.yml@main
     with:
       debug: true

--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -22,7 +22,6 @@ jobs:
   sync-external-images:
     permissions:
       id-token: write # This is required for requesting the JWT token
-      contents: read # This is required for actions/checkout
     uses: kyma-project/test-infra/.github/workflows/image-syncer.yml@main
     with:
       debug: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,19 +1,21 @@
 name: Tag Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
-permissions:
-  contents: write
-
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
+      contents: write # Required for creating the release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- CodeQL reports that default permissions are to corse-grained
- -> added most restrictive permissions for all jobs
- -> enabled more powerful permissions on the jobs directly

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
