### PR TITLE
chore: refactor suite.K8sClient uses

### DIFF
--- a/docs/contributor/pocs/ginkgo-to-go-testing/_service_name_enrichment_test.go
+++ b/docs/contributor/pocs/ginkgo-to-go-testing/_service_name_enrichment_test.go
@@ -122,7 +122,7 @@ func TestOTelLogPipeline_ServiceNameEnrichment(t *testing.T) {
 				err := kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)
 				require.NoError(t, err)
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
 			t.Log("Waiting for resources to be ready")
 

--- a/test/e2e-migrated/logs/agent/instrumentation_scope_test.go
+++ b/test/e2e-migrated/logs/agent/instrumentation_scope_test.go
@@ -48,15 +48,15 @@ func TestInstrumentationScope(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 
 	assert.BackendDataEventuallyMatches(t.Context(), backend, HaveFlatLogs(
 		ContainElement(SatisfyAll(

--- a/test/e2e-migrated/logs/agent/payload_parser_test.go
+++ b/test/e2e-migrated/logs/agent/payload_parser_test.go
@@ -47,15 +47,15 @@ func TestPayloadParser(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 
 	// Parse traces properly
 	assert.BackendDataEventuallyMatches(t.Context(), backend, HaveFlatLogs(

--- a/test/e2e-migrated/logs/agent/trace_attributes_parser_test.go
+++ b/test/e2e-migrated/logs/agent/trace_attributes_parser_test.go
@@ -55,14 +55,14 @@ func TestAttributesParser(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
+	assert.DeploymentReady(t.Context(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
 
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 	assert.OTelLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 
 	assert.BackendDataEventuallyMatches(t.Context(), backend, HaveFlatLogs(ContainElement(SatisfyAll(

--- a/test/e2e-migrated/logs/fluentbit/custom_filter_test.go
+++ b/test/e2e-migrated/logs/fluentbit/custom_filter_test.go
@@ -35,7 +35,7 @@ func TestCustomFilterDenied(t *testing.T) {
 		Build()
 
 	Consistently(func(g Gomega) {
-		g.Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, &pipeline)).ShouldNot(Succeed())
+		g.Expect(kitk8s.CreateObjects(t.Context(), &pipeline)).ShouldNot(Succeed())
 	}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 }
 
@@ -75,14 +75,14 @@ func TestCustomFilterAllowed(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.LogPipelineUnsupportedMode(t.Context(), suite.K8sClient, pipelineName, true)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.LogPipelineUnsupportedMode(t.Context(), pipelineName, true)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, includeNs)
 	assert.FluentBitLogsFromNamespaceNotDelivered(t.Context(), backend, excludeNs)
 }

--- a/test/e2e-migrated/logs/fluentbit/custom_output_test.go
+++ b/test/e2e-migrated/logs/fluentbit/custom_output_test.go
@@ -50,13 +50,13 @@ func TestCustomOutput(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.LogPipelineUnsupportedMode(t.Context(), suite.K8sClient, pipelineName, true)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.LogPipelineUnsupportedMode(t.Context(), pipelineName, true)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.FluentBitLogsFromPodDelivered(t.Context(), backend, loggen.DefaultName)
 }

--- a/test/e2e-migrated/logs/fluentbit/dedot_test.go
+++ b/test/e2e-migrated/logs/fluentbit/dedot_test.go
@@ -46,14 +46,14 @@ func TestDedot(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, logProducer.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), logProducer.NamespacedName())
 
 	assert.BackendDataEventuallyMatches(t.Context(), backend, fluentbit.HaveFlatLogs(
 		ContainElement(fluentbit.HaveKubernetesLabels(HaveKeyWithValue("dedot_label", "logging-dedot-value")))),

--- a/test/e2e-migrated/logs/fluentbit/keep_annotation_test.go
+++ b/test/e2e-migrated/logs/fluentbit/keep_annotation_test.go
@@ -47,14 +47,14 @@ func TestKeepAnnotations(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, logProducer.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), logProducer.NamespacedName())
 
 	assert.BackendDataEventuallyMatches(t.Context(), backend, fluentbit.HaveFlatLogs(
 		ContainElement(fluentbit.HaveKubernetesAnnotations(HaveKeyWithValue("release", "v1.0.0")))),

--- a/test/e2e-migrated/logs/fluentbit/log_parser_test.go
+++ b/test/e2e-migrated/logs/fluentbit/log_parser_test.go
@@ -54,14 +54,14 @@ Types user:string pass:string`
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, logProducer.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), logProducer.NamespacedName())
 
 	assert.BackendDataEventuallyMatches(t.Context(), backend, fluentbit.HaveFlatLogs(ContainElement(SatisfyAll(
 		fluentbit.HaveAttributes(HaveKeyWithValue("user", "foo")),

--- a/test/e2e-migrated/logs/fluentbit/modify_timestamp_date_format_test.go
+++ b/test/e2e-migrated/logs/fluentbit/modify_timestamp_date_format_test.go
@@ -47,14 +47,14 @@ func TestModifyTimestampDateFormat(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, logProducer.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), logProducer.NamespacedName())
 
 	assert.BackendDataEventuallyMatches(t.Context(), backend, fluentbit.HaveFlatLogs(HaveEach(SatisfyAll(
 		fluentbit.HaveAttributes(HaveKey("@timestamp")),

--- a/test/e2e-migrated/logs/misc/version_conversion_test.go
+++ b/test/e2e-migrated/logs/misc/version_conversion_test.go
@@ -71,9 +71,9 @@ func TestVersionConversion(t *testing.T) {
 		&v1Beta1LogPipeline,
 	}
 
-	kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)
+	kitk8s.CreateObjects(t.Context(), resources...)
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
 
 	var v1Alpha1AsV1Beta1 telemetryv1beta1.LogPipeline

--- a/test/e2e-migrated/logs/shared/check_metrics_endpoint_test.go
+++ b/test/e2e-migrated/logs/shared/check_metrics_endpoint_test.go
@@ -72,11 +72,11 @@ func TestMetricsEndpoint_OTel(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+			require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
@@ -112,14 +112,14 @@ func TestMetricsEndpoint_FluentBit(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.LogPipelineUnsupportedMode(t.Context(), suite.K8sClient, pipelineName, false)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.LogPipelineUnsupportedMode(t.Context(), pipelineName, false)
 
 	fluentBitMetricsURL := suite.ProxyClient.ProxyURLForService(kitkyma.FluentBitMetricsService.Namespace, kitkyma.FluentBitMetricsService.Name, "api/v1/metrics/prometheus", fbports.HTTP)
 	assert.EmitsFluentBitMetrics(t.Context(), fluentBitMetricsURL)

--- a/test/e2e-migrated/logs/shared/container_selector_test.go
+++ b/test/e2e-migrated/logs/shared/container_selector_test.go
@@ -63,18 +63,18 @@ func TestContainerSelector_OTel(t *testing.T) {
 	resources = append(resources, backend2.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend2.NamespacedName())
+	assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+	assert.DeploymentReady(t.Context(), backend1.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend2.NamespacedName())
 
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, includePipelineName)
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, excludePipelineName)
+	assert.OTelLogPipelineHealthy(t.Context(), includePipelineName)
+	assert.OTelLogPipelineHealthy(t.Context(), excludePipelineName)
 
 	// backend1 - only container1 should be delivered
 	assert.OTelLogsFromContainerDelivered(t.Context(), backend1, container1)
@@ -128,16 +128,16 @@ func TestContainerSelector_FluentBit(t *testing.T) {
 	resources = append(resources, backend2.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend2.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend1.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend2.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, includePipelineName)
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, excludePipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), includePipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), excludePipelineName)
 
 	// backend1 - only container1 should be delivered
 	assert.FluentBitLogsFromContainerDelivered(t.Context(), backend1, container1)

--- a/test/e2e-migrated/logs/shared/disabled_input_test.go
+++ b/test/e2e-migrated/logs/shared/disabled_input_test.go
@@ -44,9 +44,9 @@ func TestDisabledInput_OTel(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
 	Eventually(func(g Gomega) {
 		var daemonSet appsv1.DaemonSet
@@ -82,9 +82,9 @@ func TestDisabledInput_FluentBit(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
 	Eventually(func(g Gomega) {
 		var daemonSet appsv1.DaemonSet

--- a/test/e2e-migrated/logs/shared/endpoint_validation_test.go
+++ b/test/e2e-migrated/logs/shared/endpoint_validation_test.go
@@ -73,12 +73,12 @@ func TestEndpointInvalid_OTel(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resourcesToSucceedCreation...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resourcesToSucceedCreation...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resourcesToSucceedCreation...)).Should(Succeed())
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resourcesToFailCreation...)).Should(MatchError(ContainSubstring("invalid hostname")))
+			Expect(kitk8s.CreateObjects(t.Context(), resourcesToSucceedCreation...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resourcesToFailCreation...)).Should(MatchError(ContainSubstring("invalid hostname")))
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineNameValueFromSecret, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineNameValueFromSecret, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonEndpointInvalid,
@@ -123,12 +123,12 @@ func TestEndpointInvalid_FluentBit(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resourcesToSucceedCreation...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resourcesToSucceedCreation...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resourcesToSucceedCreation...)).Should(Succeed())
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resourcesToFailCreation...)).Should(MatchError(ContainSubstring("invalid hostname")))
+	Expect(kitk8s.CreateObjects(t.Context(), resourcesToSucceedCreation...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resourcesToFailCreation...)).Should(MatchError(ContainSubstring("invalid hostname")))
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineNameValueFromSecret, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineNameValueFromSecret, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonEndpointInvalid,

--- a/test/e2e-migrated/logs/shared/extract_labels_test.go
+++ b/test/e2e-migrated/logs/shared/extract_labels_test.go
@@ -123,17 +123,17 @@ func TestExtractLabels_OTel(t *testing.T) {
 			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Equal(2))
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 
 			assert.BackendDataConsistentlyMatches(t.Context(), backend, HaveFlatLogs(
@@ -195,16 +195,16 @@ func TestExtractLabels_FluentBit(t *testing.T) {
 	resources = append(resources, backendDropped.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineNameNotDropped)
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineNameDropped)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineNameNotDropped)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineNameDropped)
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, types.NamespacedName{Namespace: notDroppedNs, Name: kitbackend.DefaultName})
-	assert.DeploymentReady(t.Context(), suite.K8sClient, types.NamespacedName{Namespace: droppedNs, Name: kitbackend.DefaultName})
-	assert.DeploymentReady(t.Context(), suite.K8sClient, types.NamespacedName{Namespace: genNs, Name: loggen.DefaultName})
+	assert.DeploymentReady(t.Context(), types.NamespacedName{Namespace: notDroppedNs, Name: kitbackend.DefaultName})
+	assert.DeploymentReady(t.Context(), types.NamespacedName{Namespace: droppedNs, Name: kitbackend.DefaultName})
+	assert.DeploymentReady(t.Context(), types.NamespacedName{Namespace: genNs, Name: loggen.DefaultName})
 
 	// Scenario 1: Labels not dropped
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backendNotDropped, genNs)

--- a/test/e2e-migrated/logs/shared/keep_original_body_test.go
+++ b/test/e2e-migrated/logs/shared/keep_original_body_test.go
@@ -69,17 +69,17 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 	resources = append(resources, backendGen2.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen2.NamespacedName())
+	assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+	assert.DeploymentReady(t.Context(), backendGen1.NamespacedName())
+	assert.DeploymentReady(t.Context(), backendGen2.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineKeepOriginalBodyName)
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineWithoutKeepOriginalBodyName)
+	assert.OTelLogPipelineHealthy(t.Context(), pipelineKeepOriginalBodyName)
+	assert.OTelLogPipelineHealthy(t.Context(), pipelineWithoutKeepOriginalBodyName)
 
 	assert.OTelLogsFromNamespaceDelivered(t.Context(), backendGen1, gen1Ns)
 
@@ -216,16 +216,16 @@ func TestKeepOriginalBody_FluentBit(t *testing.T) {
 	resources = append(resources, backendGen2.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backendGen2.NamespacedName())
+	assert.DeploymentReady(t.Context(), backendGen1.NamespacedName())
+	assert.DeploymentReady(t.Context(), backendGen2.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineKeepOriginalBodyName)
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineWithoutKeepOriginalBodyName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineKeepOriginalBodyName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineWithoutKeepOriginalBodyName)
 
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backendGen1, gen1Ns)
 

--- a/test/e2e-migrated/logs/shared/mtls_about_to_expire_cert_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_about_to_expire_cert_test.go
@@ -90,19 +90,19 @@ func TestMTLSAboutToExpireCert_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionTrue,
 				Reason: conditions.ReasonTLSCertificateAboutToExpire,
@@ -159,15 +159,15 @@ func TestMTLSAboutToExpireCert_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionTrue,
 		Reason: conditions.ReasonTLSCertificateAboutToExpire,

--- a/test/e2e-migrated/logs/shared/mtls_cert_key_pair_dont_match_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_cert_key_pair_dont_match_test.go
@@ -70,17 +70,17 @@ func TestMTLSCertKeyDontMatch_OTel(t *testing.T) {
 			)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonTLSConfigurationInvalid,
 			})
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeFlowHealthy,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -131,17 +131,17 @@ func TestMTLSCertKeyDontMatch_FluentBit(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonTLSConfigurationInvalid,
 	})
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,

--- a/test/e2e-migrated/logs/shared/mtls_expired_cert_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_expired_cert_test.go
@@ -69,17 +69,17 @@ func TestMTLSExpiredCert_OTel(t *testing.T) {
 			)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonTLSCertificateExpired,
 			})
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeFlowHealthy,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -130,17 +130,17 @@ func TestMTLSExpiredCert_FluentBit(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonTLSCertificateExpired,
 	})
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,

--- a/test/e2e-migrated/logs/shared/mtls_invalid_ca_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_invalid_ca_test.go
@@ -69,17 +69,17 @@ func TestMTLSInvalidCA_OTel(t *testing.T) {
 			)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonTLSConfigurationInvalid,
 			})
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeFlowHealthy,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -129,17 +129,17 @@ func TestMTLSInvalidCA_FluentBit(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonTLSConfigurationInvalid,
 	})
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,

--- a/test/e2e-migrated/logs/shared/mtls_invalid_cert_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_invalid_cert_test.go
@@ -69,17 +69,17 @@ func TestMTLSInvalidCert_OTel(t *testing.T) {
 			)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonTLSConfigurationInvalid,
 			})
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeFlowHealthy,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -129,17 +129,17 @@ func TestMTLSInvalidCert_FluentBit(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonTLSConfigurationInvalid,
 	})
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,

--- a/test/e2e-migrated/logs/shared/mtls_missing_values_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_missing_values_test.go
@@ -65,9 +65,9 @@ func TestMTLSMissingValues_OTel(t *testing.T) {
 			)
 
 			t.Cleanup(func() {
-				Expect(kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)).Should(MatchError(ContainSubstring(notFoundError))) //nolint:usetesting // Remove ctx from DeleteObjects
+				Expect(kitk8s.DeleteObjects(context.Background(), resources...)).Should(MatchError(ContainSubstring(notFoundError))) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(MatchError(ContainSubstring(tlsCrdValidationError)))
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(MatchError(ContainSubstring(tlsCrdValidationError)))
 		})
 	}
 }
@@ -103,7 +103,7 @@ func TestMTLSMissingValues_FluentBit(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		Expect(kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)).Should(MatchError(ContainSubstring(notFoundError))) //nolint:usetesting // Remove ctx from DeleteObjects
+		Expect(kitk8s.DeleteObjects(context.Background(), resources...)).Should(MatchError(ContainSubstring(notFoundError))) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(MatchError(ContainSubstring(tlsCrdValidationError)))
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(MatchError(ContainSubstring(tlsCrdValidationError)))
 }

--- a/test/e2e-migrated/logs/shared/mtls_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_test.go
@@ -84,13 +84,13 @@ func TestMTLS_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
@@ -138,12 +138,12 @@ func TestMTLS_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, backendNs)
 }

--- a/test/e2e-migrated/logs/shared/multi_pipeline_broken_test.go
+++ b/test/e2e-migrated/logs/shared/multi_pipeline_broken_test.go
@@ -85,19 +85,19 @@ func TestMultiPipelineBroken_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+			require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineGood.Name)
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineBroken.Name, metav1.Condition{
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineGood.Name)
+			assert.LogPipelineHasCondition(t.Context(), pipelineBroken.Name, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonReferencedSecretMissing,
@@ -143,15 +143,15 @@ func TestMultiPipelineBroken_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineGood.Name)
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineBroken.Name, metav1.Condition{
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineGood.Name)
+	assert.LogPipelineHasCondition(t.Context(), pipelineBroken.Name, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonReferencedSecretMissing,

--- a/test/e2e-migrated/logs/shared/multi_pipeline_fanout_test.go
+++ b/test/e2e-migrated/logs/shared/multi_pipeline_fanout_test.go
@@ -84,15 +84,15 @@ func TestMultiPipelineFanout_OTel(t *testing.T) {
 			resources = append(resources, backend2.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+			require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend1.NamespacedName())
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend2.NamespacedName())
+			assert.DeploymentReady(t.Context(), backend1.NamespacedName())
+			assert.DeploymentReady(t.Context(), backend2.NamespacedName())
 
-			assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline1.Name)
-			assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline2.Name)
+			assert.FluentBitLogPipelineHealthy(t.Context(), pipeline1.Name)
+			assert.FluentBitLogPipelineHealthy(t.Context(), pipeline2.Name)
 
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend1, genNs)
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend2, genNs)
@@ -137,15 +137,15 @@ func TestMultiPipelineFanout_FluentBit(t *testing.T) {
 	resources = append(resources, backend2.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend2.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend1.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend2.NamespacedName())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline1.Name)
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline2.Name)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipeline1.Name)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipeline2.Name)
 
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend1, genNs)
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend2, genNs)

--- a/test/e2e-migrated/logs/shared/multi_pipeline_max_pipeline_test.go
+++ b/test/e2e-migrated/logs/shared/multi_pipeline_max_pipeline_test.go
@@ -83,35 +83,35 @@ func TestMultiPipelineMaxPipeline(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...))            //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, pipelines[2:]...))        //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, &additionalFBPipeline))   //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, &additionalOTelPipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...))            //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), pipelines[2:]...))        //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), &additionalFBPipeline))   //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), &additionalOTelPipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, pipelines...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), pipelines...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
 	t.Log("Asserting 5 pipelines are healthy")
 
 	for i, pipeline := range pipelines {
 		if i%2 == 0 {
-			assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline.GetName())
+			assert.FluentBitLogPipelineHealthy(t.Context(), pipeline.GetName())
 		} else {
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline.GetName())
+			assert.OTelLogPipelineHealthy(t.Context(), pipeline.GetName())
 		}
 	}
 
 	t.Log("Attempting to create the 6th pipeline (FluentBit)")
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, &additionalFBPipeline))
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalFBPipeline.GetName(), metav1.Condition{
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), &additionalFBPipeline))
+	assert.LogPipelineHasCondition(t.Context(), additionalFBPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonMaxPipelinesExceeded,
 	})
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalFBPipeline.GetName(), metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), additionalFBPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -120,17 +120,17 @@ func TestMultiPipelineMaxPipeline(t *testing.T) {
 	t.Log("Deleting one previously healthy pipeline and expecting the additional FluentBit pipeline to be healthy")
 
 	deletePipeline := pipelines[0]
-	require.NoError(t, kitk8s.DeleteObjects(t.Context(), suite.K8sClient, deletePipeline))
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, additionalFBPipeline.GetName())
+	require.NoError(t, kitk8s.DeleteObjects(t.Context(), deletePipeline))
+	assert.FluentBitLogPipelineHealthy(t.Context(), additionalFBPipeline.GetName())
 
 	t.Log("Attempting to create the 6th pipeline (OTel)")
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, &additionalOTelPipeline))
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalOTelPipeline.GetName(), metav1.Condition{
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), &additionalOTelPipeline))
+	assert.LogPipelineHasCondition(t.Context(), additionalOTelPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonMaxPipelinesExceeded,
 	})
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalOTelPipeline.GetName(), metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), additionalOTelPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -142,8 +142,8 @@ func TestMultiPipelineMaxPipeline(t *testing.T) {
 	t.Log("Deleting one previously healthy pipeline and expecting the additional OTel pipeline to be healthy")
 
 	deletePipeline = pipelines[1]
-	require.NoError(t, kitk8s.DeleteObjects(t.Context(), suite.K8sClient, deletePipeline))
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, additionalFBPipeline.GetName())
+	require.NoError(t, kitk8s.DeleteObjects(t.Context(), deletePipeline))
+	assert.FluentBitLogPipelineHealthy(t.Context(), additionalFBPipeline.GetName())
 }
 
 func TestMultiPipelineMaxPipeline_OTel(t *testing.T) {
@@ -184,30 +184,30 @@ func TestMultiPipelineMaxPipeline_OTel(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...))        //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, pipelines[1:]...))    //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, &additionalPipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...))        //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), pipelines[1:]...))    //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), &additionalPipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, pipelines...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), pipelines...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 	t.Log("Asserting 5 pipelines are healthy")
 
 	for _, pipeline := range pipelines {
-		assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline.GetName())
+		assert.OTelLogPipelineHealthy(t.Context(), pipeline.GetName())
 	}
 
 	t.Log("Attempting to create the 6th pipeline")
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, &additionalPipeline))
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalPipeline.GetName(), metav1.Condition{
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), &additionalPipeline))
+	assert.LogPipelineHasCondition(t.Context(), additionalPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonMaxPipelinesExceeded,
 	})
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalPipeline.GetName(), metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), additionalPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -219,8 +219,8 @@ func TestMultiPipelineMaxPipeline_OTel(t *testing.T) {
 	t.Log("Deleting one previously healthy pipeline and expecting the additional pipeline to be healthy")
 
 	deletePipeline := pipelines[0]
-	require.NoError(t, kitk8s.DeleteObjects(t.Context(), suite.K8sClient, deletePipeline))
-	assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, additionalPipeline.GetName())
+	require.NoError(t, kitk8s.DeleteObjects(t.Context(), deletePipeline))
+	assert.OTelLogPipelineHealthy(t.Context(), additionalPipeline.GetName())
 }
 
 func TestMultiPipelineMaxPipeline_FluentBit(t *testing.T) {
@@ -261,30 +261,30 @@ func TestMultiPipelineMaxPipeline_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...))        //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, pipelines[1:]...))    //nolint:usetesting // Remove ctx from DeleteObjects
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, &additionalPipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...))        //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), pipelines[1:]...))    //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), &additionalPipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, pipelines...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), pipelines...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
 	t.Log("Asserting 5 pipelines are healthy")
 
 	for _, pipeline := range pipelines {
-		assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipeline.GetName())
+		assert.FluentBitLogPipelineHealthy(t.Context(), pipeline.GetName())
 	}
 
 	t.Log("Attempting to create the 6th pipeline")
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, &additionalPipeline))
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalPipeline.GetName(), metav1.Condition{
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), &additionalPipeline))
+	assert.LogPipelineHasCondition(t.Context(), additionalPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonMaxPipelinesExceeded,
 	})
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, additionalPipeline.GetName(), metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), additionalPipeline.GetName(), metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -296,6 +296,6 @@ func TestMultiPipelineMaxPipeline_FluentBit(t *testing.T) {
 	t.Log("Deleting one previously healthy pipeline and expecting the additional pipeline to be healthy")
 
 	deletePipeline := pipelines[0]
-	require.NoError(t, kitk8s.DeleteObjects(t.Context(), suite.K8sClient, deletePipeline))
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, additionalPipeline.GetName())
+	require.NoError(t, kitk8s.DeleteObjects(t.Context(), deletePipeline))
+	assert.FluentBitLogPipelineHealthy(t.Context(), additionalPipeline.GetName())
 }

--- a/test/e2e-migrated/logs/shared/namespace_selector_test.go
+++ b/test/e2e-migrated/logs/shared/namespace_selector_test.go
@@ -123,20 +123,20 @@ func TestNamespaceSelector_OTel(t *testing.T) {
 			resources = append(resources, backend2.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend1.NamespacedName())
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend2.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend1.NamespacedName())
+			assert.DeploymentReady(t.Context(), backend2.NamespacedName())
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, includePipelineName)
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, excludePipelineName)
+			assert.OTelLogPipelineHealthy(t.Context(), includePipelineName)
+			assert.OTelLogPipelineHealthy(t.Context(), excludePipelineName)
 
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend1, gen1Ns)
 			assert.OTelLogsFromNamespaceNotDelivered(t.Context(), backend2, gen2Ns)
@@ -185,15 +185,15 @@ func TestNamespaceSelector_FluentBit(t *testing.T) {
 	resources = append(resources, backend2.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, includePipelineName)
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, excludePipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), includePipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), excludePipelineName)
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend1.NamespacedName())
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend2.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend1.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend2.NamespacedName())
 
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 

--- a/test/e2e-migrated/logs/shared/observed_time_test.go
+++ b/test/e2e-migrated/logs/shared/observed_time_test.go
@@ -77,13 +77,13 @@ func TestObservedTime_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
 
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 			assert.BackendDataConsistentlyMatches(t.Context(), backend, HaveFlatLogs(

--- a/test/e2e-migrated/logs/shared/resources_test.go
+++ b/test/e2e-migrated/logs/shared/resources_test.go
@@ -78,9 +78,9 @@ func TestResources_OTel(t *testing.T) {
 				Build()
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, &pipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), &pipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, &pipeline, secret.K8sObject())).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), &pipeline, secret.K8sObject())).Should(Succeed())
 
 			assert.ResourcesExist(t.Context(), suite.K8sClient, tc.resources...)
 			// FIXME: Currently failing (resources are not deleted when pipeline becomes non-reconcilable)
@@ -129,9 +129,9 @@ func TestResources_FluentBit(t *testing.T) {
 		Build()
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, &pipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), &pipeline)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, &pipeline, secret.K8sObject())).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), &pipeline, secret.K8sObject())).Should(Succeed())
 
 	assert.ResourcesExist(t.Context(), suite.K8sClient, reources...)
 

--- a/test/e2e-migrated/logs/shared/secret_rotation_test.go
+++ b/test/e2e-migrated/logs/shared/secret_rotation_test.go
@@ -63,17 +63,17 @@ func TestSecretRotation_OTel(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeConfigurationGenerated,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonReferencedSecretMissing,
 			})
 
-			assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+			assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 				Type:   conditions.TypeFlowHealthy,
 				Status: metav1.ConditionFalse,
 				Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -87,9 +87,9 @@ func TestSecretRotation_OTel(t *testing.T) {
 			})
 
 			// Create the secret and make sure the pipeline heals
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, secret.K8sObject())).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), secret.K8sObject())).Should(Succeed())
 
-			assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+			assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 		})
 	}
 }
@@ -120,17 +120,17 @@ func TestSecretRotation_FluentBit(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonReferencedSecretMissing,
 	})
 
-	assert.LogPipelineHasCondition(t.Context(), suite.K8sClient, pipelineName, metav1.Condition{
+	assert.LogPipelineHasCondition(t.Context(), pipelineName, metav1.Condition{
 		Type:   conditions.TypeFlowHealthy,
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonSelfMonConfigNotGenerated,
@@ -144,7 +144,7 @@ func TestSecretRotation_FluentBit(t *testing.T) {
 	})
 
 	// Create the secret and make sure the pipeline heals
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, secret.K8sObject())).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), secret.K8sObject())).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 }

--- a/test/e2e-migrated/logs/shared/secretref_misconfigured_test.go
+++ b/test/e2e-migrated/logs/shared/secretref_misconfigured_test.go
@@ -44,7 +44,7 @@ func TestSecretrefMisconfigured_OTel(t *testing.T) {
 				Build()
 
 			Consistently(func(g Gomega) {
-				g.Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, &pipeline)).ShouldNot(Succeed())
+				g.Expect(kitk8s.CreateObjects(t.Context(), &pipeline)).ShouldNot(Succeed())
 			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 		})
 	}
@@ -64,6 +64,6 @@ func TestSecretrefMisconfigured_FluentBit(t *testing.T) {
 		Build()
 
 	Consistently(func(g Gomega) {
-		g.Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, &pipeline)).ShouldNot(Succeed())
+		g.Expect(kitk8s.CreateObjects(t.Context(), &pipeline)).ShouldNot(Succeed())
 	}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 }

--- a/test/e2e-migrated/logs/shared/self_monitor_happy_path_test.go
+++ b/test/e2e-migrated/logs/shared/self_monitor_happy_path_test.go
@@ -77,14 +77,14 @@ func TestSelfMonitorHappyPath_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
@@ -125,15 +125,15 @@ func TestSelfMonitorHappyPath_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+	Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.SelfMonitorName)
+	assert.DeploymentReady(t.Context(), kitkyma.SelfMonitorName)
 
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 

--- a/test/e2e-migrated/logs/shared/service_name_test.go
+++ b/test/e2e-migrated/logs/shared/service_name_test.go
@@ -116,19 +116,19 @@ func TestServiceName_OTel(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			Expect(kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(t.Context(), resources...)).Should(Succeed())
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 
 			verifyServiceNameAttr := func(givenPodPrefix, expectedServiceName string) {

--- a/test/e2e-migrated/logs/shared/single_pipeline_test.go
+++ b/test/e2e-migrated/logs/shared/single_pipeline_test.go
@@ -75,18 +75,18 @@ func TestSinglePipeline_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+			require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 		})
 	}
@@ -118,15 +118,15 @@ func TestSinglePipeline_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.LogPipelineUnsupportedMode(t.Context(), suite.K8sClient, pipelineName, false)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.LogPipelineUnsupportedMode(t.Context(), pipelineName, false)
 
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, generatorNs)
 }

--- a/test/e2e-migrated/logs/shared/single_pipeline_v1beta1_test.go
+++ b/test/e2e-migrated/logs/shared/single_pipeline_v1beta1_test.go
@@ -89,18 +89,18 @@ func TestSinglePipelineV1Beta1_OTel(t *testing.T) {
 			resources = append(resources, backend.K8sObjects()...)
 
 			t.Cleanup(func() {
-				require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+				require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 			})
-			require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+			require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-			assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
-			assert.DeploymentReady(t.Context(), suite.K8sClient, kitkyma.LogGatewayName)
+			assert.DeploymentReady(t.Context(), backend.NamespacedName())
+			assert.DeploymentReady(t.Context(), kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.LogAgentName)
 			}
 
-			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+			assert.OTelLogPipelineHealthy(t.Context(), pipelineName)
 			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 		})
 	}
@@ -148,15 +148,15 @@ func TestSinglePipelineV1Beta1_FluentBit(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+		require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 	})
-	require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+	require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-	assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+	assert.DeploymentReady(t.Context(), backend.NamespacedName())
 	assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-	assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
-	assert.LogPipelineUnsupportedMode(t.Context(), suite.K8sClient, pipelineName, false)
+	assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
+	assert.LogPipelineUnsupportedMode(t.Context(), pipelineName, false)
 
 	assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, genNs)
 }

--- a/test/e2e-migrated/upgrade/upgrade_test.go
+++ b/test/e2e-migrated/upgrade/upgrade_test.go
@@ -46,24 +46,24 @@ func TestUpgrade(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Run("before upgrade", func(t *testing.T) {
-		require.NoError(t, kitk8s.CreateObjects(t.Context(), suite.K8sClient, resources...))
+		require.NoError(t, kitk8s.CreateObjects(t.Context(), resources...))
 
-		assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+		assert.DeploymentReady(t.Context(), backend.NamespacedName())
 		assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-		assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+		assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 		assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, generatorNs)
 	})
 
 	t.Run("after upgrade", func(t *testing.T) {
 		t.Cleanup(func() {
-			require.NoError(t, kitk8s.DeleteObjects(context.Background(), suite.K8sClient, resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
+			require.NoError(t, kitk8s.DeleteObjects(context.Background(), resources...)) //nolint:usetesting // Remove ctx from DeleteObjects
 		})
 
-		assert.DeploymentReady(t.Context(), suite.K8sClient, backend.NamespacedName())
+		assert.DeploymentReady(t.Context(), backend.NamespacedName())
 		assert.DaemonSetReady(t.Context(), suite.K8sClient, kitkyma.FluentBitDaemonSetName)
 
-		assert.FluentBitLogPipelineHealthy(t.Context(), suite.K8sClient, pipelineName)
+		assert.FluentBitLogPipelineHealthy(t.Context(), pipelineName)
 		assert.FluentBitLogsFromNamespaceDelivered(t.Context(), backend, generatorNs)
 	})
 }

--- a/test/e2e/logs/fluentbit/upgrade_test.go
+++ b/test/e2e/logs/fluentbit/upgrade_test.go
@@ -56,21 +56,21 @@ var _ = Describe(suite.ID(), Label(suite.LabelLogsFluentBit), Ordered, func() {
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running pipeline", Label(suite.LabelUpgrade), func() {
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, pipelineName)
 		})
 
 		It("Should have a log backend running", Label(suite.LabelUpgrade), func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a log producer running", Label(suite.LabelUpgrade), func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should have produced logs in the backend", Label(suite.LabelUpgrade), func() {

--- a/test/e2e/metrics/basic_v1alpha1_test.go
+++ b/test/e2e/metrics/basic_v1alpha1_test.go
@@ -65,13 +65,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", Label(suite.LabelUpgrade), func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should reject scaling below minimum", Label(suite.LabelUpgrade), func() {
@@ -156,7 +156,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 		})
 
 		It("Should have a metrics backend running", Label(suite.LabelUpgrade), func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/basic_v1beta1_test.go
+++ b/test/e2e/metrics/basic_v1beta1_test.go
@@ -69,13 +69,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics, suite.LabelExperimental),
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should reject scaling below minimum", func() {
@@ -160,7 +160,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics, suite.LabelExperimental),
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/endpoint_invalid_test.go
+++ b/test/e2e/metrics/endpoint_invalid_test.go
@@ -69,9 +69,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipelines", func() {

--- a/test/e2e/metrics/endpoint_path_validation_test.go
+++ b/test/e2e/metrics/endpoint_path_validation_test.go
@@ -41,29 +41,29 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 
 		BeforeAll(func() {
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient,
+				Expect(kitk8s.DeleteObjects(suite.Ctx,
 					&metricPipelineWithGRPCAndWithoutPath, &metricPipelineWithHTTPAndPath, &metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())
 			})
 		})
 
 		It("Should reject a MetricPipeline with path and default protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
 		})
 
 		It("Should reject a MetricPipeline with path and gRPC protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipelineWithGRPCAndPath)).ShouldNot(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipelineWithGRPCAndPath)).ShouldNot(Succeed())
 		})
 
 		It("Should accept a MetricPipeline with no path and gRPC protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipelineWithGRPCAndWithoutPath)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipelineWithGRPCAndWithoutPath)).Should(Succeed())
 		})
 
 		It("Should accept a MetricPipeline with no path and HTTP protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipelineWithHTTPAndWithoutPath)).Should(Succeed())
 		})
 
 		It("Should accept a MetricPipeline with path and HTTP protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipelineWithHTTPAndPath)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipelineWithHTTPAndPath)).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/metrics/endpoint_port_test.go
+++ b/test/e2e/metrics/endpoint_port_test.go
@@ -68,9 +68,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipelines", func() {

--- a/test/e2e/metrics/endpoint_with_path_test.go
+++ b/test/e2e/metrics/endpoint_with_path_test.go
@@ -43,9 +43,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a secret with endpoint and path", func() {

--- a/test/e2e/metrics/kyma_input_test.go
+++ b/test/e2e/metrics/kyma_input_test.go
@@ -52,20 +52,20 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 		k8sObjects := makeResources()
 
 		DeferCleanup(func() {
-			Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
-		Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+		Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 	})
 
 	Context("When a metricpipeline with kyma input annotation exists", Ordered, func() {
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Ensures the metrics backends are ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendForKymaInputName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendForKymaInputName, Namespace: mockNs})
 		})
 
 		It("Ensures the metric pipelines are healthy", func() {

--- a/test/e2e/metrics/mtls_about_to_expire_cert_test.go
+++ b/test/e2e/metrics/mtls_about_to_expire_cert_test.go
@@ -65,9 +65,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -75,7 +75,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 		})
 
 		It("Should have running metrics gateway", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a tlsCertAboutToExpire Condition set in pipeline conditions", func() {
@@ -96,7 +96,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 		})
 
 		It("Should have a metric backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/mtls_cert_key_pair_dont_match_test.go
+++ b/test/e2e/metrics/mtls_cert_key_pair_dont_match_test.go
@@ -68,9 +68,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/metrics/mtls_expired_cert_test.go
+++ b/test/e2e/metrics/mtls_expired_cert_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/metrics/mtls_invalid_ca_test.go
+++ b/test/e2e/metrics/mtls_invalid_ca_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/metrics/mtls_invalid_cert_test.go
+++ b/test/e2e/metrics/mtls_invalid_cert_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/metrics/mtls_missing_values_test.go
+++ b/test/e2e/metrics/mtls_missing_values_test.go
@@ -116,12 +116,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sSucceedingObjects, k8sFailingObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sSucceedingObjects...)).Should(Succeed())
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sFailingObjects...)).
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sSucceedingObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sFailingObjects...)).
 					Should(MatchError(ContainSubstring(notFoundError)))
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sSucceedingObjects...)).Should(Succeed())
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sFailingObjects...)).
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sSucceedingObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sFailingObjects...)).
 				Should(MatchError(ContainSubstring(tlsCrdValidationError)))
 		})
 

--- a/test/e2e/metrics/mtls_test.go
+++ b/test/e2e/metrics/mtls_test.go
@@ -60,9 +60,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -70,11 +70,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 		})
 
 		It("Should have running metric gateway", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a metric backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/multi_pipeline_broken_pipeline_test.go
+++ b/test/e2e/metrics/multi_pipeline_broken_pipeline_test.go
@@ -59,9 +59,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -70,11 +70,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/multi_pipeline_max_pipeline_test.go
+++ b/test/e2e/metrics/multi_pipeline_max_pipeline_test.go
@@ -55,9 +55,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMaxPipeline), Ordered, func() {
 					return obj.GetName() == pipelineCreatedFirst.GetName() // first pipeline is deleted separately in one of the specs
 				})
 				k8sObjectsToDelete = append(k8sObjectsToDelete, pipelineCreatedLater)
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjectsToDelete...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjectsToDelete...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have only running pipelines", func() {
@@ -73,7 +73,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMaxPipeline), Ordered, func() {
 				pipelineCreatedLater = &pipeline
 				pipelinesNames = append(pipelinesNames, pipelineName)
 
-				Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &pipeline)).Should(Succeed())
+				Expect(kitk8s.CreateObjects(suite.Ctx, &pipeline)).Should(Succeed())
 
 				assert.MetricPipelineHasCondition(suite.Ctx, suite.K8sClient, pipelineName, metav1.Condition{
 					Type:   conditions.TypeConfigurationGenerated,
@@ -91,7 +91,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMaxPipeline), Ordered, func() {
 
 		It("Should have only running pipeline", func() {
 			By("Deleting a pipeline", func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, pipelineCreatedFirst)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, pipelineCreatedFirst)).Should(Succeed())
 
 				for _, pipeline := range pipelinesNames[1:] {
 					assert.MetricPipelineHealthy(suite.Ctx, suite.K8sClient, pipeline)

--- a/test/e2e/metrics/multi_pipeline_namespace_selector_test.go
+++ b/test/e2e/metrics/multi_pipeline_namespace_selector_test.go
@@ -80,14 +80,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running metric agent daemonset", func() {
@@ -95,8 +95,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
 		})

--- a/test/e2e/metrics/multi_pipeline_test.go
+++ b/test/e2e/metrics/multi_pipeline_test.go
@@ -85,9 +85,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -96,13 +96,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayMetricsService)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendRuntimeName, Namespace: mockNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendPrometheusName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendRuntimeName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendPrometheusName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendRuntimeName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendPrometheusName, Namespace: mockNs})
 		})

--- a/test/e2e/metrics/no_input_test.go
+++ b/test/e2e/metrics/no_input_test.go
@@ -59,19 +59,19 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics, suite.LabelSetA), Ordered
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
 			k8sObjectsToCreate := append(k8sObjects, &metricPipelineWithInput)
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjectsToCreate...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjectsToCreate...)).Should(Succeed())
 		})
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
@@ -93,7 +93,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics, suite.LabelSetA), Ordered
 		})
 
 		It("Should delete the pipeline with input", func() {
-			Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &metricPipelineWithInput)).Should(Succeed())
+			Expect(kitk8s.DeleteObjects(suite.Ctx, &metricPipelineWithInput)).Should(Succeed())
 		})
 
 		It("Ensures the metric agent DaemonSet is no longer running", func() {

--- a/test/e2e/metrics/otlp_input_test.go
+++ b/test/e2e/metrics/otlp_input_test.go
@@ -48,18 +48,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/prometheus_input_diagnostic_metric_test.go
+++ b/test/e2e/metrics/prometheus_input_diagnostic_metric_test.go
@@ -57,18 +57,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Ensures the metrics backend is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Ensures the metric agent daemonset is ready", func() {

--- a/test/e2e/metrics/prometheus_input_test.go
+++ b/test/e2e/metrics/prometheus_input_test.go
@@ -59,14 +59,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Ensures the metric agent daemonset is ready", func() {
@@ -74,7 +74,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 		})
 
 		It("Ensures the metrics backend is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Ensures the metricpipeline is running", func() {

--- a/test/e2e/metrics/resources_test.go
+++ b/test/e2e/metrics/resources_test.go
@@ -34,9 +34,9 @@ var _ = Describe(suite.ID(), Ordered, func() {
 
 		BeforeAll(func() {
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &metricPipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &metricPipeline)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipeline, secret.K8sObject())).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipeline, secret.K8sObject())).Should(Succeed())
 		})
 
 		Context("Should have gateway resources", Ordered, func() {
@@ -86,7 +86,7 @@ var _ = Describe(suite.ID(), Ordered, func() {
 			})
 
 			It("Should have a gateway Deployment with correct pod priority class", func() {
-				assert.DeploymentHasPriorityClass(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName, "telemetry-priority-class")
+				assert.DeploymentHasPriorityClass(suite.Ctx, kitkyma.MetricGatewayName, "telemetry-priority-class")
 			})
 		})
 
@@ -150,9 +150,9 @@ var _ = Describe(suite.ID(), Ordered, func() {
 
 		BeforeAll(func() {
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &metricPipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &metricPipeline)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipeline, secret.K8sObject())).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipeline, secret.K8sObject())).Should(Succeed())
 		})
 
 		Context("should have experimental gateway resources", Ordered, func() {

--- a/test/e2e/metrics/runtime_input_test.go
+++ b/test/e2e/metrics/runtime_input_test.go
@@ -140,9 +140,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have healthy pipelines", func() {
@@ -151,7 +151,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 		})
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Ensures the metric agent daemonset is ready", func() {
@@ -159,15 +159,15 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 		})
 
 		It("Should have metrics backends running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendResourceMetricsEnabledNameA, Namespace: mockNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendResourceMetricsEnabledNameB, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendResourceMetricsEnabledNameA, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendResourceMetricsEnabledNameB, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendResourceMetricsEnabledNameA, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendResourceMetricsEnabledNameB, Namespace: mockNs})
 
 		})
 
 		It("should have workloads created properly", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: DeploymentName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: DeploymentName, Namespace: mockNs})
 			assert.DaemonSetReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: DaemonSetName, Namespace: mockNs})
 			assert.StatefulSetReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: StatefulSetName, Namespace: mockNs})
 			assert.JobReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: JobName, Namespace: mockNs})

--- a/test/e2e/metrics/runtime_node_namespace_test.go
+++ b/test/e2e/metrics/runtime_node_namespace_test.go
@@ -94,9 +94,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 				k8sObjects := makeResources()
 
 				DeferCleanup(func() {
-					Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+					Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 				})
-				Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
 			It("Should have healthy pipelines", func() {
@@ -104,7 +104,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			})
 
 			It("Ensures the metric gateway deployment is ready", func() {
-				assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+				assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 			})
 
 			It("Ensures the metric agent daemonset is ready", func() {
@@ -112,7 +112,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetB), 
 			})
 
 			It("Should have metrics backends running", func() {
-				assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendOnlyNodeMetricsEnabledName, Namespace: tt.namespace})
+				assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendOnlyNodeMetricsEnabledName, Namespace: tt.namespace})
 				assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendOnlyNodeMetricsEnabledName, Namespace: tt.namespace})
 
 			})

--- a/test/e2e/metrics/secret_missing_test.go
+++ b/test/e2e/metrics/secret_missing_test.go
@@ -31,10 +31,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 			Build()
 
 		BeforeAll(func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipeline)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipeline)).Should(Succeed())
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &metricPipeline, secret.K8sObject())).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &metricPipeline, secret.K8sObject())).Should(Succeed())
 			})
 		})
 
@@ -73,7 +73,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetC), 
 
 		It("Should have running metricpipeline", func() {
 			By("Creating missing secret", func() {
-				Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, secret.K8sObject())).Should(Succeed())
+				Expect(kitk8s.CreateObjects(suite.Ctx, secret.K8sObject())).Should(Succeed())
 			})
 
 			assert.MetricPipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)

--- a/test/e2e/metrics/service_name_test.go
+++ b/test/e2e/metrics/service_name_test.go
@@ -80,13 +80,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Label(suite.LabelSetA), 
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 

--- a/test/e2e/metrics/validation_test.go
+++ b/test/e2e/metrics/validation_test.go
@@ -31,7 +31,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMetrics), Ordered, func() {
 				WithOTLPOutput(testutils.OTLPBasicAuthFromSecret("name", "namespace", "", "")).
 				Build()
 			Consistently(func(g Gomega) {
-				g.Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipeline)).ShouldNot(Succeed())
+				g.Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipeline)).ShouldNot(Succeed())
 			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 		})
 	})

--- a/test/e2e/misc/overrides_test.go
+++ b/test/e2e/misc/overrides_test.go
@@ -97,18 +97,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 				k8sObjects = append(k8sObjects, overrides)
 			}
 
-			Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
-		Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+		Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 	})
 
 	Context("When a logpipeline with HTTP output exists", Ordered, func() {
 		It("Should have a running logpipeline", func() {
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, pipelineName)
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have INFO level logs in the backend", func() {
@@ -142,7 +142,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 
 		It("Should add the overrides configmap and modify the log pipeline", func() {
 			overrides = kitk8s.NewOverrides().WithLogLevel(kitk8s.DEBUG).K8sObject()
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, overrides)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, overrides)).Should(Succeed())
 
 			lookupKey := types.NamespacedName{
 				Name: pipelineName,

--- a/test/e2e/misc/telemetry_logs_analysis_test.go
+++ b/test/e2e/misc/telemetry_logs_analysis_test.go
@@ -147,24 +147,24 @@ var _ = Describe(suite.ID(), Label(suite.LabelMisc), Ordered, func() {
 			K8sObjects = append(K8sObjects, objs...)
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, K8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, K8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, K8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, K8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running metric and trace gateways", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have running backends", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: namespace, Name: logBackendName})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: namespace, Name: metricBackendName})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: namespace, Name: traceBackendName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: namespace, Name: logBackendName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: namespace, Name: metricBackendName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: namespace, Name: traceBackendName})
 
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: namespace, Name: otelCollectorLogBackendName})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: namespace, Name: fluentBitLogBackendName})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: namespace, Name: selfMonitorLogBackendName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: namespace, Name: otelCollectorLogBackendName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: namespace, Name: fluentBitLogBackendName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: namespace, Name: selfMonitorLogBackendName})
 		})
 
 		It("Should have running agents", func() {
@@ -173,13 +173,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMisc), Ordered, func() {
 		})
 
 		It("Should have running pipelines", func() {
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, logBackendName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, logBackendName)
 			assert.MetricPipelineHealthy(suite.Ctx, suite.K8sClient, metricBackendName)
 			assert.TracePipelineHealthy(suite.Ctx, suite.K8sClient, traceBackendName)
 
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, otelCollectorLogBackendName)
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, fluentBitLogBackendName)
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, selfMonitorLogBackendName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, otelCollectorLogBackendName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, fluentBitLogBackendName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, selfMonitorLogBackendName)
 		})
 
 		It("Should push metrics successfully", func() {

--- a/test/e2e/misc/telemetry_test.go
+++ b/test/e2e/misc/telemetry_test.go
@@ -37,9 +37,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 			tracePipeline := testutils.NewTracePipelineBuilder().WithName(tracePipelineName).Build()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &tracePipeline)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipeline)).Should(Succeed())
 		})
 
 		It("Should have Telemetry with TracePipeline endpoints", func() {
@@ -64,9 +64,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 			metricPipeline := testutils.NewMetricPipelineBuilder().WithName(metricPipelineName).Build()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &metricPipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &metricPipeline)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &metricPipeline)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &metricPipeline)).Should(Succeed())
 		})
 
 		It("Should have Telemetry with MetricPipeline endpoints", func() {
@@ -92,9 +92,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 				Build()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &tracePipeline)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipeline)).Should(Succeed())
 		})
 
 		It("Should have Telemetry with warning state", func() {
@@ -182,7 +182,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 
 		BeforeAll(func() {
 			Eventually(func(g Gomega) {
-				g.Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &logPipeline)).Should(Succeed())
+				g.Expect(kitk8s.CreateObjects(suite.Ctx, &logPipeline)).Should(Succeed())
 			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 		})
 
@@ -190,7 +190,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 			// Recreate Telemetry for remaining tests
 			Eventually(func(g Gomega) {
 				newTelemetry := []client.Object{kitk8s.NewTelemetry("default", "kyma-system").K8sObject()}
-				g.Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, newTelemetry...)).Should(Succeed())
+				g.Expect(kitk8s.CreateObjects(suite.Ctx, newTelemetry...)).Should(Succeed())
 			}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 
 			Eventually(func(g Gomega) {
@@ -219,7 +219,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 			By("Deleting telemetry", func() {
 				var telemetry operatorv1alpha1.Telemetry
 				Expect(suite.K8sClient.Get(suite.Ctx, kitkyma.TelemetryName, &telemetry)).Should(Succeed())
-				Expect(kitk8s.ForceDeleteObjects(suite.Ctx, suite.K8sClient, &telemetry)).Should(Succeed())
+				Expect(kitk8s.ForceDeleteObjects(suite.Ctx, &telemetry)).Should(Succeed())
 			})
 
 			Eventually(func(g Gomega) {
@@ -259,7 +259,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 
 		It("Should delete Telemetry", func() {
 			By("Deleting the orphaned LogPipeline", func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &logPipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &logPipeline)).Should(Succeed())
 			})
 
 			Eventually(func(g Gomega) {

--- a/test/e2e/selfmonitor/metrics_healthy_test.go
+++ b/test/e2e/selfmonitor/metrics_healthy_test.go
@@ -57,9 +57,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsHealthy), Ord
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have global internal metrics compatibility annotation config", func() {
@@ -79,7 +79,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsHealthy), Ord
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have service deployed", func() {
@@ -88,7 +88,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsHealthy), Ord
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
@@ -97,7 +97,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsHealthy), Ord
 		})
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should deliver telemetrygen metrics", func() {

--- a/test/e2e/selfmonitor/traces_healthy_test.go
+++ b/test/e2e/selfmonitor/traces_healthy_test.go
@@ -59,13 +59,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesHealthy), Orde
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a network policy deployed", func() {
@@ -96,7 +96,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesHealthy), Orde
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should deliver telemetrygen traces", func() {

--- a/test/e2e/traces/basic_v1alpha1_test.go
+++ b/test/e2e/traces/basic_v1alpha1_test.go
@@ -66,13 +66,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running trace gateway deployment", Label(suite.LabelUpgrade), func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have 2 trace gateway replicas", Label(suite.LabelUpgrade), func() {
@@ -166,7 +166,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should have a trace backend running", Label(suite.LabelUpgrade), func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should have a running pipeline", Label(suite.LabelUpgrade), func() {

--- a/test/e2e/traces/basic_v1beta1_test.go
+++ b/test/e2e/traces/basic_v1beta1_test.go
@@ -68,13 +68,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces, suite.LabelExperimental), 
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have 2 trace gateway replicas", func() {
@@ -168,7 +168,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces, suite.LabelExperimental), 
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should have a running pipeline", func() {

--- a/test/e2e/traces/endpoint_invalid_test.go
+++ b/test/e2e/traces/endpoint_invalid_test.go
@@ -70,9 +70,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipelines", func() {

--- a/test/e2e/traces/endpoint_path_validation_test.go
+++ b/test/e2e/traces/endpoint_path_validation_test.go
@@ -41,29 +41,29 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 
 		BeforeAll(func() {
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient,
+				Expect(kitk8s.DeleteObjects(suite.Ctx,
 					&tracePipelineWithGRPCAndWithoutPath, &tracePipelineWithHTTPAndPath, &tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())
 			})
 		})
 
 		It("Should reject a TracePipeline with path and default protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipelineDefaultGRPCWithPath)).ShouldNot(Succeed())
 		})
 
 		It("Should reject a TracePipeline with path and gRPC protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipelineWithGRPCAndPath)).ShouldNot(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipelineWithGRPCAndPath)).ShouldNot(Succeed())
 		})
 
 		It("Should accept a TracePipeline with no path and gRPC protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipelineWithGRPCAndWithoutPath)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipelineWithGRPCAndWithoutPath)).Should(Succeed())
 		})
 
 		It("Should accept a TracePipeline with no path and HTTP protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipelineWithHTTPAndWithoutPath)).Should(Succeed())
 		})
 
 		It("Should accept a TracePipeline with path and HTTP protocol", func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipelineWithHTTPAndPath)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipelineWithHTTPAndPath)).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/traces/endpoint_port_test.go
+++ b/test/e2e/traces/endpoint_port_test.go
@@ -68,9 +68,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipelines", func() {

--- a/test/e2e/traces/endpoint_with_path_test.go
+++ b/test/e2e/traces/endpoint_with_path_test.go
@@ -47,9 +47,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a secret with endpoint and path", func() {

--- a/test/e2e/traces/mtls_about_to_expire_cert_test.go
+++ b/test/e2e/traces/mtls_about_to_expire_cert_test.go
@@ -65,9 +65,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -75,7 +75,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a tlsCertificateAboutToExpire Condition set in pipeline conditions", func() {
@@ -96,7 +96,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should deliver telemetrygen traces", func() {

--- a/test/e2e/traces/mtls_cert_key_pair_dont_match_test.go
+++ b/test/e2e/traces/mtls_cert_key_pair_dont_match_test.go
@@ -67,9 +67,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/traces/mtls_expired_cert_test.go
+++ b/test/e2e/traces/mtls_expired_cert_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/traces/mtls_invalid_ca_test.go
+++ b/test/e2e/traces/mtls_invalid_ca_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/traces/mtls_invalid_cert_test.go
+++ b/test/e2e/traces/mtls_invalid_cert_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should set ConfigurationGenerated condition to False in pipeline", func() {

--- a/test/e2e/traces/mtls_missing_values_test.go
+++ b/test/e2e/traces/mtls_missing_values_test.go
@@ -116,12 +116,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sSucceedingObjects, k8sFailingObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sSucceedingObjects...)).Should(Succeed())
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sFailingObjects...)).
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sSucceedingObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sFailingObjects...)).
 					Should(MatchError(ContainSubstring(notFoundError)))
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sSucceedingObjects...)).Should(Succeed())
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sFailingObjects...)).
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sSucceedingObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sFailingObjects...)).
 				Should(MatchError(ContainSubstring(tlsCrdValidationError)))
 		})
 

--- a/test/e2e/traces/mtls_test.go
+++ b/test/e2e/traces/mtls_test.go
@@ -59,9 +59,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -69,11 +69,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should verify traces from telemetrygen are delivered", func() {

--- a/test/e2e/traces/multi_pipeline_broken_pipeline_test.go
+++ b/test/e2e/traces/multi_pipeline_broken_pipeline_test.go
@@ -60,9 +60,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -71,11 +71,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), Ordered, func() {
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should verify traces from telemetrygen are delivered", func() {

--- a/test/e2e/traces/multi_pipeline_max_pipeline_test.go
+++ b/test/e2e/traces/multi_pipeline_max_pipeline_test.go
@@ -54,9 +54,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelMaxPipeline), Ordered, func() {
 					return obj.GetName() == pipelineCreatedFirst.GetName() // first pipeline is deleted separately in one of the specs
 				})
 				k8sObjectsToDelete = append(k8sObjectsToDelete, pipelineCreatedLater)
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjectsToDelete...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjectsToDelete...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have only running pipelines", func() {
@@ -72,7 +72,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMaxPipeline), Ordered, func() {
 				pipelineCreatedLater = &pipeline
 				pipelinesNames = append(pipelinesNames, pipelineName)
 
-				Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &pipeline)).Should(Succeed())
+				Expect(kitk8s.CreateObjects(suite.Ctx, &pipeline)).Should(Succeed())
 
 				assert.TracePipelineHasCondition(suite.Ctx, suite.K8sClient, pipelineName, metav1.Condition{
 					Type:   conditions.TypeConfigurationGenerated,
@@ -90,7 +90,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMaxPipeline), Ordered, func() {
 
 		It("Should have only running pipelines", func() {
 			By("Deleting a pipeline", func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, pipelineCreatedFirst)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, pipelineCreatedFirst)).Should(Succeed())
 
 				for _, pipeline := range pipelinesNames[1:] {
 					assert.TracePipelineHealthy(suite.Ctx, suite.K8sClient, pipeline)

--- a/test/e2e/traces/multi_pipeline_test.go
+++ b/test/e2e/traces/multi_pipeline_test.go
@@ -61,9 +61,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have running pipelines", func() {
@@ -72,12 +72,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), Ordered, func() {
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
 		})
 
 		It("Should verify traces from telemetrygen are delivered", func() {

--- a/test/e2e/traces/noisy_span_filter_test.go
+++ b/test/e2e/traces/noisy_span_filter_test.go
@@ -152,9 +152,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running pipeline", func() {
@@ -162,11 +162,11 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should deliver regular telemetrygen traces", func() {

--- a/test/e2e/traces/resources_test.go
+++ b/test/e2e/traces/resources_test.go
@@ -33,9 +33,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 
 		BeforeAll(func() {
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &tracePipeline)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipeline, secret.K8sObject())).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipeline, secret.K8sObject())).Should(Succeed())
 		})
 
 		It("Should have a ServiceAccount owned by the TracePipeline", func() {
@@ -84,7 +84,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should have a Deployment with correct pod priority class", func() {
-			assert.DeploymentHasPriorityClass(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName, "telemetry-priority-class")
+			assert.DeploymentHasPriorityClass(suite.Ctx, kitkyma.TraceGatewayName, "telemetry-priority-class")
 		})
 
 		It("Should clean up gateway resources when pipeline becomes non-reconcilable", func() {

--- a/test/e2e/traces/secret_missing_test.go
+++ b/test/e2e/traces/secret_missing_test.go
@@ -31,10 +31,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			Build()
 
 		BeforeAll(func() {
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipeline)).Should(Succeed())
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, &tracePipeline, secret.K8sObject())).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, &tracePipeline, secret.K8sObject())).Should(Succeed())
 			})
 		})
 
@@ -73,7 +73,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 
 		It("Should have running tracepipeline", func() {
 			By("Creating missing secret", func() {
-				Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, secret.K8sObject())).Should(Succeed())
+				Expect(kitk8s.CreateObjects(suite.Ctx, secret.K8sObject())).Should(Succeed())
 			})
 
 			assert.TracePipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)

--- a/test/e2e/traces/service_name_test.go
+++ b/test/e2e/traces/service_name_test.go
@@ -67,18 +67,18 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should have a running pipeline", func() {

--- a/test/e2e/traces/validation_test.go
+++ b/test/e2e/traces/validation_test.go
@@ -31,7 +31,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), Ordered, func() {
 				WithOTLPOutput(testutils.OTLPBasicAuthFromSecret("name", "namespace", "", "")).
 				Build()
 			Consistently(func(g Gomega) {
-				g.Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, &tracePipeline)).ShouldNot(Succeed())
+				g.Expect(kitk8s.CreateObjects(suite.Ctx, &tracePipeline)).ShouldNot(Succeed())
 			}, periodic.ConsistentlyTimeout, periodic.DefaultInterval).Should(Succeed())
 		})
 	})

--- a/test/integration/istio/access_logs_test.go
+++ b/test/integration/istio/access_logs_test.go
@@ -64,13 +64,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should have sample app running", func() {
@@ -83,7 +83,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have the log pipeline running", func() {
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, pipelineName)
 		})
 
 		It("Should have a running log agent daemonset", func() {

--- a/test/integration/istio/logs_self_monitor_backpressure_test.go
+++ b/test/integration/istio/logs_self_monitor_backpressure_test.go
@@ -47,13 +47,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsBackpressure), O
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running logpipeline", func() {
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, pipelineName)
 		})
 
 		It("Should have a running log agent daemonset", func() {
@@ -61,19 +61,19 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsBackpressure), O
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a log producer running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should wait for the log flow to gradually become unhealthy", func() {
-			assert.LogPipelineConditionReasonsTransition(suite.Ctx, suite.K8sClient, pipelineName, conditions.TypeFlowHealthy, []assert.ReasonStatus{
+			assert.LogPipelineConditionReasonsTransition(suite.Ctx, pipelineName, conditions.TypeFlowHealthy, []assert.ReasonStatus{
 				{Reason: conditions.ReasonSelfMonFlowHealthy, Status: metav1.ConditionTrue},
 				{Reason: conditions.ReasonSelfMonBufferFillingUp, Status: metav1.ConditionFalse},
 				{Reason: conditions.ReasonSelfMonSomeDataDropped, Status: metav1.ConditionFalse},

--- a/test/integration/istio/logs_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_self_monitor_outage_test.go
@@ -51,17 +51,17 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsOutage), Ordered
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running logpipeline", func() {
-			assert.FluentBitLogPipelineHealthy(suite.Ctx, suite.K8sClient, pipelineName)
+			assert.FluentBitLogPipelineHealthy(suite.Ctx, pipelineName)
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a running log agent daemonset", func() {
@@ -69,15 +69,15 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsOutage), Ordered
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a log producer running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: loggen.DefaultName})
 		})
 
 		It("Should wait for the log flow to gradually become unhealthy", func() {
-			assert.LogPipelineConditionReasonsTransition(suite.Ctx, suite.K8sClient, pipelineName, conditions.TypeFlowHealthy, []assert.ReasonStatus{
+			assert.LogPipelineConditionReasonsTransition(suite.Ctx, pipelineName, conditions.TypeFlowHealthy, []assert.ReasonStatus{
 				{Reason: conditions.ReasonSelfMonFlowHealthy, Status: metav1.ConditionTrue},
 				{Reason: conditions.ReasonSelfMonNoLogsDelivered, Status: metav1.ConditionFalse},
 				{Reason: conditions.ReasonSelfMonAllDataDropped, Status: metav1.ConditionFalse},

--- a/test/integration/istio/metrics_cloud_provider_attributes_test.go
+++ b/test/integration/istio/metrics_cloud_provider_attributes_test.go
@@ -82,9 +82,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Label(suite.LabelMet
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have healthy pipelines", func() {
@@ -92,16 +92,16 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Label(suite.LabelMet
 		})
 
 		It("Ensures the metric gateway deployment is ready", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have metrics backends running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backendName, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backendName, Namespace: mockNs})
 		})
 
 		It("should have workloads created properly", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: DeploymentName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: DeploymentName, Namespace: mockNs})
 		})
 
 		It("Ensures accessibility of metric agent metrics endpoint", func() {

--- a/test/integration/istio/metrics_istio_envoy_multi_pipeline_test.go
+++ b/test/integration/istio/metrics_istio_envoy_multi_pipeline_test.go
@@ -80,14 +80,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running metric agent daemonset", func() {
@@ -95,8 +95,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend1Name, Namespace: mockNs})
 			assert.ServiceReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: backend2Name, Namespace: mockNs})
 		})

--- a/test/integration/istio/metrics_istio_input_envoy_metrics_test.go
+++ b/test/integration/istio/metrics_istio_input_envoy_metrics_test.go
@@ -62,14 +62,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running metric agent daemonset", func() {
@@ -77,7 +77,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should have a running metric agent daemonset", func() {

--- a/test/integration/istio/metrics_istio_input_test.go
+++ b/test/integration/istio/metrics_istio_input_test.go
@@ -101,14 +101,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running metric agent daemonset", func() {
@@ -116,7 +116,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should have a running metric agent daemonset", func() {

--- a/test/integration/istio/metrics_otlp_input_test.go
+++ b/test/integration/istio/metrics_otlp_input_test.go
@@ -82,7 +82,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 				for _, resource := range k8sObjects {
 					Eventually(func(g Gomega) {
 						key := types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}
@@ -92,16 +92,16 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 				}
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: istiofiedBackendNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: istiofiedBackendNs})
 		})
 
 		It("Should push metrics successfully", func() {

--- a/test/integration/istio/metrics_prometheus_input_test.go
+++ b/test/integration/istio/metrics_prometheus_input_test.go
@@ -72,14 +72,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
 
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running metric agent daemonset", func() {
@@ -87,7 +87,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
 		})
 
 		Context("Verify metric scraping works with annotating pods and services", Ordered, func() {

--- a/test/integration/istio/metrics_self_monitor_backpressure_test.go
+++ b/test/integration/istio/metrics_self_monitor_backpressure_test.go
@@ -51,9 +51,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsBackpressure)
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metricpipeline", func() {
@@ -61,19 +61,19 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsBackpressure)
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a telemetrygen running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should wait for the metrics flow to gradually become unhealthy", func() {

--- a/test/integration/istio/metrics_self_monitor_outage_test.go
+++ b/test/integration/istio/metrics_self_monitor_outage_test.go
@@ -79,9 +79,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running metricpipeline", func() {
@@ -89,19 +89,19 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 		})
 
 		It("Should have a running metric gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.MetricGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.MetricGatewayName)
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a telemetrygen running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should wait for the metrics flow to report a full buffer", func() {

--- a/test/integration/istio/traces_self_monitor_backpressure_test.go
+++ b/test/integration/istio/traces_self_monitor_backpressure_test.go
@@ -51,9 +51,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesBackpressure),
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running tracepipeline", func() {
@@ -61,19 +61,19 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesBackpressure),
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a telemetrygen running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should wait for the trace flow to gradually become unhealthy", func() {

--- a/test/integration/istio/traces_self_monitor_outage_test.go
+++ b/test/integration/istio/traces_self_monitor_outage_test.go
@@ -54,9 +54,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 		BeforeAll(func() {
 			k8sObjects := makeResources()
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a running tracepipeline", func() {
@@ -64,19 +64,19 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have a running self-monitor", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.SelfMonitorName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.SelfMonitorName)
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
 		})
 
 		It("Should have a telemetrygen running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})
 
 		It("Should wait for the trace flow to report a full buffer", func() {

--- a/test/integration/istio/traces_test.go
+++ b/test/integration/istio/traces_test.go
@@ -93,14 +93,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 			k8sObjects := makeResources()
 
 			DeferCleanup(func() {
-				Expect(kitk8s.DeleteObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+				Expect(kitk8s.DeleteObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 			})
-			Expect(kitk8s.CreateObjects(suite.Ctx, suite.K8sClient, k8sObjects...)).Should(Succeed())
+			Expect(kitk8s.CreateObjects(suite.Ctx, k8sObjects...)).Should(Succeed())
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: istiofiedBackendNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
+			assert.DeploymentReady(suite.Ctx, types.NamespacedName{Name: kitbackend.DefaultName, Namespace: istiofiedBackendNs})
 		})
 
 		It("Should have sample app running with Istio sidecar", func() {
@@ -113,7 +113,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelIntegration), Ordered, func() {
 		})
 
 		It("Should have a running trace gateway deployment", func() {
-			assert.DeploymentReady(suite.Ctx, suite.K8sClient, kitkyma.TraceGatewayName)
+			assert.DeploymentReady(suite.Ctx, kitkyma.TraceGatewayName)
 		})
 
 		It("Should have the trace pipelines running", func() {

--- a/test/testkit/assert/deployment.go
+++ b/test/testkit/assert/deployment.go
@@ -11,11 +11,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
 
-func DeploymentReady(ctx context.Context, k8sClient client.Client, name types.NamespacedName) {
+func DeploymentReady(ctx context.Context, name types.NamespacedName) {
 	Eventually(func(g Gomega) {
-		ready, err := isDeploymentReady(ctx, k8sClient, name)
+		ready, err := isDeploymentReady(ctx, suite.K8sClient, name)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(ready).To(BeTrueBecause("Deployment not ready"))
 	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
@@ -37,10 +38,10 @@ func isDeploymentReady(ctx context.Context, k8sClient client.Client, name types.
 	return arePodsReady(ctx, k8sClient, listOptions)
 }
 
-func DeploymentHasPriorityClass(ctx context.Context, k8sClient client.Client, name types.NamespacedName, expectedPriorityClassName string) {
+func DeploymentHasPriorityClass(ctx context.Context, name types.NamespacedName, expectedPriorityClassName string) {
 	Eventually(func(g Gomega) {
 		var deployment appsv1.Deployment
-		g.Expect(k8sClient.Get(ctx, name, &deployment)).To(Succeed())
+		g.Expect(suite.K8sClient.Get(ctx, name, &deployment)).To(Succeed())
 
 		g.Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal(expectedPriorityClassName))
 	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())


### PR DESCRIPTION
…the utility functions that need it

## Description

Changes proposed in this pull request (what was done and why):

- Stop passing `suite.K8sClient` variable around and move it directly to the utility functions that need it.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
