### PR TITLE
docs: remove schemaUrl from sample-app

### DIFF
--- a/docs/user/integration/sample-app/setup.go
+++ b/docs/user/integration/sample-app/setup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -19,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 var (
@@ -68,10 +68,9 @@ func newOtelResource() (*resource.Resource, error) {
 	// Ensure default SDK resources and the required service name are set.
 	res, err := resource.New(
 		context.Background(),
-		resource.WithSchemaURL(semconv.SchemaURL),
-		resource.WithAttributes(semconv.ServiceName("sample-app")), // Default service name which might get overriden by OTEL_SERVICE_NAME.
-		resource.WithFromEnv(),                                     // Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
-		resource.WithTelemetrySDK(),                                // Discover and provide information about the OpenTelemetry SDK used.
+		resource.WithAttributes(attribute.String("service.name", "sample-app")), // Default service name which might get overriden by OTEL_SERVICE_NAME.
+		resource.WithFromEnv(),      // Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
+		resource.WithTelemetrySDK(), // Discover and provide information about the OpenTelemetry SDK used.
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Description

The otel bump on the sample-app (https://github.com/kyma-project/telemetry-manager/pull/2235) caused that the sample-app could not startup anymore as the schemaUrl send with the data is not aligned anymore with the sdk version.
Instead of maintaining the schemaUrl with every otel bump, I removed the url from the sample

Changes proposed in this pull request (what was done and why):

- removed schemaUrl from the sample

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
