### PR TITLE
fix: move body only if it is json

### DIFF
--- a/internal/otelcollector/config/log/agent/receivers.go
+++ b/internal/otelcollector/config/log/agent/receivers.go
@@ -196,6 +196,7 @@ func makeDropAttributeLogTag() Operator {
 func makeBodyRouter() Operator {
 	regexPattern := `^{.*}$`
 
+        // If body is not a JSON document, then skip all operators as they are all based on a parsed record and go to noop
 	return Operator{
 		ID:      "body-router",
 		Type:    Router,

--- a/internal/otelcollector/config/log/agent/receivers.go
+++ b/internal/otelcollector/config/log/agent/receivers.go
@@ -196,7 +196,7 @@ func makeDropAttributeLogTag() Operator {
 func makeBodyRouter() Operator {
 	regexPattern := `^{.*}$`
 
-        // If body is not a JSON document, then skip all operators as they are all based on a parsed record and go to noop
+	// If body is not a JSON document, then skip all operators as they are all based on a parsed record and go to noop
 	return Operator{
 		ID:      "body-router",
 		Type:    Router,

--- a/internal/otelcollector/config/log/agent/receivers.go
+++ b/internal/otelcollector/config/log/agent/receivers.go
@@ -30,6 +30,8 @@ const (
 	attributeKeySpanID      = "span_id"
 	attributeKeyTraceFlags  = "trace_flags"
 	attributeKeyTraceParent = "traceparent"
+
+	operatorNoop = "noop"
 )
 
 func makeFileLogReceiver(logpipeline telemetryv1alpha1.LogPipeline) *FileLog {
@@ -135,6 +137,7 @@ func makeOperators(logPipeline telemetryv1alpha1.LogPipeline) []Operator {
 		makeContainerParser(),
 		makeMoveToLogStream(),
 		makeDropAttributeLogTag(),
+		makeBodyRouter(),
 		makeJSONParser(),
 	}
 	if keepOriginalBody {
@@ -190,16 +193,29 @@ func makeDropAttributeLogTag() Operator {
 	}
 }
 
-// parse body as json and move it to attributes
-func makeJSONParser() Operator {
+func makeBodyRouter() Operator {
 	regexPattern := `^{.*}$`
 
+	return Operator{
+		ID:      "body-router",
+		Type:    Router,
+		Default: operatorNoop,
+		Routes: []Route{
+			{
+				Expression: fmt.Sprintf("body matches '%s'", regexPattern),
+				Output:     "json-parser",
+			},
+		},
+	}
+}
+
+// parse body as json and move it to attributes
+func makeJSONParser() Operator {
 	return Operator{
 		ID:        "json-parser",
 		Type:      JsonParser,
 		ParseFrom: "body",
 		ParseTo:   "attributes",
-		IfExpr:    fmt.Sprintf("body matches '%s'", regexPattern),
 	}
 }
 
@@ -279,14 +295,14 @@ func makeTraceRouter() Operator {
 	return Operator{
 		ID:      "trace-router",
 		Type:    Router,
-		Default: "noop",
+		Default: operatorNoop,
 		Routes: []Route{
 			{
 				Expression: ottlexpr.AttributeIsNotNil(attributeKeyTraceID),
 				Output:     "trace-parser",
 			},
 			{
-				Expression: ottlexpr.JoinWithAnd(ottlexpr.AttributeIsNil(attributeKeyTraceID), ottlexpr.AttributeIsNotNil(attributeKeyTraceParent), fmt.Sprintf("%s matches '%s'", ottlexpr.Attribute(attributeKeyTraceParent), traceParentExpression)),
+				Expression: ottlexpr.JoinWithAnd(ottlexpr.AttributeIsNotNil(attributeKeyTraceParent), fmt.Sprintf("%s matches '%s'", ottlexpr.Attribute(attributeKeyTraceParent), traceParentExpression)),
 				Output:     "trace-parent-parser",
 			},
 		},
@@ -334,10 +350,9 @@ func makeTraceParentParser() Operator {
 
 func makeRemoveTraceParent() Operator {
 	return Operator{
-		ID:     "remove-trace-parent",
-		Type:   Remove,
-		Field:  ottlexpr.Attribute(attributeKeyTraceParent),
-		Output: "remove-trace-id",
+		ID:    "remove-trace-parent",
+		Type:  Remove,
+		Field: ottlexpr.Attribute(attributeKeyTraceParent),
 	}
 }
 
@@ -347,7 +362,6 @@ func makeRemoveTraceID() Operator {
 		Type:   Remove,
 		Field:  ottlexpr.Attribute(attributeKeyTraceID),
 		IfExpr: ottlexpr.AttributeIsNotNil(attributeKeyTraceID),
-		Output: "remove-span-id",
 	}
 }
 
@@ -357,7 +371,6 @@ func makeRemoveSpanID() Operator {
 		Type:   Remove,
 		Field:  ottlexpr.Attribute(attributeKeySpanID),
 		IfExpr: ottlexpr.AttributeIsNotNil(attributeKeySpanID),
-		Output: "remove-trace-flags",
 	}
 }
 
@@ -373,7 +386,7 @@ func makeRemoveTraceFlags() Operator {
 // The noop operator is required because of router operator, an entry that does not match any of the routes is dropped and not processed further, to avoid that we add a noop operator as default route
 func makeNoop() Operator {
 	return Operator{
-		ID:   "noop",
+		ID:   operatorNoop,
 		Type: Noop,
 	}
 }

--- a/internal/otelcollector/config/log/agent/testdata/config.yaml
+++ b/internal/otelcollector/config/log/agent/testdata/config.yaml
@@ -69,9 +69,14 @@ receivers:
             - id: drop-attribute-log-tag
               type: remove
               field: attributes["logtag"]
+            - id: body-router
+              type: router
+              routes:
+                - expr: body matches '^{.*}$'
+                  output: json-parser
+              default: noop
             - id: json-parser
               type: json_parser
-              if: body matches '^{.*}$'
               parse_from: body
               parse_to: attributes
             - id: move-body-to-attributes-log-original
@@ -109,7 +114,7 @@ receivers:
               routes:
                 - expr: attributes["trace_id"] != nil
                   output: trace-parser
-                - expr: attributes["trace_id"] == nil and attributes["traceparent"] != nil and attributes["traceparent"] matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
+                - expr: attributes["traceparent"] != nil and attributes["traceparent"] matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
                   output: trace-parent-parser
               default: noop
             - id: trace-parent-parser
@@ -136,17 +141,14 @@ receivers:
             - id: remove-trace-parent
               type: remove
               field: attributes["traceparent"]
-              output: remove-trace-id
             - id: remove-trace-id
               type: remove
               if: attributes["trace_id"] != nil
               field: attributes["trace_id"]
-              output: remove-span-id
             - id: remove-span-id
               type: remove
               if: attributes["span_id"] != nil
               field: attributes["span_id"]
-              output: remove-trace-flags
             - id: remove-trace-flags
               type: remove
               if: attributes["trace_flags"] != nil

--- a/internal/otelcollector/config/log/agent/testdata/config_compatibility_enabled.yaml
+++ b/internal/otelcollector/config/log/agent/testdata/config_compatibility_enabled.yaml
@@ -72,9 +72,14 @@ receivers:
             - id: drop-attribute-log-tag
               type: remove
               field: attributes["logtag"]
+            - id: body-router
+              type: router
+              routes:
+                - expr: body matches '^{.*}$'
+                  output: json-parser
+              default: noop
             - id: json-parser
               type: json_parser
-              if: body matches '^{.*}$'
               parse_from: body
               parse_to: attributes
             - id: move-body-to-attributes-log-original
@@ -112,7 +117,7 @@ receivers:
               routes:
                 - expr: attributes["trace_id"] != nil
                   output: trace-parser
-                - expr: attributes["trace_id"] == nil and attributes["traceparent"] != nil and attributes["traceparent"] matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
+                - expr: attributes["traceparent"] != nil and attributes["traceparent"] matches '^[0-9a-f]{2}-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$'
                   output: trace-parent-parser
               default: noop
             - id: trace-parent-parser
@@ -139,17 +144,14 @@ receivers:
             - id: remove-trace-parent
               type: remove
               field: attributes["traceparent"]
-              output: remove-trace-id
             - id: remove-trace-id
               type: remove
               if: attributes["trace_id"] != nil
               field: attributes["trace_id"]
-              output: remove-span-id
             - id: remove-span-id
               type: remove
               if: attributes["span_id"] != nil
               field: attributes["span_id"]
-              output: remove-trace-flags
             - id: remove-trace-flags
               type: remove
               if: attributes["trace_flags"] != nil

--- a/test/e2e/logs/fluentbit/keep_original_body_test.go
+++ b/test/e2e/logs/fluentbit/keep_original_body_test.go
@@ -94,7 +94,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsFluentBit), Ordered, func() {
 			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
-		It("Should ship JSON logs without original body to backend1 having drop orginal active", func() {
+		It("Should ship JSON logs without original body to backend1 having drop original active", func() {
 			Eventually(func(g Gomega) {
 				resp, err := suite.ProxyClient.Get(backend1ExportURL)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -107,7 +107,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsFluentBit), Ordered, func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should ship plain logs with original body to backend1 having drop orginal active", func() {
+		It("Should ship plain logs with original body to backend1 having drop original active", func() {
 			Eventually(func(g Gomega) {
 				resp, err := suite.ProxyClient.Get(backend1ExportURL)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsFluentBit), Ordered, func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should ship JSON logs with original body to backend2 having drop orginal inactive", func() {
+		It("Should ship JSON logs with original body to backend2 having drop original inactive", func() {
 			Eventually(func(g Gomega) {
 				resp, err := suite.ProxyClient.Get(backend2ExportURL)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -131,7 +131,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsFluentBit), Ordered, func() {
 			}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})
 
-		It("Should ship plain logs with original body to backend2 having drop orginal inactive", func() {
+		It("Should ship plain logs with original body to backend2 having drop original inactive", func() {
 			Eventually(func(g Gomega) {
 				resp, err := suite.ProxyClient.Get(backend2ExportURL)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/logs/otel/application/basic_test.go
+++ b/test/e2e/logs/otel/application/basic_test.go
@@ -123,8 +123,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsOtel, suite.LabelSignalPull, s
 				g.Expect(bodyContent).To(HaveFlatOtelLogs(ContainElement(SatisfyAll(
 					HaveOtelTimestamp(Not(BeEmpty())),
 					HaveObservedTimestamp(Not(BeEmpty())),
-					HaveLogRecordBody(BeEmpty()),
-					HaveAttributes(HaveKey("log.original")),
 				))))
 			}, periodic.ConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
 		})

--- a/test/testkit/mocks/loggen/log_producer.go
+++ b/test/testkit/mocks/loggen/log_producer.go
@@ -104,16 +104,17 @@ func (lp *LogProducer) PodSpec() corev1.PodSpec {
 func (lp *LogProducer) alpineSpec() corev1.PodSpec {
 	logCmd := `while true
 do
-	echo "foo bar"
-	sleep 10
+    echo "foo bar"
+    sleep 10
 done`
 	if lp.useJSON {
 		logCmd = `while true
 do
-	echo '{"name": "a", "level": "INFO", "age": 30, "city": "Munich", "trace_id": "255c2212dd02c02ac59a923ff07aec74", "span_id": "c5c735f175ad06a6", "trace_flags": "00"}'
-    echo '{"name": "b", "log.level":"WARN", "age": 30, "city": "Munich", "traceparent": "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01"}'
-    echo '{"name": "c", "age": 30, "city": "Munich", "span_id": "123456789"}'
-	sleep 10
+    echo '{"name": "a", "level": "INFO", "age": 30, "city": "Munich", "trace_id": "255c2212dd02c02ac59a923ff07aec74", "span_id": "c5c735f175ad06a6", "trace_flags": "00", "message":"a-body"}'
+    echo '{"name": "b", "log.level":"WARN", "age": 30, "city": "Munich", "traceparent": "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01", "msg":"b-body"}'
+    echo '{"name": "c", "age": 30, "city": "Munich", "span_id": "123456789", "body":"c-body"}'
+    echo 'name=d age=30 city=Munich span_id=123456789 msg=test'
+    sleep 10
 done`
 	}
 


### PR DESCRIPTION
## Description

The log body was moved to log.original always, even if it was not parsable

Changes proposed in this pull request (what was done and why):

- In case log body is not JSON parsable, skip the whole operator chain as it is based on a parsed body
- Added more advanced test cases
- Removed unneeded operator outputs

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
