### PR TITLE
fix: clean OTLP log body for JSON logs even if original should not be kept

### DIFF
--- a/internal/otelcollector/config/log/agent/receivers.go
+++ b/internal/otelcollector/config/log/agent/receivers.go
@@ -142,6 +142,8 @@ func makeOperators(logPipeline telemetryv1alpha1.LogPipeline) []Operator {
 	}
 	if keepOriginalBody {
 		operators = append(operators, makeMoveBodyToLogOriginal())
+	} else {
+		operators = append(operators, makeRemoveBody())
 	}
 
 	operators = append(operators,
@@ -227,6 +229,15 @@ func makeMoveBodyToLogOriginal() Operator {
 		Type: Move,
 		From: "body",
 		To:   ottlexpr.Attribute("log.original"),
+	}
+}
+
+// remove body attribute
+func makeRemoveBody() Operator {
+	return Operator{
+		ID:    "remove-body",
+		Type:  Remove,
+		Field: "body",
 	}
 }
 

--- a/internal/otelcollector/config/log/agent/receivers_test.go
+++ b/internal/otelcollector/config/log/agent/receivers_test.go
@@ -61,6 +61,7 @@ func TestReceiverCreator(t *testing.T) {
 				makeDropAttributeLogTag(),
 				makeBodyRouter(),
 				makeJSONParser(),
+				makeRemoveBody(),
 				makeMoveMessageToBody(),
 				makeMoveMsgToBody(),
 				makeSeverityParserFromLevel(),
@@ -148,6 +149,16 @@ func TestMakeMoveBodyToLogOriginal(t *testing.T) {
 		Type: "move",
 		From: "body",
 		To:   "attributes[\"log.original\"]",
+	}
+	assert.Equal(t, expectedCBTO, mbto)
+}
+
+func TestMakeRemoveBody(t *testing.T) {
+	mbto := makeRemoveBody()
+	expectedCBTO := Operator{
+		ID:    "remove-body",
+		Type:  "remove",
+		Field: "body",
 	}
 	assert.Equal(t, expectedCBTO, mbto)
 }

--- a/test/e2e-migrated/logs/shared/keep_original_body_test.go
+++ b/test/e2e-migrated/logs/shared/keep_original_body_test.go
@@ -20,53 +20,60 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
 )
 
+const (
+	//keepOriginalBody = true (default)
+	scenarioKeepOriginal = "keepOriginalBody"
+	//keepOriginalBody = false
+	scenarioDropOriginal = "dropOriginalBody"
+)
+
 func TestKeepOriginalBody_OTel(t *testing.T) {
 	suite.RegisterTestCase(t, suite.LabelLogAgent)
 
 	var (
-		uniquePrefix = unique.Prefix()
-		gen1Ns       = uniquePrefix("gen-1")
-		gen2Ns       = uniquePrefix("gen-2")
+		uniquePrefix         = unique.Prefix()
+		sourceNsKeepOriginal = uniquePrefix("source" + scenarioKeepOriginal)
+		sourceNsDropOriginal = uniquePrefix("source" + scenarioDropOriginal)
 
-		backendGen1Ns = uniquePrefix("backend-gen-1")
-		backendGen2Ns = uniquePrefix("backend-gen-2")
+		backendNsKeepOriginal = uniquePrefix("backend" + scenarioKeepOriginal)
+		backendNsDropOriginal = uniquePrefix("backend" + scenarioDropOriginal)
 
-		pipelineKeepOriginalBodyName        = uniquePrefix("keep-original-body")
-		pipelineWithoutKeepOriginalBodyName = uniquePrefix("without-keep-original-body")
+		pipelineKeepOriginalName = uniquePrefix(scenarioKeepOriginal)
+		pipelineDropOriginalName = uniquePrefix(scenarioDropOriginal)
 	)
 
-	backendGen1 := kitbackend.New(backendGen1Ns, kitbackend.SignalTypeLogsOTel, kitbackend.WithName("backend-gen-1"))
-	backendGen2 := kitbackend.New(backendGen2Ns, kitbackend.SignalTypeLogsOTel, kitbackend.WithName("backend-gen-2"))
+	backendKeepOriginal := kitbackend.New(backendNsKeepOriginal, kitbackend.SignalTypeLogsOTel, kitbackend.WithName(scenarioKeepOriginal))
+	backendDropOriginal := kitbackend.New(backendNsDropOriginal, kitbackend.SignalTypeLogsOTel, kitbackend.WithName(scenarioDropOriginal))
 
-	pipelineWithoutKeepOriginalBody := testutils.NewLogPipelineBuilder().
-		WithName(pipelineWithoutKeepOriginalBodyName).
+	pipelineKeepOriginal := testutils.NewLogPipelineBuilder().
+		WithName(pipelineDropOriginalName).
 		WithApplicationInput(true,
-			[]testutils.ExtendedNamespaceSelectorOptions{testutils.ExtIncludeNamespaces(gen1Ns)}...).
+			[]testutils.ExtendedNamespaceSelectorOptions{testutils.ExtIncludeNamespaces(sourceNsKeepOriginal)}...).
 		WithKeepOriginalBody(false).
-		WithOTLPOutput(testutils.OTLPEndpoint(backendGen1.Endpoint())).
+		WithOTLPOutput(testutils.OTLPEndpoint(backendKeepOriginal.Endpoint())).
 		Build()
 
-	pipelineKeepOriginalBody := testutils.NewLogPipelineBuilder().
-		WithName(pipelineKeepOriginalBodyName).
+	pipelineDropOriginal := testutils.NewLogPipelineBuilder().
+		WithName(pipelineKeepOriginalName).
 		WithApplicationInput(true,
-			[]testutils.ExtendedNamespaceSelectorOptions{testutils.ExtIncludeNamespaces(gen2Ns)}...).
+			[]testutils.ExtendedNamespaceSelectorOptions{testutils.ExtIncludeNamespaces(sourceNsDropOriginal)}...).
 		WithKeepOriginalBody(true).
-		WithOTLPOutput(testutils.OTLPEndpoint(backendGen2.Endpoint())).
+		WithOTLPOutput(testutils.OTLPEndpoint(backendDropOriginal.Endpoint())).
 		Build()
 
 	var resources []client.Object
 	resources = append(resources,
-		kitk8s.NewNamespace(gen1Ns).K8sObject(),
-		kitk8s.NewNamespace(gen2Ns).K8sObject(),
-		kitk8s.NewNamespace(backendGen1Ns).K8sObject(),
-		kitk8s.NewNamespace(backendGen2Ns).K8sObject(),
-		&pipelineKeepOriginalBody,
-		&pipelineWithoutKeepOriginalBody,
-		loggen.New(gen1Ns).WithUseJSON().K8sObject(),
-		loggen.New(gen2Ns).WithUseJSON().K8sObject(),
+		kitk8s.NewNamespace(sourceNsKeepOriginal).K8sObject(),
+		kitk8s.NewNamespace(sourceNsDropOriginal).K8sObject(),
+		kitk8s.NewNamespace(backendNsKeepOriginal).K8sObject(),
+		kitk8s.NewNamespace(backendNsDropOriginal).K8sObject(),
+		&pipelineDropOriginal,
+		&pipelineKeepOriginal,
+		loggen.New(sourceNsKeepOriginal).WithUseJSON().K8sObject(),
+		loggen.New(sourceNsDropOriginal).WithUseJSON().K8sObject(),
 	)
-	resources = append(resources, backendGen1.K8sObjects()...)
-	resources = append(resources, backendGen2.K8sObjects()...)
+	resources = append(resources, backendKeepOriginal.K8sObjects()...)
+	resources = append(resources, backendDropOriginal.K8sObjects()...)
 
 	t.Cleanup(func() {
 		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
@@ -74,19 +81,19 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
 
 	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen2.NamespacedName())
+	assert.DeploymentReady(t.Context(), suite.K8sClient, backendKeepOriginal.NamespacedName())
+	assert.DeploymentReady(t.Context(), suite.K8sClient, backendDropOriginal.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineKeepOriginalBodyName)
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineWithoutKeepOriginalBodyName)
+	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineKeepOriginalName)
+	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineDropOriginalName)
 
-	assert.OTelLogsFromNamespaceDelivered(t.Context(), backendGen1, gen1Ns)
+	assert.OTelLogsFromNamespaceDelivered(t.Context(), backendDropOriginal, sourceNsKeepOriginal)
 
-	// Scenario [keepOriginalBody=false with JSON logs]: Ship `JSON` Logs without original body shipped to Backend1
-	// Since JSON body is parsed, the original body is not shipped to the backend and JSON fields are present in attributes
-	// Parse logline with `message`
-	assert.BackendDataEventuallyMatches(t.Context(), backendGen1, HaveFlatLogs(
+	// Scenario [keepOriginalBody=false with JSON logs]: Ship `JSON` Logs without original body
+	// Since JSON body is parsed, the original body is not shipped and JSON fields are present in attributes
+	// Parse logline with `message` and move to body
+	assert.BackendDataEventuallyMatches(t.Context(), backendDropOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveAttributes(HaveKeyWithValue("name", "a")),
 			HaveLogBody(Equal("a-body")),
@@ -95,8 +102,8 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 		)),
 	))
 
-	// Parse logline with `msg`
-	assert.BackendDataEventuallyMatches(t.Context(), backendGen1, HaveFlatLogs(
+	// Parse logline with `msg` and move to body
+	assert.BackendDataEventuallyMatches(t.Context(), backendDropOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveAttributes(HaveKeyWithValue("name", "b")),
 			HaveLogBody(Equal("b-body")),
@@ -105,20 +112,20 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 		)),
 	))
 
-	// Parse logline which has `body`
-	// Since message or msg is not present we keep the `Body()`
-	assert.BackendDataEventuallyMatches(t.Context(), backendGen1, HaveFlatLogs(
+	// Parse logline which has `body` attribute
+	// Since message or msg is not present the `Body()`` is empty
+	assert.BackendDataEventuallyMatches(t.Context(), backendDropOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveAttributes(HaveKeyWithValue("name", "c")),
-			HaveLogBody(Equal("{\"name\": \"c\", \"age\": 30, \"city\": \"Munich\", \"span_id\": \"123456789\", \"body\":\"c-body\"}")),
-			HaveAttributes(HaveKey("body")),
+			HaveLogBody(BeEmpty()),
+			HaveAttributes(HaveKeyWithValue("body", "c-body")),
 			HaveAttributes(Not(HaveKey("log.original"))),
 		)),
 	))
 
-	// Scenario [keepOriginalBody=false with Plain logs]: Ship `Plain` Logs with original body shipped to Backend1
-	// Since Plain body is not parsed, the original body is shipped to the backend and attributes is empty
-	assert.BackendDataEventuallyMatches(t.Context(), backendGen1, HaveFlatLogs(
+	// Scenario [keepOriginalBody=false with Plain logs]: Ship `Plain` Logs with original body
+	// Since Plain body is not parsed, the original body is shipped to the backend and attributes are empty
+	assert.BackendDataEventuallyMatches(t.Context(), backendDropOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveLogBody(HavePrefix("name=d")),
 			HaveAttributes(Not(HaveKey("log.original"))),
@@ -126,10 +133,10 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 	))
 
 	// Tests where we expect log.Original() to be present
-	assert.OTelLogsFromNamespaceDelivered(t.Context(), backendGen2, gen2Ns)
+	assert.OTelLogsFromNamespaceDelivered(t.Context(), backendKeepOriginal, sourceNsDropOriginal)
 
-	// Scenario [keepOriginalBody=true with JSON logs]: Ship `JSON` Logs with original body shipped to Backend2
-	assert.BackendDataConsistentlyMatches(t.Context(), backendGen2, HaveFlatLogs(
+	// Scenario [keepOriginalBody=true with JSON logs]: Ship `JSON` Logs with original body
+	assert.BackendDataConsistentlyMatches(t.Context(), backendKeepOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveAttributes(HaveKeyWithValue("name", "a")),
 			HaveLogBody(Equal("a-body")),
@@ -139,30 +146,31 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 	))
 
 	// Parse logline with `msg`
-	assert.BackendDataEventuallyMatches(t.Context(), backendGen1, HaveFlatLogs(
+	assert.BackendDataEventuallyMatches(t.Context(), backendKeepOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveAttributes(HaveKeyWithValue("name", "b")),
 			HaveLogBody(Equal("b-body")),
 			HaveAttributes(Not(HaveKey("msg"))),
-			HaveAttributes(Not(HaveKey("log.original"))),
+			HaveAttributes(HaveKey("log.original")),
 		)),
 	))
 
 	// Parse logline which has `body`
-	// Since message or msg is not present we keep the `Body()`
-	assert.BackendDataEventuallyMatches(t.Context(), backendGen1, HaveFlatLogs(
+	// Since message or msg is not present the `Body()` is empty
+	assert.BackendDataEventuallyMatches(t.Context(), backendKeepOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveAttributes(HaveKeyWithValue("name", "c")),
-			HaveLogBody(Equal("{\"name\": \"c\", \"age\": 30, \"city\": \"Munich\", \"span_id\": \"123456789\", \"body\":\"c-body\"}")),
-			HaveAttributes(HaveKey("body")),
-			HaveAttributes(Not(HaveKey("log.original"))),
+			HaveLogBody(BeEmpty()),
+			HaveAttributes(HaveKeyWithValue("body", "c-body")),
+			HaveAttributes(HaveKey("log.original")),
 		)),
 	))
 
-	// Scenario [keepOriginalBody=true with Plain logs]: Ship `Plain` Logs with original body shipped to Backend2
-	assert.BackendDataConsistentlyMatches(t.Context(), backendGen2, HaveFlatLogs(
+	// Scenario [keepOriginalBody=true with Plain logs]: Ship `Plain` Logs with original body
+	assert.BackendDataConsistentlyMatches(t.Context(), backendKeepOriginal, HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			HaveLogBody(HavePrefix("name=d")),
+			HaveAttributes(Not(HaveKey("log.original"))),
 		)),
 	))
 }
@@ -171,66 +179,66 @@ func TestKeepOriginalBody_FluentBit(t *testing.T) {
 	suite.RegisterTestCase(t, suite.LabelFluentBit)
 
 	var (
-		uniquePrefix = unique.Prefix()
-		gen1Ns       = uniquePrefix("gen-1")
-		gen2Ns       = uniquePrefix("gen-2")
+		uniquePrefix         = unique.Prefix()
+		sourceNsKeepOriginal = uniquePrefix("source" + scenarioKeepOriginal)
+		sourceNsDropOriginal = uniquePrefix("source" + scenarioDropOriginal)
 
-		backendGen1Ns = uniquePrefix("backend-gen-1")
-		backendGen2Ns = uniquePrefix("backend-gen-2")
+		backendNsKeepOriginal = uniquePrefix("backend" + scenarioKeepOriginal)
+		backendNsDropOriginal = uniquePrefix("backend" + scenarioDropOriginal)
 
-		pipelineKeepOriginalBodyName        = uniquePrefix("keep-original-body")
-		pipelineWithoutKeepOriginalBodyName = uniquePrefix("without-keep-original-body")
+		pipelineKeepOriginalName = uniquePrefix(scenarioKeepOriginal)
+		pipelineDropOriginalName = uniquePrefix(scenarioDropOriginal)
 	)
 
-	backendGen1 := kitbackend.New(backendGen1Ns, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithName("backend-gen-1"))
-	backendGen2 := kitbackend.New(backendGen2Ns, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithName("backend-gen-2"))
+	backendKeepOriginal := kitbackend.New(backendNsKeepOriginal, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithName(scenarioKeepOriginal))
+	backendDropOriginal := kitbackend.New(backendNsDropOriginal, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithName(scenarioDropOriginal))
 
-	pipelineWithoutKeepOriginalBody := testutils.NewLogPipelineBuilder().
-		WithName(pipelineKeepOriginalBodyName).
+	pipelineKeepOriginal := testutils.NewLogPipelineBuilder().
+		WithName(pipelineKeepOriginalName).
 		WithApplicationInput(true).
-		WithIncludeNamespaces(gen1Ns).
+		WithIncludeNamespaces(sourceNsKeepOriginal).
 		WithKeepOriginalBody(false).
-		WithHTTPOutput(testutils.HTTPHost(backendGen1.Host()), testutils.HTTPPort(backendGen1.Port())).
+		WithHTTPOutput(testutils.HTTPHost(backendKeepOriginal.Host()), testutils.HTTPPort(backendKeepOriginal.Port())).
 		Build()
 
-	pipelineKeepOriginalBody := testutils.NewLogPipelineBuilder().
-		WithName(pipelineWithoutKeepOriginalBodyName).
+	pipelineDropOriginal := testutils.NewLogPipelineBuilder().
+		WithName(pipelineDropOriginalName).
 		WithApplicationInput(true).
-		WithIncludeNamespaces(gen2Ns).
+		WithIncludeNamespaces(sourceNsDropOriginal).
 		WithKeepOriginalBody(true).
-		WithHTTPOutput(testutils.HTTPHost(backendGen2.Host()), testutils.HTTPPort(backendGen2.Port())).
+		WithHTTPOutput(testutils.HTTPHost(backendDropOriginal.Host()), testutils.HTTPPort(backendDropOriginal.Port())).
 		Build()
 
 	var resources []client.Object
 	resources = append(resources,
-		kitk8s.NewNamespace(gen1Ns).K8sObject(),
-		kitk8s.NewNamespace(gen2Ns).K8sObject(),
-		kitk8s.NewNamespace(backendGen1Ns).K8sObject(),
-		kitk8s.NewNamespace(backendGen2Ns).K8sObject(),
-		&pipelineKeepOriginalBody,
-		&pipelineWithoutKeepOriginalBody,
-		loggen.New(gen1Ns).WithUseJSON().K8sObject(),
-		loggen.New(gen2Ns).WithUseJSON().K8sObject(),
+		kitk8s.NewNamespace(sourceNsKeepOriginal).K8sObject(),
+		kitk8s.NewNamespace(sourceNsDropOriginal).K8sObject(),
+		kitk8s.NewNamespace(backendNsKeepOriginal).K8sObject(),
+		kitk8s.NewNamespace(backendNsDropOriginal).K8sObject(),
+		&pipelineDropOriginal,
+		&pipelineKeepOriginal,
+		loggen.New(sourceNsKeepOriginal).WithUseJSON().K8sObject(),
+		loggen.New(sourceNsDropOriginal).WithUseJSON().K8sObject(),
 	)
-	resources = append(resources, backendGen1.K8sObjects()...)
-	resources = append(resources, backendGen2.K8sObjects()...)
+	resources = append(resources, backendKeepOriginal.K8sObjects()...)
+	resources = append(resources, backendDropOriginal.K8sObjects()...)
 
 	t.Cleanup(func() {
 		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
 	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen2.NamespacedName())
+	assert.DeploymentReady(t.Context(), suite.K8sClient, backendKeepOriginal.NamespacedName())
+	assert.DeploymentReady(t.Context(), suite.K8sClient, backendDropOriginal.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineKeepOriginalBodyName)
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineWithoutKeepOriginalBodyName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineKeepOriginalName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineDropOriginalName)
 
-	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backendGen1, gen1Ns)
+	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backendDropOriginal, sourceNsKeepOriginal)
 
-	// Scenario [keepOriginalBody=false with JSON logs]: Ship `JSON` Logs without original body shipped to Backend1
-	assert.BackendDataConsistentlyMatches(t.Context(), backendGen1, fluentbit.HaveFlatLogs(
+	// Scenario [keepOriginalBody=false with JSON logs]: Ship `JSON` Logs without original body
+	assert.BackendDataConsistentlyMatches(t.Context(), backendDropOriginal, fluentbit.HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			fluentbit.HaveAttributes(HaveKeyWithValue("name", "b")),
 			fluentbit.HaveLogBody(BeEmpty()),
@@ -238,16 +246,16 @@ func TestKeepOriginalBody_FluentBit(t *testing.T) {
 	))
 
 	// Scenario [keepOriginalBody=false with Plain logs]: Ship `Plain` Logs with original body shipped to Backend1
-	assert.BackendDataConsistentlyMatches(t.Context(), backendGen1, fluentbit.HaveFlatLogs(
+	assert.BackendDataConsistentlyMatches(t.Context(), backendDropOriginal, fluentbit.HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			fluentbit.HaveLogBody(HavePrefix("name=d")),
 		)),
 	))
 
-	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backendGen2, gen2Ns)
+	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backendKeepOriginal, sourceNsDropOriginal)
 
 	// Scenario [keepOriginalBody=true with JSON logs]: Ship `JSON` Logs with original body shipped to Backend2
-	assert.BackendDataConsistentlyMatches(t.Context(), backendGen2, fluentbit.HaveFlatLogs(
+	assert.BackendDataConsistentlyMatches(t.Context(), backendKeepOriginal, fluentbit.HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			fluentbit.HaveAttributes(HaveKeyWithValue("name", "b")),
 			fluentbit.HaveLogBody(Not(BeEmpty())),
@@ -255,7 +263,7 @@ func TestKeepOriginalBody_FluentBit(t *testing.T) {
 	))
 
 	// Scenario [keepOriginalBody=false with Plain logs]: Ship `Plain` Logs with original body shipped to Backend2
-	assert.BackendDataConsistentlyMatches(t.Context(), backendGen2, fluentbit.HaveFlatLogs(
+	assert.BackendDataConsistentlyMatches(t.Context(), backendKeepOriginal, fluentbit.HaveFlatLogs(
 		ContainElement(SatisfyAll(
 			fluentbit.HaveLogBody(HavePrefix("name=d")),
 		)),


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- if keepOriginalBody is false, the body was not cleaned for JSON logs. Have fixed that
- Fixed the test cases which tested wrongly

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
