### PR TITLE
chore: build telemetry-manager image when dependencies dir is updated

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -12,7 +12,6 @@ on:
       - "release-[0-9]+.[0-9]+"
     paths-ignore:
       - "docs/**"
-      - "dependencies/**"
       - "**/*.md"
       - "OWNERS"
       - "CODEOWNERS"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Build telemetry-manager image when dependencies dir is updated

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
