### PR TITLE
chore: avoid running tests for experimental features on gardener cluster

### DIFF
--- a/hack/gardener-integration-test.sh
+++ b/hack/gardener-integration-test.sh
@@ -17,7 +17,7 @@ function run-tests-with-git-image () {
     make ginkgo
     make deploy
     hack/deploy-istio.sh
-    ${GINKGO} run --junit-report=junit-report.xml --tags istio --label-filter="integration" test/integration/istio
+    ${GINKGO} run --junit-report=junit-report.xml --tags istio --label-filter="integration && !experimental" test/integration/istio
 }
 
 function main() {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Avoid running tests for experimental features on gardener cluster, since we are deploying the non-experimental version on the gardener cluster in the branch integration job

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
