### PR TITLE
docs: sample-app: do not have units in the exported prometheus metrics

### DIFF
--- a/docs/user/integration/sample-app/setup.go
+++ b/docs/user/integration/sample-app/setup.go
@@ -138,7 +138,9 @@ func newMetricReader(ctx context.Context) (metric.Reader, error) {
 	endpointEnv := os.Getenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
 
 	if exporterEnv == "prometheus" {
-		reader, err := prometheus.New()
+		reader, err := prometheus.New(
+			prometheus.WithoutUnits(),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("creating prometheus metric reader: %w", err)
 		}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The sample-app started to enrich metric names expoted via prometheus with units. Do keep naming stable I explicitly configured the "withoutUnit" option

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
