### PR TITLE
chore: bump otel collector to 0.126.0

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250508-147743cd"
 DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.1"
-DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.124.0-main"
+DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.126.0-main"
 DEFAULT_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.4.0-0eb80ba"
 DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.124.1"

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -6,6 +6,6 @@ package images
 const (
 	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250508-147743cd"
 	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.1"
-	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.124.0-main"
+	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.126.0-main"
 	DefaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.4.0-0eb80ba"
 )

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -4,21 +4,21 @@ bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250508-147743cd
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.1
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.124.0-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.126.0-main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.4.0-0eb80ba
 mend:
   language: golang-mod
   exclude:
-    - '**/mocks/**'
-    - '**/stubs/**'
-    - '**/test/**'
-    - '**/*_test.go'
+    - "**/mocks/**"
+    - "**/stubs/**"
+    - "**/test/**"
+    - "**/*_test.go"
     - docs/**
 checkmarx-one:
   preset: go-default
   exclude:
-    - '**/mocks/**'
-    - '**/stubs/**'
-    - '**/test/**'
-    - '**/*_test.go'
+    - "**/mocks/**"
+    - "**/stubs/**"
+    - "**/test/**"
+    - "**/*_test.go"
     - docs/**


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump otel collector to version 0.126.0
- bump telemetrygen to version 0.126.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
