### PR TITLE
chore: remove dead links after singleonreceivercreator removed from repo

### DIFF
--- a/docs/contributor/arch/012b-leader-receiver-creator-as-extension.md
+++ b/docs/contributor/arch/012b-leader-receiver-creator-as-extension.md
@@ -10,7 +10,7 @@ Accepted
 
 The Telemetry OTel Collector collects metrics exposed by the Kubernetes API server using [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver), 
 and custom resource metrics are collected using [kymastatsreceiver](https://github.com/kyma-project/opentelemetry-collector-components/tree/main/receiver/kymastatsreceiver). 
-To run these receivers in high availability mode and prevent sending duplicate metrics, we've implemented [Singleton Receiver Creator](https://github.com/kyma-project/opentelemetry-collector-components/tree/main/receiver/singletonreceivercreator) based on [Leader Receiver Creator](./012a-leader-receiver-creator.md).
+To run these receivers in high availability mode and prevent sending duplicate metrics, we've implemented Singleton Receiver Creator based on [Leader Receiver Creator](./012a-leader-receiver-creator.md).
 
 ## Decision
 However, after feedback from community and careful deliberation, we realize the `singleonreceivercreator` would be better suited to be used as an extension.
@@ -50,7 +50,7 @@ extensions:
 The leader elector extension would contain the configuration providing lease name and namespace. This extension would be then referenced in the receivers.
 
 ### Consequences
-The Singleton Receiver Creator (https://github.com/kyma-project/opentelemetry-collector-components/tree/main/receiver/singletonreceivercreator) would be deprecated and removed. The `kymastatsreceiver` and `k8sclusterreceiver` would use the leader elector extension for leader election.
+The Singleton Receiver Creator would be deprecated and removed. The `kymastatsreceiver` and `k8sclusterreceiver` would use the leader elector extension for leader election.
 
 The change would also require changes in the `k8sclusterreceiver` to support the leader election extension.
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove dead links to the repository, after `singleonreceivercreator` removed from the repository

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/2112

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
