### PR TITLE
fix: runtime_input e2e test flakiness

### DIFF
--- a/test/e2e-migrated/metrics/runtime_input_test.go
+++ b/test/e2e-migrated/metrics/runtime_input_test.go
@@ -36,6 +36,15 @@ func TestRuntimeInput(t *testing.T) {
 	const (
 		podNetworkErrorsMetric = "k8s.pod.network.errors"
 		podNetworkIOMetric     = "k8s.pod.network.io"
+
+		backendNameA = "backend-a"
+		backendNameB = "backend-b"
+		backendNameC = "backend-c"
+
+		deploymentName  = "deployment"
+		statefulSetName = "statefulset"
+		daemonSetName   = "daemonset"
+		jobName         = "job"
 	)
 
 	var (
@@ -44,18 +53,9 @@ func TestRuntimeInput(t *testing.T) {
 		pipelineNameB = uniquePrefix("b")
 		pipelineNameC = uniquePrefix("c")
 
-		backendNameA = uniquePrefix("backend-a")
-		backendNameB = uniquePrefix("backend-b")
-		backendNameC = uniquePrefix("backend-c")
-
 		backendNs = uniquePrefix("backend")
 		genNs     = uniquePrefix("gen")
 		podNs     = uniquePrefix("pod")
-
-		deploymentName  = uniquePrefix()
-		statefulSetName = uniquePrefix()
-		daemonSetName   = uniquePrefix()
-		jobName         = uniquePrefix()
 
 		pvName                  = uniquePrefix()
 		pvcName                 = uniquePrefix()


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix runtime_input metrics e2e test flakiness

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
