### PR TITLE
feat: support node network metrics

### DIFF
--- a/docs/user/04-metrics.md
+++ b/docs/user/04-metrics.md
@@ -488,6 +488,8 @@ If Node metrics are enabled, the following metrics are collected:
   - `k8s.node.filesystem.usage`
   - `k8s.node.memory.available`
   - `k8s.node.memory.usage`
+  - `k8s.node.network.errors`,
+  - `k8s.node.network.io`,
   - `k8s.node.memory.rss`
   - `k8s.node.memory.working_set`
 

--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -226,6 +226,7 @@ type Processors struct {
 	SetInstrumentationScopeIstio      *metric.TransformProcessor        `yaml:"transform/set-instrumentation-scope-istio,omitempty"`
 	InsertSkipEnrichmentAttribute     *metric.TransformProcessor        `yaml:"transform/insert-skip-enrichment-attribute,omitempty"`
 	DropNonPVCVolumesMetrics          *FilterProcessor                  `yaml:"filter/drop-non-pvc-volumes-metrics,omitempty"`
+	DropVirtualNetworkInterfaces      *FilterProcessor                  `yaml:"filter/drop-virtual-network-interfaces,omitempty"`
 }
 
 type Exporters struct {
@@ -237,5 +238,6 @@ type FilterProcessor struct {
 }
 
 type FilterProcessorMetrics struct {
-	Metric []string `yaml:"metric,omitempty"`
+	Metric    []string `yaml:"metric,omitempty"`
+	Datapoint []string `yaml:"datapoint,omitempty"`
 }

--- a/internal/otelcollector/config/metric/agent/config.go
+++ b/internal/otelcollector/config/metric/agent/config.go
@@ -24,13 +24,18 @@ type Receivers struct {
 }
 
 type KubeletStatsReceiver struct {
-	CollectionInterval  string                    `yaml:"collection_interval"`
-	AuthType            string                    `yaml:"auth_type"`
-	Endpoint            string                    `yaml:"endpoint"`
-	InsecureSkipVerify  bool                      `yaml:"insecure_skip_verify"`
-	MetricGroups        []MetricGroupType         `yaml:"metric_groups"`
-	Metrics             KubeletStatsMetricsConfig `yaml:"metrics"`
-	ExtraMetadataLabels []string                  `yaml:"extra_metadata_labels,omitempty"`
+	CollectionInterval          string                         `yaml:"collection_interval"`
+	AuthType                    string                         `yaml:"auth_type"`
+	Endpoint                    string                         `yaml:"endpoint"`
+	InsecureSkipVerify          bool                           `yaml:"insecure_skip_verify"`
+	MetricGroups                []MetricGroupType              `yaml:"metric_groups"`
+	Metrics                     KubeletStatsMetricsConfig      `yaml:"metrics"`
+	ExtraMetadataLabels         []string                       `yaml:"extra_metadata_labels,omitempty"`
+	CollectAllNetworkInterfaces NetworkInterfacesEnablerConfig `yaml:"collect_all_network_interfaces"`
+}
+
+type NetworkInterfacesEnablerConfig struct {
+	NodeMetrics bool `yaml:"node"`
 }
 
 type MetricConfig struct {
@@ -47,8 +52,6 @@ type KubeletStatsMetricsConfig struct {
 	K8sNodeCPUTime               MetricConfig `yaml:"k8s.node.cpu.time"`
 	K8sNodeMemoryMajorPageFaults MetricConfig `yaml:"k8s.node.memory.major_page_faults"`
 	K8sNodeMemoryPageFaults      MetricConfig `yaml:"k8s.node.memory.page_faults"`
-	K8sNodeNetworkIO             MetricConfig `yaml:"k8s.node.network.io"`
-	K8sNodeNetworkErrors         MetricConfig `yaml:"k8s.node.network.errors"`
 }
 
 type MetricGroupType string

--- a/internal/otelcollector/config/metric/agent/config_builder.go
+++ b/internal/otelcollector/config/metric/agent/config_builder.go
@@ -269,7 +269,7 @@ func makeRuntimePipelineProcessorsIDs(runtimeResources runtimeResourcesEnabled) 
 		processors = append(processors, "filter/drop-non-pvc-volumes-metrics")
 	}
 
-	processors = append(processors, "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch")
+	processors = append(processors, "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch")
 
 	return processors
 }

--- a/internal/otelcollector/config/metric/agent/config_builder_test.go
+++ b/internal/otelcollector/config/metric/agent/config_builder_test.go
@@ -128,9 +128,9 @@ func TestBuildAgentConfig(t *testing.T) {
 
 				var expectedProcessorIDs []string
 				if tc.volumeMetricsEnabled {
-					expectedProcessorIDs = []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}
+					expectedProcessorIDs = []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}
 				} else {
-					expectedProcessorIDs = []string{"memory_limiter", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}
+					expectedProcessorIDs = []string{"memory_limiter", "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}
 				}
 
 				t.Run(tc.name, func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestBuildAgentConfig(t *testing.T) {
 			require.Len(t, collectorConfig.Service.Pipelines, 3)
 			require.Contains(t, collectorConfig.Service.Pipelines, "metrics/runtime")
 			require.Equal(t, []string{"kubeletstats", "k8s_cluster"}, collectorConfig.Service.Pipelines["metrics/runtime"].Receivers)
-			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
+			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
 			require.Equal(t, []string{"otlp"}, collectorConfig.Service.Pipelines["metrics/runtime"].Exporters)
 			require.Contains(t, collectorConfig.Service.Pipelines, "metrics/prometheus")
 			require.Equal(t, []string{"prometheus/app-pods", "prometheus/app-services"}, collectorConfig.Service.Pipelines["metrics/prometheus"].Receivers)
@@ -248,7 +248,7 @@ func TestBuildAgentConfig(t *testing.T) {
 			require.Len(t, collectorConfig.Service.Pipelines, 1)
 			require.Contains(t, collectorConfig.Service.Pipelines, "metrics/runtime")
 			require.Equal(t, []string{"kubeletstats", "k8s_cluster"}, collectorConfig.Service.Pipelines["metrics/runtime"].Receivers)
-			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
+			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
 			require.Equal(t, []string{"otlp"}, collectorConfig.Service.Pipelines["metrics/runtime"].Exporters)
 		})
 
@@ -267,7 +267,7 @@ func TestBuildAgentConfig(t *testing.T) {
 			require.Len(t, collectorConfig.Service.Pipelines, 1)
 			require.Contains(t, collectorConfig.Service.Pipelines, "metrics/runtime")
 			require.Equal(t, []string{"kubeletstats", "k8s_cluster"}, collectorConfig.Service.Pipelines["metrics/runtime"].Receivers)
-			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
+			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
 			require.Equal(t, []string{"otlp"}, collectorConfig.Service.Pipelines["metrics/runtime"].Exporters)
 		})
 
@@ -320,7 +320,7 @@ func TestBuildAgentConfig(t *testing.T) {
 			require.Len(t, collectorConfig.Service.Pipelines, 2)
 			require.Contains(t, collectorConfig.Service.Pipelines, "metrics/runtime")
 			require.Equal(t, []string{"kubeletstats", "k8s_cluster"}, collectorConfig.Service.Pipelines["metrics/runtime"].Receivers)
-			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
+			require.Equal(t, []string{"memory_limiter", "filter/drop-non-pvc-volumes-metrics", "filter/drop-virtual-network-interfaces", "resource/delete-service-name", "transform/set-instrumentation-scope-runtime", "transform/insert-skip-enrichment-attribute", "batch"}, collectorConfig.Service.Pipelines["metrics/runtime"].Processors)
 			require.Equal(t, []string{"otlp"}, collectorConfig.Service.Pipelines["metrics/runtime"].Exporters)
 			require.Contains(t, collectorConfig.Service.Pipelines, "metrics/prometheus")
 			require.Equal(t, []string{"prometheus/app-pods", "prometheus/app-services"}, collectorConfig.Service.Pipelines["metrics/prometheus"].Receivers)

--- a/internal/otelcollector/config/metric/agent/processors.go
+++ b/internal/otelcollector/config/metric/agent/processors.go
@@ -14,6 +14,7 @@ func makeProcessorsConfig(inputs inputSources, instrumentationScopeVersion strin
 			Batch:         makeBatchProcessorConfig(),
 			MemoryLimiter: makeMemoryLimiterConfig(),
 		},
+		DropVirtualNetworkInterfaces: makeDropVirtualNetworkInterfacesProcessor(),
 	}
 
 	if inputs.runtime || inputs.prometheus || inputs.istio {
@@ -115,4 +116,17 @@ func makeMetricNameConditionsWithIsMatch(metrics []string) []string {
 	}
 
 	return conditions
+}
+
+func makeDropVirtualNetworkInterfacesProcessor() *FilterProcessor {
+	return &FilterProcessor{
+		Metrics: FilterProcessorMetrics{
+			Datapoint: []string{
+				ottlexpr.JoinWithAnd(
+					ottlexpr.IsMatch("metric.name", "^k8s.node.network.*"),
+					ottlexpr.Not(ottlexpr.IsMatch("attributes[\"interface\"]", "^(eth|en).*")),
+				),
+			},
+		},
+	}
 }

--- a/internal/otelcollector/config/metric/agent/receivers.go
+++ b/internal/otelcollector/config/metric/agent/receivers.go
@@ -48,10 +48,11 @@ func makeKubeletStatsConfig(runtimeResources runtimeResourcesEnabled) *KubeletSt
 			K8sNodeCPUTime:               MetricConfig{Enabled: false},
 			K8sNodeMemoryMajorPageFaults: MetricConfig{Enabled: false},
 			K8sNodeMemoryPageFaults:      MetricConfig{Enabled: false},
-			K8sNodeNetworkIO:             MetricConfig{Enabled: false},
-			K8sNodeNetworkErrors:         MetricConfig{Enabled: false},
 		},
 		ExtraMetadataLabels: []string{"k8s.volume.type"},
+		CollectAllNetworkInterfaces: NetworkInterfacesEnablerConfig{
+			NodeMetrics: true,
+		},
 	}
 }
 

--- a/internal/otelcollector/config/metric/agent/receivers_test.go
+++ b/internal/otelcollector/config/metric/agent/receivers_test.go
@@ -190,11 +190,12 @@ func TestReceivers(t *testing.T) {
 					K8sNodeCPUTime:               MetricConfig{Enabled: false},
 					K8sNodeMemoryMajorPageFaults: MetricConfig{Enabled: false},
 					K8sNodeMemoryPageFaults:      MetricConfig{Enabled: false},
-					K8sNodeNetworkIO:             MetricConfig{Enabled: false},
-					K8sNodeNetworkErrors:         MetricConfig{Enabled: false},
 				},
 				ExtraMetadataLabels: []string{
 					"k8s.volume.type",
+				},
+				CollectAllNetworkInterfaces: NetworkInterfacesEnablerConfig{
+					NodeMetrics: true,
 				},
 			}
 			require.Equal(t, expectedKubeletStatsReceiver, *collectorConfig.Receivers.KubeletStats)

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -38,6 +38,7 @@ service:
             processors:
                 - memory_limiter
                 - filter/drop-non-pvc-volumes-metrics
+                - filter/drop-virtual-network-interfaces
                 - resource/delete-service-name
                 - transform/set-instrumentation-scope-runtime
                 - transform/insert-skip-enrichment-attribute
@@ -89,12 +90,10 @@ receivers:
                 enabled: false
             k8s.node.memory.page_faults:
                 enabled: false
-            k8s.node.network.io:
-                enabled: false
-            k8s.node.network.errors:
-                enabled: false
         extra_metadata_labels:
             - k8s.volume.type
+        collect_all_network_interfaces:
+            node: true
     k8s_cluster:
         auth_type: serviceAccount
         collection_interval: 30s
@@ -369,6 +368,10 @@ processors:
         metrics:
             metric:
                 - resource.attributes["k8s.volume.name"] != nil and resource.attributes["k8s.volume.type"] != "persistentVolumeClaim"
+    filter/drop-virtual-network-interfaces:
+        metrics:
+            datapoint:
+                - IsMatch(metric.name, "^k8s.node.network.*") and not(IsMatch(attributes["interface"], "^(eth|en).*"))
 exporters:
     otlp:
         endpoint: metrics.telemetry-system.svc.cluster.local:4317

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -27,6 +27,7 @@ service:
             processors:
                 - memory_limiter
                 - filter/drop-non-pvc-volumes-metrics
+                - filter/drop-virtual-network-interfaces
                 - resource/delete-service-name
                 - transform/set-instrumentation-scope-runtime
                 - transform/insert-skip-enrichment-attribute
@@ -78,12 +79,10 @@ receivers:
                 enabled: false
             k8s.node.memory.page_faults:
                 enabled: false
-            k8s.node.network.io:
-                enabled: false
-            k8s.node.network.errors:
-                enabled: false
         extra_metadata_labels:
             - k8s.volume.type
+        collect_all_network_interfaces:
+            node: true
     k8s_cluster:
         auth_type: serviceAccount
         collection_interval: 30s
@@ -266,6 +265,10 @@ processors:
         metrics:
             metric:
                 - resource.attributes["k8s.volume.name"] != nil and resource.attributes["k8s.volume.type"] != "persistentVolumeClaim"
+    filter/drop-virtual-network-interfaces:
+        metrics:
+            datapoint:
+                - IsMatch(metric.name, "^k8s.node.network.*") and not(IsMatch(attributes["interface"], "^(eth|en).*"))
 exporters:
     otlp:
         endpoint: metrics.telemetry-system.svc.cluster.local:4317

--- a/test/e2e-migrated/metrics/runtime_input_test.go
+++ b/test/e2e-migrated/metrics/runtime_input_test.go
@@ -35,6 +35,8 @@ func TestRuntimeInput(t *testing.T) {
 	const (
 		podNetworkErrorsMetric = "k8s.pod.network.errors"
 		podNetworkIOMetric     = "k8s.pod.network.io"
+		nodeNetworkErrorsMetric = "k8s.node.network.errors"
+		nodeNetworkIOMetric     = "k8s.node.network.io"
 
 		backendNameA = "backend-a"
 		backendNameB = "backend-b"
@@ -154,6 +156,8 @@ func TestRuntimeInput(t *testing.T) {
 	backendContainsDesiredResourceAttributes(t, backendA, "k8s.node.cpu.usage", runtime.NodeMetricsResourceAttributes)
 	backendContainsDesiredMetricAttributes(t, backendA, podNetworkErrorsMetric, runtime.PodMetricsAttributes[podNetworkErrorsMetric])
 	backendContainsDesiredMetricAttributes(t, backendA, podNetworkIOMetric, runtime.PodMetricsAttributes[podNetworkIOMetric])
+	backendContainsDesiredMetricAttributes(t, backendA, podNetworkErrorsMetric, runtime.NodeMetricsAttributes[nodeNetworkErrorsMetric])
+	backendContainsDesiredMetricAttributes(t, backendA, podNetworkIOMetric, runtime.NodeMetricsAttributes[nodeNetworkIOMetric])
 	assert.BackendDataConsistentlyMatches(t, backendA,
 		HaveFlatMetrics(Not(ContainElement(HaveResourceAttributes(HaveKeyWithValue("k8s.volume.type", "emptyDir"))))),
 	)

--- a/test/testkit/metrics/runtime/node.go
+++ b/test/testkit/metrics/runtime/node.go
@@ -10,6 +10,8 @@ var (
 		"k8s.node.filesystem.usage",
 		"k8s.node.memory.available",
 		"k8s.node.memory.usage",
+		"k8s.node.network.errors",
+		"k8s.node.network.io",
 		"k8s.node.memory.rss",
 		"k8s.node.memory.working_set",
 	}
@@ -18,5 +20,10 @@ var (
 		"k8s.cluster.name",
 		"k8s.node.name",
 		"cloud.provider",
+	}
+
+	NodeMetricsAttributes = map[string][]string{
+		"k8s.node.network.errors": {"interface", "direction"},
+		"k8s.node.network.io":     {"interface", "direction"},
 	}
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Enable node network metrics, now with filtering applied to only filter for certain interfaces (en* and eth*) interfaces to prevent overloading backend with irrelevant network interfaces
- Addded a filter processor to filter for interfaces

Changes refer to particular issues, PRs or documents:

- #2083 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
