### PR TITLE
fix: prevent cross-usage of fluentbit and otlp features

### DIFF
--- a/apis/telemetry/v1alpha1/logpipeline_types.go
+++ b/apis/telemetry/v1alpha1/logpipeline_types.go
@@ -56,6 +56,9 @@ type LogPipeline struct {
 // +kubebuilder:validation:XValidation:rule="!((has(self.output.http) || has(self.output.custom))  && has(self.input.otlp))", message="otlp input is only supported with otlp output"
 // +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.input.application.dropLabels))", message="input.application.dropLabels is not supported with otlp output"
 // +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.input.application.keepAnnotations))", message="input.application.keepAnnotations is not supported with otlp output"
+// +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.filters))", message="filters are not supported with otlp output"
+// +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.files))", message="files not supported with otlp output"
+// +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.variables))", message="variables not supported with otlp output"
 type LogPipelineSpec struct {
 	// Defines where to collect logs, including selector mechanisms.
 	Input   LogPipelineInput    `json:"input,omitempty"`

--- a/apis/telemetry/v1beta1/logpipeline_types.go
+++ b/apis/telemetry/v1beta1/logpipeline_types.go
@@ -62,8 +62,12 @@ type LogPipeline struct {
 }
 
 // LogPipelineSpec defines the desired state of LogPipeline
+// +kubebuilder:validation:XValidation:rule="!((has(self.output.http) || has(self.output.custom))  && has(self.input.otlp))", message="otlp input is only supported with otlp output"
 // +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.input.runtime.dropLabels))", message="input.runtime.dropLabels is not supported with otlp output"
 // +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.input.runtime.keepAnnotations))", message="input.runtime.keepAnnotations is not supported with otlp output"
+// +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.filters))", message="filters are not supported with otlp output"
+// +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.files))", message="files not supported with otlp output"
+// +kubebuilder:validation:XValidation:rule="!(has(self.output.otlp) && has(self.variables))", message="variables not supported with otlp output"
 type LogPipelineSpec struct {
 	// Defines where to collect logs, including selector mechanisms.
 	Input   LogPipelineInput    `json:"input,omitempty"`

--- a/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
+++ b/config/development/crd/bases/telemetry.kyma-project.io_logpipelines.yaml
@@ -655,6 +655,12 @@ spec:
               rule: '!(has(self.output.otlp) && has(self.input.application.dropLabels))'
             - message: input.application.keepAnnotations is not supported with otlp output
               rule: '!(has(self.output.otlp) && has(self.input.application.keepAnnotations))'
+            - message: filters are not supported with otlp output
+              rule: '!(has(self.output.otlp) && has(self.filters))'
+            - message: files not supported with otlp output
+              rule: '!(has(self.output.otlp) && has(self.files))'
+            - message: variables not supported with otlp output
+              rule: '!(has(self.output.otlp) && has(self.variables))'
           status:
             description: Shows the observed state of the LogPipeline
             properties:
@@ -1357,10 +1363,18 @@ spec:
                 type: array
             type: object
             x-kubernetes-validations:
+            - message: otlp input is only supported with otlp output
+              rule: '!((has(self.output.http) || has(self.output.custom))  && has(self.input.otlp))'
             - message: input.runtime.dropLabels is not supported with otlp output
               rule: '!(has(self.output.otlp) && has(self.input.runtime.dropLabels))'
             - message: input.runtime.keepAnnotations is not supported with otlp output
               rule: '!(has(self.output.otlp) && has(self.input.runtime.keepAnnotations))'
+            - message: filters are not supported with otlp output
+              rule: '!(has(self.output.otlp) && has(self.filters))'
+            - message: files not supported with otlp output
+              rule: '!(has(self.output.otlp) && has(self.files))'
+            - message: variables not supported with otlp output
+              rule: '!(has(self.output.otlp) && has(self.variables))'
           status:
             description: Shows the observed state of the LogPipeline
             properties:


### PR DESCRIPTION
## Description

This PR ads verification to the LogPipeline to prevent cross-usage of fluentbit and otlp features. At the moment these fields are usable when having an OTLP output:
- spec.filters
- spec.values
- spec.files

Changes proposed in this pull request (what was done and why):

- Adds CRD validation rules to prevent usage of otlp output in combination with "files", "variables" and "filters"

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
