### PR TITLE
chore: bump OTel version to 0.128.0

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 DEFAULT_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250528-dfa5b526"
 DEFAULT_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.3"
-DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.127.0-main"
+DEFAULT_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.128.0-main"
 
 DEFAULT_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.4.1-be41b59"
-DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.126.0"
+DEFAULT_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.128.0"

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -6,6 +6,6 @@ package images
 const (
 	DefaultFluentBitExporterImage = "europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250528-dfa5b526"
 	DefaultFluentBitImage         = "europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.3"
-	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.127.0-main"
+	DefaultOTelCollectorImage     = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.128.0-main"
 	DefaultSelfMonitorImage       = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.4.1-be41b59"
 )

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -4,7 +4,7 @@ bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250528-dfa5b526
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.3
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.127.0-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.128.0-main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.4.1-be41b59
 mend:
   language: golang-mod

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -4,5 +4,5 @@
 package testkit
 
 const (
-	DefaultTelemetryGenImage = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.126.0"
+	DefaultTelemetryGenImage = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.128.0"
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump OTel image version to 0.128.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
