### PR TITLE
chore: use registry:2 from kyma-registry

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
 ### Default Environment Variables
 ## General
-ENV_K3S_IMAGE=europe-docker.pkg.dev/kyma-project/prod/external/rancher/k3s:v1.31.7-k3s1 # refers to the image used by k3d
 ENV_IMG=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main # Image URL to use all building/pushing image targets
 
 ## Gardener

--- a/.k3d-kyma.yaml
+++ b/.k3d-kyma.yaml
@@ -3,6 +3,8 @@ apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: kyma
+image: europe-docker.pkg.dev/kyma-project/prod/external/rancher/k3s:v1.31.7-k3s1 # refers to the image used by k3d
+
 servers: 1
 agents: 0
 kubeAPI:
@@ -11,6 +13,7 @@ registries:
   create:
     name: kyma
     hostPort: '5001'
+    image: europe-docker.pkg.dev/kyma-project/prod/external/library/registry:2
 
 options:
   k3s:

--- a/hack/make/provision.mk
+++ b/hack/make/provision.mk
@@ -1,7 +1,7 @@
 ##@ k3d
 .PHONY: provision-k3d
 provision-k3d: $(K3D)
-	$(K3D) cluster create --image $(K3S_IMAGE) --config .k3d-kyma.yaml
+	$(K3D) cluster create --config .k3d-kyma.yaml
 	kubectl create ns kyma-system
 
 .PHONY: provision-k3d-istio


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- use registry image from our registry to circumvent rate limiting

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
