### PR TITLE
fix: assert backend reachability using helper function everywhere

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -118,6 +118,8 @@ jobs:
       matrix:
         signal-type:
           - fluentbit
+          - log-agent
+          - log-gateway
           - metrics
           - traces
         scenario:
@@ -156,58 +158,6 @@ jobs:
         if: ${{ matrix.scenario != 'healthy' }}
         run: |
           bin/ginkgo run ${{ runner.debug && '-v' || '' }} --tags istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }}&& !experimental" test/integration/istio
-
-      - name: Finalize Test
-        uses: "./.github/template/finalize-test"
-        if: ${{ !cancelled()  }}
-        with:
-          failure: failure()
-          job-name: ${{ github.job }}-${{ matrix.signal-type }}-${{ matrix.scenario }}
-
-  e2e-experimental-self-mon:
-    needs: setup
-    strategy:
-      fail-fast: false
-      matrix:
-        signal-type:
-          - log-agent
-          - log-gateway
-        scenario:
-          - backpressure
-          - outage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Prepare Test
-        uses: "./.github/template/prepare-test"
-        with:
-          experimental: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Deploy Test Prerequisites
-        if: ${{ matrix.scenario == 'healthy' }}
-        uses: "./.github/template/deploy-test-prerequisites"
-
-      - name: Run tests without Istio
-        if: ${{ matrix.scenario == 'healthy' }}
-        run: |
-          bin/ginkgo run ${{ runner.debug && '-v' || '' }} --tags e2e --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }} && experimental" -r test/e2e
-
-        # we need Istio for fault injection to simulate backpressure and outages
-      - name: Deploy Istio Module
-        if: ${{ matrix.scenario != 'healthy' }}
-        run: hack/deploy-istio.sh
-
-      - name: Deploy Test Prerequisites
-        if: ${{ matrix.scenario != 'healthy' }}
-        uses: "./.github/template/deploy-test-prerequisites"
-
-      - name: Run tests with Istio
-        if: ${{ matrix.scenario != 'healthy' }}
-        run: |
-          bin/ginkgo run ${{ runner.debug && '-v' || '' }} --tags istio --label-filter="self-mon-${{ matrix.signal-type }}-${{ matrix.scenario }} && experimental" test/integration/istio
 
       - name: Finalize Test
         uses: "./.github/template/finalize-test"

--- a/test/e2e-migrated/logs/shared/self_monitor_healthy_test.go
+++ b/test/e2e-migrated/logs/shared/self_monitor_healthy_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
 )
 
-func TestSelfMonitorHappyPath_OTel(t *testing.T) {
+func TestSelfMonitorHealthy_OTel(t *testing.T) {
 	tests := []struct {
 		label               string
 		inputBuilder        func(includeNs string) telemetryv1alpha1.LogPipelineInput
@@ -87,13 +87,12 @@ func TestSelfMonitorHappyPath_OTel(t *testing.T) {
 			}
 
 			assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)
-
-			assert.SelfMonitorIsHealthyForPipeline(t, suite.K8sClient, pipelineName)
+			assert.LogPipelineSelfMonitorIsHealthy(t, suite.K8sClient, pipelineName)
 		})
 	}
 }
 
-func TestSelfMonitorHappyPath_FluentBit(t *testing.T) {
+func TestSelfMonitorHealthy_FluentBit(t *testing.T) {
 	suite.RegisterTestCase(t, suite.LabelFluentBit)
 
 	var (
@@ -129,6 +128,5 @@ func TestSelfMonitorHappyPath_FluentBit(t *testing.T) {
 	assert.DeploymentReady(t, kitkyma.SelfMonitorName)
 	assert.FluentBitLogPipelineHealthy(t, pipelineName)
 	assert.FluentBitLogsFromNamespaceDelivered(t, backend, genNs)
-
-	assert.SelfMonitorIsHealthyForPipeline(t, suite.K8sClient, pipelineName)
+	assert.LogPipelineSelfMonitorIsHealthy(t, suite.K8sClient, pipelineName)
 }

--- a/test/e2e-migrated/metrics/kyma_input_test.go
+++ b/test/e2e-migrated/metrics/kyma_input_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/metric"
@@ -48,8 +47,8 @@ func TestKymaInput(t *testing.T) {
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
 
+	assert.BackendReachable(t, backend)
 	assert.DeploymentReady(t, kitkyma.MetricGatewayName)
-	assert.DeploymentReady(t, types.NamespacedName{Name: backendName, Namespace: backendNs})
 	assert.MetricPipelineHealthy(t, pipelineName)
 
 	Eventually(func(g Gomega) {

--- a/test/e2e-migrated/metrics/self_monitor_healthy_test.go
+++ b/test/e2e-migrated/metrics/self_monitor_healthy_test.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
+	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	kitbackend "github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
+	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
+)
+
+func TestSelfMonitorHealthy(t *testing.T) {
+	suite.RegisterTestCase(t, suite.LabelSelfMonitoringMetricsHealthy)
+
+	var (
+		uniquePrefix = unique.Prefix()
+		pipelineName = uniquePrefix()
+		backendNs    = uniquePrefix("backend")
+		genNs        = uniquePrefix("gen")
+	)
+
+	backend := kitbackend.New(backendNs, kitbackend.SignalTypeMetrics)
+
+	pipeline := testutils.NewMetricPipelineBuilder().
+		WithName(pipelineName).
+		WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+		Build()
+
+	resources := []client.Object{
+		kitk8s.NewNamespace(backendNs).K8sObject(),
+		kitk8s.NewNamespace(genNs).K8sObject(),
+		&pipeline,
+		telemetrygen.NewPod(genNs, telemetrygen.SignalTypeMetrics).K8sObject(),
+	}
+	resources = append(resources, backend.K8sObjects()...)
+
+	t.Cleanup(func() {
+		Expect(kitk8s.DeleteObjects(resources...)).To(Succeed())
+	})
+	Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+
+	assert.BackendReachable(t, backend)
+	assert.DeploymentReady(t, kitkyma.MetricGatewayName)
+	assert.MetricPipelineHealthy(t, pipelineName)
+	assert.MetricsFromNamespaceDelivered(t, backend, genNs, telemetrygen.MetricNames)
+	assert.MetricPipelineSelfMonitorIsHealthy(t, suite.K8sClient, pipelineName)
+}

--- a/test/e2e-migrated/traces/self_monitor_healthy_test.go
+++ b/test/e2e-migrated/traces/self_monitor_healthy_test.go
@@ -1,0 +1,54 @@
+package traces
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
+	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	kitbackend "github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
+	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
+)
+
+func TestSelfMonitorHealthy(t *testing.T) {
+	suite.RegisterTestCase(t, suite.LabelSelfMonitoringTracesHealthy)
+
+	var (
+		uniquePrefix = unique.Prefix()
+		pipelineName = uniquePrefix()
+		backendNs    = uniquePrefix("backend")
+		genNs        = uniquePrefix("gen")
+	)
+
+	backend := kitbackend.New(backendNs, kitbackend.SignalTypeTraces)
+
+	pipeline := testutils.NewTracePipelineBuilder().
+		WithName(pipelineName).
+		WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+		Build()
+
+	resources := []client.Object{
+		kitk8s.NewNamespace(backendNs).K8sObject(),
+		kitk8s.NewNamespace(genNs).K8sObject(),
+		&pipeline,
+		telemetrygen.NewPod(genNs, telemetrygen.SignalTypeTraces).K8sObject(),
+	}
+	resources = append(resources, backend.K8sObjects()...)
+
+	t.Cleanup(func() {
+		Expect(kitk8s.DeleteObjects(resources...)).To(Succeed())
+	})
+	Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+
+	assert.BackendReachable(t, backend)
+	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
+	assert.TracePipelineHealthy(t, pipelineName)
+	assert.TracesFromNamespaceDelivered(t, backend, genNs)
+	assert.TracePipelineSelfMonitorIsHealthy(t, suite.K8sClient, pipelineName)
+}

--- a/test/e2e/misc/overrides_test.go
+++ b/test/e2e/misc/overrides_test.go
@@ -33,6 +33,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 	var (
 		mockNs           = suite.ID()
 		pipelineName     = suite.ID()
+		backend          *kitbackend.Backend
 		backendExportURL string
 		overrides        *corev1.ConfigMap
 		now              time.Time
@@ -42,7 +43,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 		var objs []client.Object
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit)
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit)
 		objs = append(objs, backend.K8sObjects()...)
 		backendExportURL = backend.ExportURL(suite.ProxyClient)
 
@@ -108,7 +109,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelTelemetry), Ordered, func() {
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have INFO level logs in the backend", func() {

--- a/test/e2e/misc/telemetry_logs_analysis_test.go
+++ b/test/e2e/misc/telemetry_logs_analysis_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
@@ -155,14 +154,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelMisc), Ordered, func() {
 			assert.DeploymentReady(GinkgoT(), kitkyma.TraceGatewayName)
 		})
 
-		It("Should have running backends", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: namespace, Name: logBackendName})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: namespace, Name: metricBackendName})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: namespace, Name: traceBackendName})
-
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: namespace, Name: otelCollectorLogBackendName})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: namespace, Name: fluentBitLogBackendName})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: namespace, Name: selfMonitorLogBackendName})
+		It("Should have reachable backends", func() {
+			assert.BackendReachable(GinkgoT(), logBackend)
+			assert.BackendReachable(GinkgoT(), metricBackend)
+			assert.BackendReachable(GinkgoT(), traceBackend)
+			assert.BackendReachable(GinkgoT(), otelCollectorLogBackend)
+			assert.BackendReachable(GinkgoT(), fluentBitLogBackend)
+			assert.BackendReachable(GinkgoT(), selfMonitorLogBackend)
 		})
 
 		It("Should have running agents", func() {

--- a/test/integration/istio/access_logs_otlp_test.go
+++ b/test/integration/istio/access_logs_otlp_test.go
@@ -34,6 +34,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		mockNs              = suite.ID()
 		pipelineName        = suite.ID()
 		logBackend          *kitbackend.Backend
+		traceBackend        *kitbackend.Backend
 		logBackendExportURL string
 		metricPodURL        string
 	)
@@ -61,7 +62,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 
 		// Deploy a TracePipeline sending spans to the trace backend to verify that
 		// the istio noise filter is applied
-		traceBackend := kitbackend.New(mockNs, kitbackend.SignalTypeTraces, kitbackend.WithName("traces"))
+		traceBackend = kitbackend.New(mockNs, kitbackend.SignalTypeTraces, kitbackend.WithName("traces"))
 		objs = append(objs, traceBackend.K8sObjects()...)
 
 		tracePipeline := testutils.NewTracePipelineBuilder().
@@ -84,8 +85,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 			Expect(kitk8s.CreateObjects(GinkgoT(), k8sObjects...)).Should(Succeed())
 		})
 
-		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), logBackend.NamespacedName())
+		It("Should have reachable backends", func() {
+			assert.BackendReachable(GinkgoT(), logBackend)
+			assert.BackendReachable(GinkgoT(), traceBackend)
 		})
 
 		It("Should have sample app running", func() {

--- a/test/integration/istio/access_logs_test.go
+++ b/test/integration/istio/access_logs_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
@@ -32,6 +31,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 	var (
 		mockNs           = suite.ID()
 		pipelineName     = suite.ID()
+		backend          *kitbackend.Backend
 		backendExportURL string
 		metricPodURL     string
 	)
@@ -40,7 +40,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		var objs []client.Object
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit)
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit)
 		objs = append(objs, backend.K8sObjects()...)
 		backendExportURL = backend.ExportURL(suite.ProxyClient)
 
@@ -70,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have sample app running", func() {

--- a/test/integration/istio/logs_agent_self_monitor_backpressure_test.go
+++ b/test/integration/istio/logs_agent_self_monitor_backpressure_test.go
@@ -24,11 +24,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsAgentBackpressur
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithAbortFaultInjection(85))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithAbortFaultInjection(85))
 
 		logProducer := floggen.NewDeployment(mockNs).WithReplicas(3)
 
@@ -69,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsAgentBackpressur
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a log producer running", func() {

--- a/test/integration/istio/logs_agent_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_agent_self_monitor_outage_test.go
@@ -70,10 +70,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsAgentOutage), Or
 			assert.DeploymentReady(GinkgoT(), kitkyma.SelfMonitorName)
 		})
 
-		It("Should have a log backend running", func() {
-			assert.BackendReachable(GinkgoT(), backend)
-		})
-
 		It("Should have a log producer running", func() {
 			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: floggen.DefaultName})
 		})

--- a/test/integration/istio/logs_agent_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_agent_self_monitor_outage_test.go
@@ -25,11 +25,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsAgentOutage), Or
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithReplicas(0))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithReplicas(0))
 
 		logProducer := floggen.NewDeployment(mockNs).WithReplicas(3)
 
@@ -70,7 +71,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsAgentOutage), Or
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a log producer running", func() {

--- a/test/integration/istio/logs_fluentbit_self_monitor_backpressure_test.go
+++ b/test/integration/istio/logs_fluentbit_self_monitor_backpressure_test.go
@@ -24,12 +24,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsFluentBitBackpre
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithAbortFaultInjection(85))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithAbortFaultInjection(85))
 		logProducer := floggen.NewDeployment(mockNs).WithReplicas(3)
 		objs = append(objs, backend.K8sObjects()...)
 		objs = append(objs, logProducer.K8sObject())
@@ -65,7 +66,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsFluentBitBackpre
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a log producer running", func() {

--- a/test/integration/istio/logs_fluentbit_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_fluentbit_self_monitor_outage_test.go
@@ -25,13 +25,14 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsFluentBitOutage)
 	var (
 		mockNs       = suite.ID()
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
 		objs = append(objs, kitk8s.NewNamespace(mockNs, kitk8s.WithIstioInjection()).K8sObject())
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithReplicas(0))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsFluentBit, kitbackend.WithReplicas(0))
 
 		logProducer := floggen.NewDeployment(mockNs).WithReplicas(2)
 
@@ -69,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsFluentBitOutage)
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a log producer running", func() {

--- a/test/integration/istio/logs_fluentbit_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_fluentbit_self_monitor_outage_test.go
@@ -69,10 +69,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsFluentBitOutage)
 			assert.DaemonSetReady(GinkgoT(), kitkyma.FluentBitDaemonSetName)
 		})
 
-		It("Should have a log backend running", func() {
-			assert.BackendReachable(GinkgoT(), backend)
-		})
-
 		It("Should have a log producer running", func() {
 			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: floggen.DefaultName})
 		})

--- a/test/integration/istio/logs_gateway_self_monitor_backpressure_test.go
+++ b/test/integration/istio/logs_gateway_self_monitor_backpressure_test.go
@@ -24,11 +24,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsGatewayBackpress
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithAbortFaultInjection(85))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithAbortFaultInjection(85))
 
 		logGenerator := telemetrygen.NewDeployment(mockNs, telemetrygen.SignalTypeLogs,
 			telemetrygen.WithRate(800),
@@ -71,7 +72,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsGatewayBackpress
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a telemetrygen running", func() {

--- a/test/integration/istio/logs_gateway_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_gateway_self_monitor_outage_test.go
@@ -72,10 +72,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsGatewayOutage), 
 			assert.DeploymentReady(GinkgoT(), kitkyma.SelfMonitorName)
 		})
 
-		It("Should have a log backend running", func() {
-			assert.BackendReachable(GinkgoT(), backend)
-		})
-
 		It("Should have a telemetrygen running", func() {
 			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})

--- a/test/integration/istio/logs_gateway_self_monitor_outage_test.go
+++ b/test/integration/istio/logs_gateway_self_monitor_outage_test.go
@@ -25,11 +25,12 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsGatewayOutage), 
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithReplicas(0))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithReplicas(0))
 
 		logGenerator := telemetrygen.NewDeployment(mockNs, telemetrygen.SignalTypeLogs,
 			telemetrygen.WithRate(800),
@@ -72,7 +73,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringLogsGatewayOutage), 
 		})
 
 		It("Should have a log backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a telemetrygen running", func() {

--- a/test/integration/istio/metrics_istio_envoy_multi_pipeline_test.go
+++ b/test/integration/istio/metrics_istio_envoy_multi_pipeline_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
@@ -33,8 +32,10 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		mockNs            = suite.ID()
 		app1Ns            = "app-1"
 		app2Ns            = "app-2"
+		backend1          *kitbackend.Backend
 		backend1Name      = "backend-1"
 		backend1ExportURL string
+		backend2          *kitbackend.Backend
 		backend2Name      = "backend-2"
 		backend2ExportURL string
 	)
@@ -45,7 +46,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 			kitk8s.NewNamespace(app1Ns, kitk8s.WithIstioInjection()).K8sObject(),
 			kitk8s.NewNamespace(app2Ns, kitk8s.WithIstioInjection()).K8sObject())
 
-		backend1 := kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithName(backend1Name))
+		backend1 = kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithName(backend1Name))
 		backend1ExportURL = backend1.ExportURL(suite.ProxyClient)
 		objs = append(objs, backend1.K8sObjects()...)
 
@@ -57,7 +58,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 			Build()
 		objs = append(objs, &pipelineIncludeApp1Ns)
 
-		backend2 := kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithName(backend2Name))
+		backend2 = kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithName(backend2Name))
 		backend2ExportURL = backend2.ExportURL(suite.ProxyClient)
 		objs = append(objs, backend2.K8sObjects()...)
 
@@ -95,8 +96,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: backend1Name, Namespace: mockNs})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: backend2Name, Namespace: mockNs})
+			assert.BackendReachable(GinkgoT(), backend1)
+			assert.BackendReachable(GinkgoT(), backend2)
 		})
 
 		It("Should verify envoy metric reach backend-1", func() {

--- a/test/integration/istio/metrics_istio_input_envoy_metrics_test.go
+++ b/test/integration/istio/metrics_istio_input_envoy_metrics_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
@@ -32,6 +31,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		mockNs           = suite.ID()
 		app1Ns           = suite.IDWithSuffix("app-1")
 		pipelineName     = suite.ID()
+		backend          *kitbackend.Backend
 		backendExportURL string
 	)
 
@@ -40,7 +40,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject(),
 			kitk8s.NewNamespace(app1Ns, kitk8s.WithIstioInjection()).K8sObject())
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeMetrics)
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeMetrics)
 		objs = append(objs, backend.K8sObjects()...)
 		backendExportURL = backend.ExportURL(suite.ProxyClient)
 
@@ -77,7 +77,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a running metric agent daemonset", func() {

--- a/test/integration/istio/metrics_istio_input_test.go
+++ b/test/integration/istio/metrics_istio_input_test.go
@@ -71,6 +71,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio, suite.
 		pipelineName = suite.ID()
 
 		metricBackend *kitbackend.Backend
+		logBackend    *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
@@ -95,7 +96,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio, suite.
 
 		// Deploy a LogPipeline and an app sending OTLP logs to the log gateway
 		// to make sure that the istio noise filter is applied to app-to-gateway communication
-		logBackend := kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithName("logs"))
+		logBackend = kitbackend.New(mockNs, kitbackend.SignalTypeLogsOTel, kitbackend.WithName("logs"))
 		objs = append(objs, logBackend.K8sObjects()...)
 
 		logPipeline := testutils.NewLogPipelineBuilder().
@@ -127,8 +128,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio, suite.
 			assert.DaemonSetReady(GinkgoT(), kitkyma.MetricAgentName)
 		})
 
-		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), metricBackend.NamespacedName())
+		It("Should have reachable backends", func() {
+			assert.BackendReachable(GinkgoT(), metricBackend)
+			assert.BackendReachable(GinkgoT(), logBackend)
 		})
 
 		It("Should have a running metric agent daemonset", func() {

--- a/test/integration/istio/metrics_otlp_input_test.go
+++ b/test/integration/istio/metrics_otlp_input_test.go
@@ -97,9 +97,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 			assert.DeploymentReady(GinkgoT(), kitkyma.MetricGatewayName)
 		})
 
-		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: istiofiedBackendNs})
+		It("Should have reachable backends", func() {
+			assert.BackendReachable(GinkgoT(), backend)
+			assert.BackendReachable(GinkgoT(), istiofiedBackend)
 		})
 
 		It("Should push metrics successfully", func() {

--- a/test/integration/istio/metrics_prometheus_input_test.go
+++ b/test/integration/istio/metrics_prometheus_input_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/kyma-project/telemetry-manager/internal/otelcollector/config/metric"
@@ -30,6 +29,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		httpsAnnotatedMetricProducerName = suite.IDWithSuffix("producer-https")
 		httpAnnotatedMetricProducerName  = suite.IDWithSuffix("producer-http")
 		unannotatedMetricProducerName    = suite.IDWithSuffix("producer")
+		backend                          *kitbackend.Backend
 	)
 	var backendExportURL string
 
@@ -39,7 +39,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		objs = append(objs, kitk8s.NewNamespace(mockNs).K8sObject())
 
 		// Mocks namespace objects
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeMetrics)
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeMetrics)
 		objs = append(objs, backend.K8sObjects()...)
 		backendExportURL = backend.ExportURL(suite.ProxyClient)
 
@@ -87,7 +87,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: mockNs})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		Context("Verify metric scraping works with annotating pods and services", Ordered, func() {

--- a/test/integration/istio/metrics_self_monitor_backpressure_test.go
+++ b/test/integration/istio/metrics_self_monitor_backpressure_test.go
@@ -24,12 +24,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsBackpressure)
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithAbortFaultInjection(85))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithAbortFaultInjection(85))
 		objs = append(objs, backend.K8sObjects()...)
 
 		metricPipeline := testutils.NewMetricPipelineBuilder().
@@ -69,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsBackpressure)
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a telemetrygen running", func() {

--- a/test/integration/istio/metrics_self_monitor_outage_test.go
+++ b/test/integration/istio/metrics_self_monitor_outage_test.go
@@ -27,12 +27,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithReplicas(0))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeMetrics, kitbackend.WithReplicas(0))
 		objs = append(objs, backend.K8sObjects()...)
 
 		metricPipeline := testutils.NewMetricPipelineBuilder().
@@ -97,7 +98,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 		})
 
 		It("Should have a metrics backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a telemetrygen running", func() {

--- a/test/integration/istio/metrics_self_monitor_outage_test.go
+++ b/test/integration/istio/metrics_self_monitor_outage_test.go
@@ -97,10 +97,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringMetricsOutage), Orde
 			assert.DeploymentReady(GinkgoT(), kitkyma.SelfMonitorName)
 		})
 
-		It("Should have a metrics backend running", func() {
-			assert.BackendReachable(GinkgoT(), backend)
-		})
-
 		It("Should have a telemetrygen running", func() {
 			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})

--- a/test/integration/istio/traces_self_monitor_backpressure_test.go
+++ b/test/integration/istio/traces_self_monitor_backpressure_test.go
@@ -24,12 +24,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesBackpressure),
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeTraces, kitbackend.WithAbortFaultInjection(75))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeTraces, kitbackend.WithAbortFaultInjection(75))
 		objs = append(objs, backend.K8sObjects()...)
 
 		tracePipeline := testutils.NewTracePipelineBuilder().
@@ -69,7 +70,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesBackpressure),
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a telemetrygen running", func() {

--- a/test/integration/istio/traces_self_monitor_outage_test.go
+++ b/test/integration/istio/traces_self_monitor_outage_test.go
@@ -27,12 +27,13 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 	var (
 		mockNs       = "istio-permissive-mtls"
 		pipelineName = suite.ID()
+		backend      *kitbackend.Backend
 	)
 
 	makeResources := func() []client.Object {
 		var objs []client.Object
 
-		backend := kitbackend.New(mockNs, kitbackend.SignalTypeTraces, kitbackend.WithReplicas(0))
+		backend = kitbackend.New(mockNs, kitbackend.SignalTypeTraces, kitbackend.WithReplicas(0))
 		objs = append(objs, backend.K8sObjects()...)
 
 		tracePipeline := testutils.NewTracePipelineBuilder().
@@ -72,7 +73,7 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 		})
 
 		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Namespace: mockNs, Name: kitbackend.DefaultName})
+			assert.BackendReachable(GinkgoT(), backend)
 		})
 
 		It("Should have a telemetrygen running", func() {

--- a/test/integration/istio/traces_self_monitor_outage_test.go
+++ b/test/integration/istio/traces_self_monitor_outage_test.go
@@ -72,10 +72,6 @@ var _ = Describe(suite.ID(), Label(suite.LabelSelfMonitoringTracesOutage), Order
 			assert.DeploymentReady(GinkgoT(), kitkyma.SelfMonitorName)
 		})
 
-		It("Should have a trace backend running", func() {
-			assert.BackendReachable(GinkgoT(), backend)
-		})
-
 		It("Should have a telemetrygen running", func() {
 			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: telemetrygen.DefaultName, Namespace: mockNs})
 		})

--- a/test/integration/istio/traces_test.go
+++ b/test/integration/istio/traces_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
@@ -36,6 +35,8 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		appNs                     = suite.IDWithSuffix("app")
 		pipeline1Name             = suite.IDWithSuffix("1")
 		pipeline2Name             = suite.IDWithSuffix("2")
+		backend                   *kitbackend.Backend
+		istiofiedBackend          *kitbackend.Backend
 		backendExportURL          string
 		istiofiedBackendExportURL string
 		appURL                    string
@@ -50,23 +51,23 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 		objs = append(objs, kitk8s.NewNamespace(istiofiedBackendNs, kitk8s.WithIstioInjection()).K8sObject())
 		objs = append(objs, kitk8s.NewNamespace(appNs).K8sObject())
 
-		backend1 := kitbackend.New(backendNs, kitbackend.SignalTypeTraces)
-		objs = append(objs, backend1.K8sObjects()...)
-		backendExportURL = backend1.ExportURL(suite.ProxyClient)
+		backend = kitbackend.New(backendNs, kitbackend.SignalTypeTraces)
+		objs = append(objs, backend.K8sObjects()...)
+		backendExportURL = backend.ExportURL(suite.ProxyClient)
 
-		backend2 := kitbackend.New(istiofiedBackendNs, kitbackend.SignalTypeTraces)
-		objs = append(objs, backend2.K8sObjects()...)
-		istiofiedBackendExportURL = backend2.ExportURL(suite.ProxyClient)
+		istiofiedBackend = kitbackend.New(istiofiedBackendNs, kitbackend.SignalTypeTraces)
+		objs = append(objs, istiofiedBackend.K8sObjects()...)
+		istiofiedBackendExportURL = istiofiedBackend.ExportURL(suite.ProxyClient)
 
 		istioTracePipeline := testutils.NewTracePipelineBuilder().
 			WithName(pipeline2Name).
-			WithOTLPOutput(testutils.OTLPEndpoint(backend2.Endpoint())).
+			WithOTLPOutput(testutils.OTLPEndpoint(istiofiedBackend.Endpoint())).
 			Build()
 		objs = append(objs, &istioTracePipeline)
 
 		tracePipeline := testutils.NewTracePipelineBuilder().
 			WithName(pipeline1Name).
-			WithOTLPOutput(testutils.OTLPEndpoint(backend1.Endpoint())).
+			WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
 			Build()
 		objs = append(objs, &tracePipeline)
 
@@ -98,9 +99,9 @@ var _ = Describe(suite.ID(), Label(suite.LabelGardener, suite.LabelIstio), Order
 			Expect(kitk8s.CreateObjects(GinkgoT(), k8sObjects...)).Should(Succeed())
 		})
 
-		It("Should have a trace backend running", func() {
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: backendNs})
-			assert.DeploymentReady(GinkgoT(), types.NamespacedName{Name: kitbackend.DefaultName, Namespace: istiofiedBackendNs})
+		It("Should have reachable backends", func() {
+			assert.BackendReachable(GinkgoT(), backend)
+			assert.BackendReachable(GinkgoT(), istiofiedBackend)
 		})
 
 		It("Should have sample app running with Istio sidecar", func() {

--- a/test/testkit/assert/metrics.go
+++ b/test/testkit/assert/metrics.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
@@ -122,4 +123,16 @@ func MetricPipelineConditionReasonsTransition(t testkit.T, pipelineName, condTyp
 
 		fmt.Fprintf(GinkgoWriter, "Transitioned to [%s]%s\n", currCond.Status, currCond.Reason)
 	}
+}
+
+//nolint:dupl // TODO: Find a generic approach to merge this helper function with the other ones for the other telemetry types
+func MetricPipelineSelfMonitorIsHealthy(t testkit.T, k8sClient client.Client, pipelineName string) {
+	t.Helper()
+
+	Eventually(func(g Gomega) {
+		var pipeline telemetryv1alpha1.MetricPipeline
+		key := types.NamespacedName{Name: pipelineName}
+		g.Expect(k8sClient.Get(t.Context(), key, &pipeline)).To(Succeed())
+		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeFlowHealthy)).To(BeTrueBecause("Flow not healthy"))
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }

--- a/test/testkit/assert/telemetry.go
+++ b/test/testkit/assert/telemetry.go
@@ -8,8 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/kyma-project/telemetry-manager/apis/operator/v1alpha1"
-	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
-	"github.com/kyma-project/telemetry-manager/internal/conditions"
 	"github.com/kyma-project/telemetry-manager/test/testkit"
 	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
 	"github.com/kyma-project/telemetry-manager/test/testkit/periodic"
@@ -38,16 +36,5 @@ func TelemetryHasCondition(t testkit.T, k8sClient client.Client, expectedCond me
 		g.Expect(condition).NotTo(BeNil())
 		g.Expect(condition.Reason).To(Equal(expectedCond.Reason))
 		g.Expect(condition.Status).To(Equal(expectedCond.Status))
-	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
-}
-
-func SelfMonitorIsHealthyForPipeline(t testkit.T, k8sClient client.Client, pipelineName string) {
-	t.Helper()
-
-	Eventually(func(g Gomega) {
-		var pipeline telemetryv1alpha1.LogPipeline
-		key := types.NamespacedName{Name: pipelineName}
-		g.Expect(k8sClient.Get(t.Context(), key, &pipeline)).To(Succeed())
-		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeFlowHealthy)).To(BeTrueBecause("Flow not healthy"))
 	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }

--- a/test/testkit/assert/traces.go
+++ b/test/testkit/assert/traces.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	telemetryv1alpha1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1alpha1"
 	"github.com/kyma-project/telemetry-manager/internal/conditions"
@@ -98,4 +99,16 @@ func TracePipelineConditionReasonsTransition(t testkit.T, pipelineName, condType
 
 		fmt.Fprintf(GinkgoWriter, "Transitioned to [%s]%s\n", currCond.Status, currCond.Reason)
 	}
+}
+
+//nolint:dupl // TODO: Find a generic approach to merge this helper function with the other ones for the other telemetry types
+func TracePipelineSelfMonitorIsHealthy(t testkit.T, k8sClient client.Client, pipelineName string) {
+	t.Helper()
+
+	Eventually(func(g Gomega) {
+		var pipeline telemetryv1alpha1.TracePipeline
+		key := types.NamespacedName{Name: pipelineName}
+		g.Expect(k8sClient.Get(t.Context(), key, &pipeline)).To(Succeed())
+		g.Expect(meta.IsStatusConditionTrue(pipeline.Status.Conditions, conditions.TypeFlowHealthy)).To(BeTrueBecause("Flow not healthy"))
+	}, periodic.EventuallyTimeout, periodic.DefaultInterval).Should(Succeed())
 }


### PR DESCRIPTION
…ng backend reachability

## Description

Changes proposed in this pull request (what was done and why):

- Ensure the BackendReachable helper function is used everywhere for checking backend reachability, instead of just checking the deployment readiness
- Ensure consistency between selfmonitor e2e tests

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
