### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,7 +69,6 @@ jobs:
       dockerfile: Dockerfile
       context: .
       tags: ${{ needs.envs.outputs.tags }}
-      build-engine: buildx
       platforms: "linux/amd64,linux/arm64"
 
   notify-on-failure:

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -47,7 +47,6 @@ jobs:
       dockerfile: Dockerfile
       context: dependencies/sample-app
       tags: ${{ needs.envs.outputs.tags }}
-      build-engine: buildx
       platforms: "linux/amd64,linux/arm64"
   list-images:
     needs: build-image

--- a/.github/workflows/build-stdout-log-generator-image.yaml
+++ b/.github/workflows/build-stdout-log-generator-image.yaml
@@ -47,7 +47,6 @@ jobs:
       dockerfile: Dockerfile
       context: dependencies/stdout-log-generator
       tags: ${{ needs.envs.outputs.tags }}
-      build-engine: buildx
       platforms: "linux/amd64,linux/arm64"
   list-images:
     needs: build-image

--- a/.github/workflows/build-telemetry-self-monitor-image.yml
+++ b/.github/workflows/build-telemetry-self-monitor-image.yml
@@ -70,7 +70,6 @@ jobs:
       context: dependencies/telemetry-self-monitor
       build-args: ${{ needs.envs.outputs.build-args }}
       tags: ${{ needs.envs.outputs.build-tag }}
-      build-engine: buildx
       platforms: "linux/amd64,linux/arm64"
   list-images:
     needs: build-image


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.