### PR TITLE
chore: introduce offset in E2E assertions to show the error properly

### DIFF
--- a/test/e2e-migrated/logs/shared/namespace_selector_test.go
+++ b/test/e2e-migrated/logs/shared/namespace_selector_test.go
@@ -139,7 +139,7 @@ func TestNamespaceSelector_OTel(t *testing.T) {
 			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, excludePipelineName)
 
 			assert.OTelLogsFromNamespaceDelivered1(t, backend1, "foo")
-			//assert.OTelLogsFromNamespaceNotDelivered(t.Context(), backend2, gen2Ns)
+			// assert.OTelLogsFromNamespaceNotDelivered(t.Context(), backend2, gen2Ns)
 		})
 	}
 }

--- a/test/e2e-migrated/logs/shared/namespace_selector_test.go
+++ b/test/e2e-migrated/logs/shared/namespace_selector_test.go
@@ -138,8 +138,8 @@ func TestNamespaceSelector_OTel(t *testing.T) {
 			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, includePipelineName)
 			assert.OTelLogPipelineHealthy(t.Context(), suite.K8sClient, excludePipelineName)
 
-			assert.OTelLogsFromNamespaceDelivered(t.Context(), backend1, gen1Ns)
-			assert.OTelLogsFromNamespaceNotDelivered(t.Context(), backend2, gen2Ns)
+			assert.OTelLogsFromNamespaceDelivered1(t, backend1, "foo")
+			//assert.OTelLogsFromNamespaceNotDelivered(t.Context(), backend2, gen2Ns)
 		})
 	}
 }

--- a/test/testkit/assert/logs.go
+++ b/test/testkit/assert/logs.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -59,6 +60,13 @@ func OTelLogsFromContainerDelivered(ctx context.Context, backend *kitbackend.Bac
 func OTelLogsFromContainerNotDelivered(ctx context.Context, backend *kitbackend.Backend, containerName string) {
 	BackendDataConsistentlyMatches(ctx, backend,
 		HaveFlatLogs(Not(ContainElement(HaveResourceAttributes(HaveKeyWithValue("k8s.container.name", containerName))))),
+	)
+}
+
+func OTelLogsFromNamespaceDelivered1(t *testing.T, backend *kitbackend.Backend, namespace string) {
+	t.Helper()
+	BackendDataEventuallyMatches1(1, t, backend,
+		HaveFlatLogs(ContainElement(HaveResourceAttributes(HaveKeyWithValue("k8s.namespace.name", namespace)))),
 	)
 }
 

--- a/test/testkit/assert/shared.go
+++ b/test/testkit/assert/shared.go
@@ -3,6 +3,9 @@ package assert
 import (
 	"context"
 	"net/http"
+	"runtime"
+	"strings"
+	"testing"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -11,6 +14,12 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
+
+func BackendDataEventuallyMatches1(offset int, t *testing.T, backend *kitbackend.Backend, httpBodyMatcher types.GomegaMatcher) {
+	t.Helper()
+	queryURL := suite.ProxyClient.ProxyURLForService(backend.Namespace(), backend.Name(), kitbackend.QueryPath, kitbackend.QueryPort)
+	HTTPResponseEventuallyMatches1(offset+1, t, queryURL, httpBodyMatcher)
+}
 
 func BackendDataEventuallyMatches(ctx context.Context, backend *kitbackend.Backend, httpBodyMatcher types.GomegaMatcher) {
 	queryURL := suite.ProxyClient.ProxyURLForService(backend.Namespace(), backend.Name(), kitbackend.QueryPath, kitbackend.QueryPort)
@@ -21,6 +30,26 @@ func BackendDataConsistentlyMatches(ctx context.Context, backend *kitbackend.Bac
 	queryURL := suite.ProxyClient.ProxyURLForService(backend.Namespace(), backend.Name(), kitbackend.QueryPath, kitbackend.QueryPort)
 	HTTPResponseConsistentlyMatches(ctx, queryURL, httpBodyMatcher)
 }
+
+func HTTPResponseEventuallyMatches1(offset int, t *testing.T, queryURL string, httpBodyMatcher types.GomegaMatcher) {
+	t.Helper()
+	//t.Log("Waiting for the backend to be ready...")
+
+	//t.Logf("The offset is: %d", getOffset())
+	EventuallyWithOffset(getOffset(), func(g Gomega) {
+		resp, err := suite.ProxyClient.GetWithContext(t.Context(), queryURL)
+		g.Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+		//return testme(g, resp, httpBodyMatcher)
+		g.Expect(resp).To(HaveHTTPBody(httpBodyMatcher))
+	}, 2, periodic.TelemetryInterval).Should(Succeed(), "")
+}
+
+//func testme(g Gomega, resp *http.Response, httpBodyMatcher types.GomegaMatcher) bool {
+//	//return g.Expect(resp).To(HaveHTTPBody(httpBodyMatcher))
+//	return false
+//}
 
 func HTTPResponseEventuallyMatches(ctx context.Context, queryURL string, httpBodyMatcher types.GomegaMatcher) {
 	Eventually(func(g Gomega) {
@@ -40,4 +69,44 @@ func HTTPResponseConsistentlyMatches(ctx context.Context, queryURL string, httpB
 		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 		g.Expect(resp).To(HaveHTTPBody(httpBodyMatcher))
 	}, periodic.ConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
+}
+
+func getOffset() int {
+	pc := make([]uintptr, 32)
+	n := runtime.Callers(0, pc) // Capture full stack
+	frames := runtime.CallersFrames(pc[:n])
+
+	var startCounting bool
+	count := 0
+
+	for {
+		frame, more := frames.Next()
+		funcName := getFuncName(frame.Function)
+
+		if !startCounting {
+			if funcName == "getOffset" {
+				startCounting = true
+				continue
+			}
+			continue
+		}
+
+		if strings.HasPrefix(funcName, "Test") {
+			break
+		}
+
+		count++
+		if !more {
+			break
+		}
+	}
+
+	return count
+
+}
+func getFuncName(fullName string) string {
+	if idx := strings.LastIndex(fullName, "."); idx != -1 {
+		return fullName[idx+1:]
+	}
+	return fullName
 }

--- a/test/testkit/assert/shared.go
+++ b/test/testkit/assert/shared.go
@@ -33,23 +33,14 @@ func BackendDataConsistentlyMatches(ctx context.Context, backend *kitbackend.Bac
 
 func HTTPResponseEventuallyMatches1(offset int, t *testing.T, queryURL string, httpBodyMatcher types.GomegaMatcher) {
 	t.Helper()
-	//t.Log("Waiting for the backend to be ready...")
-
-	//t.Logf("The offset is: %d", getOffset())
 	EventuallyWithOffset(getOffset(), func(g Gomega) {
 		resp, err := suite.ProxyClient.GetWithContext(t.Context(), queryURL)
 		g.Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
-		//return testme(g, resp, httpBodyMatcher)
 		g.Expect(resp).To(HaveHTTPBody(httpBodyMatcher))
 	}, 2, periodic.TelemetryInterval).Should(Succeed(), "")
 }
-
-//func testme(g Gomega, resp *http.Response, httpBodyMatcher types.GomegaMatcher) bool {
-//	//return g.Expect(resp).To(HaveHTTPBody(httpBodyMatcher))
-//	return false
-//}
 
 func HTTPResponseEventuallyMatches(ctx context.Context, queryURL string, httpBodyMatcher types.GomegaMatcher) {
 	Eventually(func(g Gomega) {
@@ -84,7 +75,7 @@ func getOffset() int {
 		funcName := getFuncName(frame.Function)
 
 		if !startCounting {
-			if funcName == "getOffset" {
+			if funcName == "getOffset" { // start offset counting from current function to TestXXXX function
 				startCounting = true
 				continue
 			}

--- a/test/testkit/assert/shared.go
+++ b/test/testkit/assert/shared.go
@@ -17,6 +17,7 @@ import (
 
 func BackendDataEventuallyMatches1(offset int, t *testing.T, backend *kitbackend.Backend, httpBodyMatcher types.GomegaMatcher) {
 	t.Helper()
+
 	queryURL := suite.ProxyClient.ProxyURLForService(backend.Namespace(), backend.Name(), kitbackend.QueryPath, kitbackend.QueryPort)
 	HTTPResponseEventuallyMatches1(offset+1, t, queryURL, httpBodyMatcher)
 }
@@ -68,6 +69,7 @@ func getOffset() int {
 	frames := runtime.CallersFrames(pc[:n])
 
 	var startCounting bool
+
 	count := 0
 
 	for {
@@ -79,6 +81,7 @@ func getOffset() int {
 				startCounting = true
 				continue
 			}
+
 			continue
 		}
 
@@ -87,17 +90,18 @@ func getOffset() int {
 		}
 
 		count++
+
 		if !more {
 			break
 		}
 	}
 
 	return count
-
 }
 func getFuncName(fullName string) string {
 	if idx := strings.LastIndex(fullName, "."); idx != -1 {
 		return fullName[idx+1:]
 	}
+
 	return fullName
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

-  Todo: Refactoring all the tests e2e_migrated pass the testing.T
- Todo: Think about assert.DeploymentReady/assert.DaemonsetReady as they are already used by non e2e-migrated tests
- Todo: Move getOffset() to a better place.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
