### PR TITLE
chore: bump fluentbit image in cache

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,6 +1,6 @@
 images:
-  - source: "fluent/fluent-bit@sha256:ca08b7d2df5bab68914db40dad2ead89ab74efd8641a8e062fc9bf138bfcf97a"
-    tag: "4.0.4" # used by the kyma telemetry module
+  - source: "fluent/fluent-bit@sha256:ef17f25f3a76c11a267f95467cda283dddd69bdd1079f5134b0926a7998ba356"
+    tag: "4.0.5" # used by the kyma telemetry module
   - source: "rancher/k3s@sha256:e8880a62f5ce10cd53d4a2dc401f50ea98f54bec45a39aa39215881e393a9d11"
     tag: "v1.31.7-k3s1" # used by k3d
   - source: "library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump fluentbit image in cache to 4.0.5

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
