### PR TITLE
chore: solve logs e2e tests backend not reachable flakiness

### DIFF
--- a/test/e2e-migrated/logs/agent/instrumentation_scope_test.go
+++ b/test/e2e-migrated/logs/agent/instrumentation_scope_test.go
@@ -50,10 +50,9 @@ func TestInstrumentationScope(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DaemonSetReady(t, kitkyma.LogAgentName)
-
 	assert.OTelLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,

--- a/test/e2e-migrated/logs/agent/severity_parser_test.go
+++ b/test/e2e-migrated/logs/agent/severity_parser_test.go
@@ -57,10 +57,9 @@ func TestSeverityParser(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DaemonSetReady(t, kitkyma.LogAgentName)
-
 	assert.OTelLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,

--- a/test/e2e-migrated/logs/agent/trace_parser_test.go
+++ b/test/e2e-migrated/logs/agent/trace_parser_test.go
@@ -57,10 +57,9 @@ func TestTraceParser(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DaemonSetReady(t, kitkyma.LogAgentName)
-
 	assert.OTelLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,

--- a/test/e2e-migrated/logs/fluentbit/app_name_test.go
+++ b/test/e2e-migrated/logs/fluentbit/app_name_test.go
@@ -63,9 +63,10 @@ func TestAppName(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+
 	assert.DeploymentReady(t, logProducerNone.NamespacedName())
 	assert.DeploymentReady(t, logProducerAppOnly.NamespacedName())
 	assert.DeploymentReady(t, logProducerNameOnly.NamespacedName())

--- a/test/e2e-migrated/logs/fluentbit/base_payload_with_http_test.go
+++ b/test/e2e-migrated/logs/fluentbit/base_payload_with_http_test.go
@@ -50,10 +50,10 @@ func TestBasePayloadWithHTTPOutput(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DeploymentReady(t, logProducer.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,
 		fluentbit.HaveFlatLogs(HaveEach(SatisfyAll(

--- a/test/e2e-migrated/logs/fluentbit/custom_filter_test.go
+++ b/test/e2e-migrated/logs/fluentbit/custom_filter_test.go
@@ -78,10 +78,11 @@ func TestCustomFilterAllowed(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
-	assert.LogPipelineUnsupportedMode(t, pipelineName, true)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+
+	assert.LogPipelineUnsupportedMode(t, pipelineName, true)
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend, includeNs)
 	assert.FluentBitLogsFromNamespaceNotDelivered(t, backend, excludeNs)
 }

--- a/test/e2e-migrated/logs/fluentbit/custom_output_test.go
+++ b/test/e2e-migrated/logs/fluentbit/custom_output_test.go
@@ -54,10 +54,11 @@ func TestCustomOutput(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
-	assert.LogPipelineUnsupportedMode(t, pipelineName, true)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+
+	assert.LogPipelineUnsupportedMode(t, pipelineName, true)
 	assert.FluentBitLogsFromPodDelivered(t, backend, stdloggen.DefaultName)
 
 	assert.BackendDataEventuallyMatches(t, backend,

--- a/test/e2e-migrated/logs/fluentbit/custom_parser_test.go
+++ b/test/e2e-migrated/logs/fluentbit/custom_parser_test.go
@@ -57,10 +57,10 @@ Types user:string pass:string`
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DeploymentReady(t, logProducer.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,
 		fluentbit.HaveFlatLogs(ContainElement(SatisfyAll(

--- a/test/e2e-migrated/logs/fluentbit/dedot_test.go
+++ b/test/e2e-migrated/logs/fluentbit/dedot_test.go
@@ -53,10 +53,10 @@ func TestDedot(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DeploymentReady(t, logProducer.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,
 		fluentbit.HaveFlatLogs(ContainElement(SatisfyAll(

--- a/test/e2e-migrated/logs/fluentbit/keep_annotation_test.go
+++ b/test/e2e-migrated/logs/fluentbit/keep_annotation_test.go
@@ -51,10 +51,10 @@ func TestKeepAnnotations(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DeploymentReady(t, logProducer.NamespacedName())
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 
 	assert.BackendDataEventuallyMatches(t, backend,
 		fluentbit.HaveFlatLogs(ContainElement(

--- a/test/e2e-migrated/logs/shared/container_selector_test.go
+++ b/test/e2e-migrated/logs/shared/container_selector_test.go
@@ -65,12 +65,10 @@ func TestContainerSelector_OTel(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend1)
+	assert.BackendReachable(t, backend2)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t, backend1.NamespacedName())
-	assert.DeploymentReady(t, backend2.NamespacedName())
-
 	assert.DaemonSetReady(t, kitkyma.LogAgentName)
-
 	assert.OTelLogPipelineHealthy(t, includePipelineName)
 	assert.OTelLogPipelineHealthy(t, excludePipelineName)
 
@@ -129,10 +127,9 @@ func TestContainerSelector_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t, backend1.NamespacedName())
-	assert.DeploymentReady(t, backend2.NamespacedName())
+	assert.BackendReachable(t, backend1)
+	assert.BackendReachable(t, backend2)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, includePipelineName)
 	assert.FluentBitLogPipelineHealthy(t, excludePipelineName)
 

--- a/test/e2e-migrated/logs/shared/disabled_input_test.go
+++ b/test/e2e-migrated/logs/shared/disabled_input_test.go
@@ -56,8 +56,8 @@ func TestDisabledInput_OTel(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.OTelLogPipelineHealthy(t, pipelineName)
 
 	// If Application input is disabled, THEN the log agent must not be deployed

--- a/test/e2e-migrated/logs/shared/extract_labels_test.go
+++ b/test/e2e-migrated/logs/shared/extract_labels_test.go
@@ -123,8 +123,8 @@ func TestExtractLabels_OTel(t *testing.T) {
 				assert.DaemonSetReady(t, kitkyma.LogAgentName)
 			}
 
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t, backend.NamespacedName())
 			assert.OTelLogPipelineHealthy(t, pipelineName)
 			assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)
 
@@ -196,12 +196,12 @@ func TestExtractLabels_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backendNotDropped)
+	assert.BackendReachable(t, backendDropped)
+	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
+	assert.DeploymentReady(t, logProducer.NamespacedName())
 	assert.FluentBitLogPipelineHealthy(t, pipelineNameNotDropped)
 	assert.FluentBitLogPipelineHealthy(t, pipelineNameDropped)
-	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-	assert.DeploymentReady(t, backendNotDropped.NamespacedName())
-	assert.DeploymentReady(t, backendDropped.NamespacedName())
-	assert.DeploymentReady(t, logProducer.NamespacedName())
 
 	// Scenario 1: Labels not dropped
 	assert.FluentBitLogsFromNamespaceDelivered(t, backendNotDropped, genNs)

--- a/test/e2e-migrated/logs/shared/keep_original_body_test.go
+++ b/test/e2e-migrated/logs/shared/keep_original_body_test.go
@@ -89,14 +89,12 @@ func TestKeepOriginalBody_OTel(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backendKeepOriginal)
+	assert.BackendReachable(t, backendDropOriginal)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
-	assert.DeploymentReady(t, backendKeepOriginal.NamespacedName())
-	assert.DeploymentReady(t, backendDropOriginal.NamespacedName())
 	assert.DaemonSetReady(t, kitkyma.LogAgentName)
-
 	assert.OTelLogPipelineHealthy(t, pipelineKeepOriginalName)
 	assert.OTelLogPipelineHealthy(t, pipelineDropOriginalName)
-
 	assert.OTelLogsFromNamespaceDelivered(t, backendDropOriginal, sourceNsDropOriginal)
 
 	assert.BackendDataEventuallyMatches(t, backendDropOriginal,
@@ -238,13 +236,11 @@ func TestKeepOriginalBody_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t, backendKeepOriginal.NamespacedName())
-	assert.DeploymentReady(t, backendDropOriginal.NamespacedName())
+	assert.BackendReachable(t, backendKeepOriginal)
+	assert.BackendReachable(t, backendDropOriginal)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, pipelineKeepOriginalName)
 	assert.FluentBitLogPipelineHealthy(t, pipelineDropOriginalName)
-
 	assert.FluentBitLogsFromNamespaceDelivered(t, backendDropOriginal, sourceNsDropOriginal)
 
 	assert.BackendDataConsistentlyMatches(t, backendDropOriginal,

--- a/test/e2e-migrated/logs/shared/mtls_about_to_expire_cert_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_about_to_expire_cert_test.go
@@ -92,8 +92,8 @@ func TestMTLSAboutToExpireCert_OTel(t *testing.T) {
 			})
 			Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t, backend.NamespacedName())
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t, kitkyma.LogAgentName)
@@ -160,10 +160,10 @@ func TestMTLSAboutToExpireCert_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, pipelineName)
+
 	assert.LogPipelineHasCondition(t, pipelineName, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionTrue,

--- a/test/e2e-migrated/logs/shared/mtls_test.go
+++ b/test/e2e-migrated/logs/shared/mtls_test.go
@@ -86,8 +86,8 @@ func TestMTLS_OTel(t *testing.T) {
 			})
 			Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+			assert.BackendReachable(t, backend)
 			assert.OTelLogPipelineHealthy(t, pipelineName)
-			assert.DeploymentReady(t, backend.NamespacedName())
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
@@ -139,8 +139,8 @@ func TestMTLS_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend)
 	assert.FluentBitLogPipelineHealthy(t, pipelineName)
-	assert.DeploymentReady(t, backend.NamespacedName())
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend, backendNs)
 }

--- a/test/e2e-migrated/logs/shared/multi_pipeline_broken_test.go
+++ b/test/e2e-migrated/logs/shared/multi_pipeline_broken_test.go
@@ -88,7 +88,7 @@ func TestMultiPipelineBroken_OTel(t *testing.T) {
 			})
 			require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-			assert.DeploymentReady(t, backend.NamespacedName())
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
@@ -146,10 +146,10 @@ func TestMultiPipelineBroken_FluentBit(t *testing.T) {
 	})
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, healthyPipeline.Name)
+
 	assert.LogPipelineHasCondition(t, brokenPipeline.Name, metav1.Condition{
 		Type:   conditions.TypeConfigurationGenerated,
 		Status: metav1.ConditionFalse,

--- a/test/e2e-migrated/logs/shared/multi_pipeline_fanout_test.go
+++ b/test/e2e-migrated/logs/shared/multi_pipeline_fanout_test.go
@@ -87,12 +87,10 @@ func TestMultiPipelineFanout_OTel(t *testing.T) {
 			})
 			require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-			assert.DeploymentReady(t, backend1.NamespacedName())
-			assert.DeploymentReady(t, backend2.NamespacedName())
-
+			assert.BackendReachable(t, backend1)
+			assert.BackendReachable(t, backend2)
 			assert.FluentBitLogPipelineHealthy(t, pipeline1.Name)
 			assert.FluentBitLogPipelineHealthy(t, pipeline2.Name)
-
 			assert.OTelLogsFromNamespaceDelivered(t, backend1, genNs)
 			assert.OTelLogsFromNamespaceDelivered(t, backend2, genNs)
 		})
@@ -140,12 +138,10 @@ func TestMultiPipelineFanout_FluentBit(t *testing.T) {
 	})
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-	assert.DeploymentReady(t, backend1.NamespacedName())
-	assert.DeploymentReady(t, backend2.NamespacedName())
-
+	assert.BackendReachable(t, backend1)
+	assert.BackendReachable(t, backend2)
 	assert.FluentBitLogPipelineHealthy(t, pipeline1.Name)
 	assert.FluentBitLogPipelineHealthy(t, pipeline2.Name)
-
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend1, genNs)
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend2, genNs)
 }

--- a/test/e2e-migrated/logs/shared/multi_pipeline_max_pipeline_test.go
+++ b/test/e2e-migrated/logs/shared/multi_pipeline_max_pipeline_test.go
@@ -91,7 +91,7 @@ func TestMultiPipelineMaxPipeline(t *testing.T) {
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 	require.NoError(t, kitk8s.CreateObjects(t, pipelines...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
 
 	t.Log("Asserting all pipelines are healthy")
@@ -192,7 +192,7 @@ func TestMultiPipelineMaxPipeline_OTel(t *testing.T) {
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 	require.NoError(t, kitk8s.CreateObjects(t, pipelines...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.LogGatewayName)
 
 	t.Log("Asserting all pipelines are healthy")
@@ -270,7 +270,7 @@ func TestMultiPipelineMaxPipeline_FluentBit(t *testing.T) {
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 	require.NoError(t, kitk8s.CreateObjects(t, pipelines...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
 
 	t.Log("Asserting all pipelines are healthy")

--- a/test/e2e-migrated/logs/shared/namespace_selector_test.go
+++ b/test/e2e-migrated/logs/shared/namespace_selector_test.go
@@ -125,9 +125,9 @@ func TestNamespaceSelector_OTel(t *testing.T) {
 			})
 			Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+			assert.BackendReachable(t, backend1)
+			assert.BackendReachable(t, backend2)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t, backend1.NamespacedName())
-			assert.DeploymentReady(t, backend2.NamespacedName())
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t, kitkyma.LogAgentName)
@@ -186,14 +186,11 @@ func TestNamespaceSelector_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+	assert.BackendReachable(t, backend1)
+	assert.BackendReachable(t, backend2)
+	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
 	assert.FluentBitLogPipelineHealthy(t, includePipelineName)
 	assert.FluentBitLogPipelineHealthy(t, excludePipelineName)
-
-	assert.DeploymentReady(t, backend1.NamespacedName())
-	assert.DeploymentReady(t, backend2.NamespacedName())
-
-	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend1, gen1Ns)
 	assert.FluentBitLogsFromNamespaceNotDelivered(t, backend2, gen2Ns)
 }

--- a/test/e2e-migrated/logs/shared/observed_time_test.go
+++ b/test/e2e-migrated/logs/shared/observed_time_test.go
@@ -79,11 +79,11 @@ func TestObservedTime_OTel(t *testing.T) {
 			})
 			Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
 			assert.OTelLogPipelineHealthy(t, pipelineName)
-			assert.DeploymentReady(t, backend.NamespacedName())
-
 			assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)
+
 			assert.BackendDataConsistentlyMatches(t, backend,
 				HaveFlatLogs(HaveEach(SatisfyAll(
 					HaveTimestamp(Not(BeEmpty())),

--- a/test/e2e-migrated/logs/shared/secret_rotation_test.go
+++ b/test/e2e-migrated/logs/shared/secret_rotation_test.go
@@ -92,7 +92,7 @@ func TestSecretRotation_OTel(t *testing.T) {
 			})
 			require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-			assert.DeploymentReady(t, backend.NamespacedName())
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
@@ -165,9 +165,8 @@ func TestSecretRotation_FluentBit(t *testing.T) {
 	})
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 	assert.FluentBitLogsFromNamespaceNotDelivered(t, backend, genNs)
 

--- a/test/e2e-migrated/logs/shared/self_monitor_happy_path_test.go
+++ b/test/e2e-migrated/logs/shared/self_monitor_happy_path_test.go
@@ -79,10 +79,9 @@ func TestSelfMonitorHappyPath_OTel(t *testing.T) {
 			})
 			Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-			assert.OTelLogPipelineHealthy(t, pipelineName)
-
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t, backend.NamespacedName())
+			assert.OTelLogPipelineHealthy(t, pipelineName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t, kitkyma.LogAgentName)
@@ -126,12 +125,10 @@ func TestSelfMonitorHappyPath_FluentBit(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).Should(Succeed())
 
-	assert.FluentBitLogPipelineHealthy(t, pipelineName)
-
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
 	assert.DeploymentReady(t, kitkyma.SelfMonitorName)
-
+	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend, genNs)
 
 	assert.SelfMonitorIsHealthyForPipeline(t, suite.K8sClient, pipelineName)

--- a/test/e2e-migrated/logs/shared/service_name_test.go
+++ b/test/e2e-migrated/logs/shared/service_name_test.go
@@ -125,8 +125,8 @@ func TestServiceName_OTel(t *testing.T) {
 				assert.DaemonSetReady(t, kitkyma.LogAgentName)
 			}
 
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
-			assert.DeploymentReady(t, backend.NamespacedName())
 			assert.OTelLogPipelineHealthy(t, pipelineName)
 			assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)
 

--- a/test/e2e-migrated/logs/shared/single_pipeline_test.go
+++ b/test/e2e-migrated/logs/shared/single_pipeline_test.go
@@ -78,7 +78,7 @@ func TestSinglePipeline_OTel(t *testing.T) {
 			})
 			require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-			assert.DeploymentReady(t, backend.NamespacedName())
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
@@ -121,11 +121,9 @@ func TestSinglePipeline_FluentBit(t *testing.T) {
 	})
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 	assert.LogPipelineUnsupportedMode(t, pipelineName, false)
-
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend, genNs)
 }

--- a/test/e2e-migrated/logs/shared/single_pipeline_v1beta1_test.go
+++ b/test/e2e-migrated/logs/shared/single_pipeline_v1beta1_test.go
@@ -92,7 +92,7 @@ func TestSinglePipelineV1Beta1_OTel(t *testing.T) {
 			})
 			require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-			assert.DeploymentReady(t, backend.NamespacedName())
+			assert.BackendReachable(t, backend)
 			assert.DeploymentReady(t, kitkyma.LogGatewayName)
 
 			if tc.expectAgent {
@@ -151,11 +151,9 @@ func TestSinglePipelineV1Beta1_FluentBit(t *testing.T) {
 	})
 	require.NoError(t, kitk8s.CreateObjects(t, resources...))
 
-	assert.DeploymentReady(t, backend.NamespacedName())
+	assert.BackendReachable(t, backend)
 	assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-
 	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 	assert.LogPipelineUnsupportedMode(t, pipelineName, false)
-
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend, genNs)
 }

--- a/test/e2e-migrated/traces/mtls_about_to_expire_cert_test.go
+++ b/test/e2e-migrated/traces/mtls_about_to_expire_cert_test.go
@@ -79,5 +79,5 @@ func TestMTLSAboutToExpireCert(t *testing.T) {
 		Reason: conditions.ReasonTLSCertificateAboutToExpire,
 	})
 
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 }

--- a/test/e2e-migrated/traces/mtls_test.go
+++ b/test/e2e-migrated/traces/mtls_test.go
@@ -60,5 +60,5 @@ func TestMTLS(t *testing.T) {
 	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 }

--- a/test/e2e-migrated/traces/multi_pipeline_broken_test.go
+++ b/test/e2e-migrated/traces/multi_pipeline_broken_test.go
@@ -65,5 +65,5 @@ func TestMultiPipelineBroken(t *testing.T) {
 		Status: metav1.ConditionFalse,
 		Reason: conditions.ReasonReferencedSecretMissing,
 	})
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 }

--- a/test/e2e-migrated/traces/multi_pipeline_fanout_test.go
+++ b/test/e2e-migrated/traces/multi_pipeline_fanout_test.go
@@ -62,6 +62,6 @@ func TestMultiPipelineFanout(t *testing.T) {
 	assert.TracePipelineHealthy(t, pipeline1Name)
 	assert.TracePipelineHealthy(t, pipeline2Name)
 
-	assert.TracesFromNamespaceDeliveredWithT(t, backend1, genNs)
-	assert.TracesFromNamespaceDeliveredWithT(t, backend2, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend1, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend2, genNs)
 }

--- a/test/e2e-migrated/traces/multi_pipeline_max_pipeline_test.go
+++ b/test/e2e-migrated/traces/multi_pipeline_max_pipeline_test.go
@@ -89,7 +89,7 @@ func TestMultiPipelineMaxPipeline(t *testing.T) {
 	})
 
 	t.Log("Verifying traces are delivered for valid pipelines")
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 
 	t.Log("Deleting one previously healthy pipeline and expecting the additional pipeline to be healthy")
 

--- a/test/e2e-migrated/traces/noisy_span_filter_test.go
+++ b/test/e2e-migrated/traces/noisy_span_filter_test.go
@@ -155,9 +155,9 @@ func TestNoisyFilters(t *testing.T) {
 	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
 
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, regularSpansNs)
+	assert.TracesFromNamespaceDelivered(t, backend, regularSpansNs)
 
-	assert.TracesFromNamespacesNotDeliveredWithT(t, backend, []string{
+	assert.TracesFromNamespacesNotDelivered(t, backend, []string{
 		vmaScrapeSpansNs,
 		healthzSpansNs,
 		fluentBitSpansNs,

--- a/test/e2e-migrated/traces/secret_rotation_test.go
+++ b/test/e2e-migrated/traces/secret_rotation_test.go
@@ -64,7 +64,7 @@ func TestSecretRotation(t *testing.T) {
 	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
-	assert.TracesFromNamespacesNotDeliveredWithT(t, backend, []string{genNs})
+	assert.TracesFromNamespacesNotDelivered(t, backend, []string{genNs})
 
 	// Update the secret to have the correct backend endpoint
 	secret.UpdateSecret(kitk8s.WithStringData(endpointKey, backend.Endpoint()))
@@ -72,5 +72,5 @@ func TestSecretRotation(t *testing.T) {
 
 	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 }

--- a/test/e2e-migrated/traces/single_pipeline_test.go
+++ b/test/e2e-migrated/traces/single_pipeline_test.go
@@ -50,7 +50,7 @@ func TestSinglePipeline(t *testing.T) {
 	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 
 	gatewayMetricsURL := suite.ProxyClient.ProxyURLForService(kitkyma.TraceGatewayMetricsService.Namespace, kitkyma.TraceGatewayMetricsService.Name, "metrics", ports.Metrics)
 	assert.EmitsOTelCollectorMetrics(t, gatewayMetricsURL)

--- a/test/e2e-migrated/traces/single_pipeline_v1beta1_test.go
+++ b/test/e2e-migrated/traces/single_pipeline_v1beta1_test.go
@@ -61,7 +61,7 @@ func TestSinglePipelineV1Beta1(t *testing.T) {
 	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
-	assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
 
 	gatewayMetricsURL := suite.ProxyClient.ProxyURLForService(kitkyma.TraceGatewayMetricsService.Namespace, kitkyma.TraceGatewayMetricsService.Name, "metrics", ports.Metrics)
 	assert.EmitsOTelCollectorMetrics(t, gatewayMetricsURL)

--- a/test/e2e-migrated/upgrade/traces_upgrade_test.go
+++ b/test/e2e-migrated/upgrade/traces_upgrade_test.go
@@ -48,13 +48,13 @@ func TestTracesUpgrade(t *testing.T) {
 		assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 		assert.TracePipelineHealthy(t, pipelineName)
 		assert.BackendReachable(t, backend)
-		assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+		assert.TracesFromNamespaceDelivered(t, backend, genNs)
 	})
 
 	t.Run("after upgrade", func(t *testing.T) {
 		assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 		assert.TracePipelineHealthy(t, pipelineName)
 		assert.BackendReachable(t, backend)
-		assert.TracesFromNamespaceDeliveredWithT(t, backend, genNs)
+		assert.TracesFromNamespaceDelivered(t, backend, genNs)
 	})
 }

--- a/test/e2e/misc/telemetry_logs_analysis_test.go
+++ b/test/e2e/misc/telemetry_logs_analysis_test.go
@@ -36,24 +36,23 @@ var _ = Describe(suite.ID(), Label(suite.LabelMisc), Ordered, func() {
 	)
 
 	var (
-		traceBackendURL string
-
-		metricBackend           *kitbackend.Backend
 		logBackend              *kitbackend.Backend
+		metricBackend           *kitbackend.Backend
+		traceBackend            *kitbackend.Backend
 		otelCollectorLogBackend *kitbackend.Backend
 		fluentBitLogBackend     *kitbackend.Backend
 		selfMonitorLogBackend   *kitbackend.Backend
-		namespace               = suite.ID()
-		gomegaMaxLength         = format.MaxLength
-		logLevelsRegexp         = "ERROR|error|WARNING|warning|WARN|warn"
+
+		namespace       = suite.ID()
+		gomegaMaxLength = format.MaxLength
+		logLevelsRegexp = "ERROR|error|WARNING|warning|WARN|warn"
 	)
 
 	makeResourcesTracePipeline := func(backendName string) []client.Object {
 		var objs []client.Object
 
 		// backend
-		traceBackend := kitbackend.New(namespace, kitbackend.SignalTypeTraces, kitbackend.WithName(backendName))
-		traceBackendURL = traceBackend.ExportURL(suite.ProxyClient)
+		traceBackend = kitbackend.New(namespace, kitbackend.SignalTypeTraces, kitbackend.WithName(backendName))
 		objs = append(objs, traceBackend.K8sObjects()...)
 
 		// pipeline
@@ -186,7 +185,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelMisc), Ordered, func() {
 		})
 
 		It("Should push traces successfully", func() {
-			assert.TracesFromNamespaceDelivered(suite.ProxyClient, traceBackendURL, namespace)
+			assert.TracesFromNamespaceDelivered(GinkgoT(), traceBackend, namespace)
 		})
 
 		It("Should collect logs successfully", func() {

--- a/test/e2e/selfmonitor/traces_healthy_test.go
+++ b/test/e2e/selfmonitor/traces_healthy_test.go
@@ -28,9 +28,9 @@ import (
 
 var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesHealthy), Ordered, func() {
 	var (
-		mockNs           = suite.ID()
-		pipelineName     = suite.ID()
-		backendExportURL string
+		mockNs       = suite.ID()
+		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
@@ -38,9 +38,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesHealthy), Orde
 
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeTraces)
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeTraces)
 		objs = append(objs, backend.K8sObjects()...)
-		backendExportURL = backend.ExportURL(suite.ProxyClient)
 
 		tracePipeline := testutils.NewTracePipelineBuilder().
 			WithName(pipelineName).
@@ -100,7 +99,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesHealthy), Orde
 		})
 
 		It("Should deliver telemetrygen traces", func() {
-			assert.TracesFromNamespaceDelivered(suite.ProxyClient, backendExportURL, kitkyma.DefaultNamespaceName)
+			assert.TracesFromNamespaceDelivered(GinkgoT(), backend, kitkyma.DefaultNamespaceName)
 		})
 
 		It("The telemetryFlowHealthy condition should be true", func() {

--- a/test/e2e/traces/basic_v1alpha1_test.go
+++ b/test/e2e/traces/basic_v1alpha1_test.go
@@ -184,7 +184,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTraces), func() {
 		})
 
 		It("Should deliver telemetrygen traces", Label(suite.LabelUpgrade), func() {
-			assert.TracesFromNamespaceDelivered(suite.ProxyClient, backend.ExportURL(suite.ProxyClient), mockNs)
+			assert.TracesFromNamespaceDelivered(GinkgoT(), backend, mockNs)
 		})
 
 		It("Should be able to get trace gateway metrics endpoint", Label(suite.LabelUpgrade), func() {

--- a/test/testkit/assert/traces.go
+++ b/test/testkit/assert/traces.go
@@ -2,7 +2,6 @@ package assert
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,14 +13,13 @@ import (
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
 	"github.com/kyma-project/telemetry-manager/test/testkit"
-	"github.com/kyma-project/telemetry-manager/test/testkit/apiserverproxy"
 	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/trace"
 	kitbackend "github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
 
-func TracesFromNamespaceDeliveredWithT(t testkit.T, backend *kitbackend.Backend, namespace string) {
+func TracesFromNamespaceDelivered(t testkit.T, backend *kitbackend.Backend, namespace string) {
 	t.Helper()
 
 	BackendDataEventuallyMatches(
@@ -33,7 +31,7 @@ func TracesFromNamespaceDeliveredWithT(t testkit.T, backend *kitbackend.Backend,
 	)
 }
 
-func TracesFromNamespacesNotDeliveredWithT(t testkit.T, backend *kitbackend.Backend, namespaces []string) {
+func TracesFromNamespacesNotDelivered(t testkit.T, backend *kitbackend.Backend, namespaces []string) {
 	t.Helper()
 
 	BackendDataConsistentlyMatches(
@@ -43,32 +41,6 @@ func TracesFromNamespacesNotDeliveredWithT(t testkit.T, backend *kitbackend.Back
 			HaveKeyWithValue("k8s.namespace.name", BeElementOf(namespaces)),
 		)))),
 	)
-}
-
-func TracesFromNamespaceDelivered(proxyClient *apiserverproxy.Client, backendExportURL, namespace string) {
-	Eventually(func(g Gomega) {
-		resp, err := proxyClient.Get(backendExportURL)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
-		g.Expect(resp).To(HaveHTTPBody(
-			HaveFlatTraces(ContainElement(HaveResourceAttributes(HaveKeyWithValue("k8s.namespace.name", namespace)))),
-		))
-		err = resp.Body.Close()
-		g.Expect(err).NotTo(HaveOccurred())
-	}, periodic.TelemetryEventuallyTimeout, periodic.TelemetryInterval).Should(Succeed())
-}
-
-func TracesFromNamespacesNotDelivered(proxyClient *apiserverproxy.Client, backendExportURL string, namespaces []string) {
-	Consistently(func(g Gomega) {
-		resp, err := proxyClient.Get(backendExportURL)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(resp).To(HaveHTTPStatus(http.StatusOK))
-		g.Expect(resp).To(HaveHTTPBody(
-			HaveFlatTraces(Not(ContainElement(HaveResourceAttributes(HaveKeyWithValue("k8s.namespace.name", BeElementOf(namespaces)))))),
-		))
-		err = resp.Body.Close()
-		g.Expect(err).NotTo(HaveOccurred())
-	}, periodic.TelemetryConsistentlyTimeout, periodic.TelemetryInterval).Should(Succeed())
 }
 
 func TracePipelineHealthy(t testkit.T, pipelineName string) {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Replace old backend assertions with BackendReachable helper function in logs e2e tests
- Uniformize use of TracesFromnamespace(Not)Delivered helper function

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/2146
- https://github.com/kyma-project/telemetry-manager/pull/2230

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
