### PR TITLE
chore: migrate selfmonitor tests

### DIFF
--- a/test/selfmonitor/backpressure_test.go
+++ b/test/selfmonitor/backpressure_test.go
@@ -1,0 +1,4 @@
+package selfmonitor
+
+// TODO: Implement a table-driven test for the backpressure self-monitoring scenario, covering all telemetry data types.
+// (this scenario requires istio as well)

--- a/test/selfmonitor/healthy_test.go
+++ b/test/selfmonitor/healthy_test.go
@@ -1,0 +1,3 @@
+package selfmonitor
+
+// TODO: Implement a table-driven test for the healthy self-monitoring scenario, covering all telemetry data types.

--- a/test/selfmonitor/healthy_test.go
+++ b/test/selfmonitor/healthy_test.go
@@ -1,3 +1,142 @@
 package selfmonitor
 
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
+	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	kitbackend "github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/stdloggen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
+	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 // TODO: Implement a table-driven test for the healthy self-monitoring scenario, covering all telemetry data types.
+func TestHealthy(t *testing.T) {
+	tests := []struct {
+		name                       string
+		signalType                 kitbackend.SignalType
+		pipeline                   func(includeNs string, backend *kitbackend.Backend) client.Object
+		generator                  func(ns string) client.Object
+		resourcesReady             func()
+		dataFromNamespaceDelivered func(ns string, backend *kitbackend.Backend)
+		selfMonitorIsHealthy       func()
+	}{
+		{
+			name: logsOTelAgentPrefix,
+			signalType: kitbackend.SignalTypeLogsOTel,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewLogPipelineBuilder().
+					WithName(logsOTelAgentPrefix).
+					WithInput(testutils.BuildLogPipelineApplicationInput(testutils.ExtIncludeNamespaces(includeNs))).
+					WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return stdloggen.NewDeployment(ns).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DeploymentReady(t, kitkyma.LogGatewayName)
+				assert.DaemonSetReady(t, kitkyma.LogAgentName)
+				assert.OTelLogPipelineHealthy(t, logsOTelAgentPrefix)
+			},
+			dataFromNamespaceDelivered: func(ns string, backend *kitbackend.Backend) {
+				assert.OTelLogsFromNamespaceDelivered(t, backend, ns)
+			},
+			selfMonitorIsHealthy: func() {
+				assert.LogPipelineSelfMonitorIsHealthy(t, suite.K8sClient, logsOTelAgentPrefix)
+			},
+		},
+		{
+			name: logsOTelGatewayPrefix,
+			signalType: kitbackend.SignalTypeLogsOTel,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewLogPipelineBuilder().
+					WithName(logsOTelGatewayPrefix).
+					WithInput(testutils.BuildLogPipelineOTLPInput(testutils.IncludeNamespaces(includeNs))).
+					WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return telemetrygen.NewDeployment(ns, telemetrygen.SignalTypeLogs).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DeploymentReady(t, kitkyma.LogGatewayName)
+				assert.OTelLogPipelineHealthy(t, logsOTelGatewayPrefix)
+			},
+			dataFromNamespaceDelivered: func(ns string, backend *kitbackend.Backend) {
+				assert.OTelLogsFromNamespaceDelivered(t, backend, ns)
+			},
+			selfMonitorIsHealthy: func() {
+				assert.LogPipelineSelfMonitorIsHealthy(t, suite.K8sClient, logsOTelGatewayPrefix)
+			},
+		},
+		{
+			name: logsFluentbitPrefix,
+			signalType: kitbackend.SignalTypeLogsFluentBit,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewLogPipelineBuilder().
+					WithName(logsFluentbitPrefix).
+					WithApplicationInput(true, testutils.ExtIncludeNamespaces(includeNs)).
+					WithHTTPOutput(testutils.HTTPHost(backend.Host()), testutils.HTTPPort(backend.Port())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return stdloggen.NewDeployment(ns).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
+				assert.FluentBitLogPipelineHealthy(t, logsFluentbitPrefix)
+			},
+			dataFromNamespaceDelivered: func(ns string, backend *kitbackend.Backend) {
+				assert.FluentBitLogsFromNamespaceDelivered(t, backend, ns)
+			},
+			selfMonitorIsHealthy: func() {
+				assert.LogPipelineSelfMonitorIsHealthy(t, suite.K8sClient, logsFluentbitPrefix)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			suite.RegisterTestCase(t, suite.LabelSelfMonitoringHealthy)
+
+			var (
+				uniquePrefix = unique.Prefix(tc.name)
+				backendNs    = uniquePrefix("backend")
+				genNs        = uniquePrefix("gen")
+			)
+
+			backend := kitbackend.New(backendNs, tc.signalType)
+
+			resources := []client.Object{
+				kitk8s.NewNamespace(backendNs).K8sObject(),
+				kitk8s.NewNamespace(genNs).K8sObject(),
+				tc.pipeline(genNs, backend),
+				tc.generator(genNs),
+			}
+			resources = append(resources, backend.K8sObjects()...)
+
+			t.Cleanup(func() {
+				Expect(kitk8s.DeleteObjects(resources...)).To(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+
+			assert.BackendReachable(t, backend)
+			tc.resourcesReady()
+			tc.dataFromNamespaceDelivered(genNs, backend)
+
+			assert.DeploymentReady(t, kitkyma.SelfMonitorName)
+			tc.selfMonitorIsHealthy()
+		})
+	}
+}

--- a/test/selfmonitor/main_test.go
+++ b/test/selfmonitor/main_test.go
@@ -5,15 +5,16 @@ import (
 	"os"
 	"testing"
 
+	kitbackend "github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
 	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
 )
 
 const (
-	logsOTelAgentPrefix   = "logs-otel-agent"
-	logsOTelGatewayPrefix = "logs-otel-gateway"
-	logsFluentbitPrefix   = "logs-fluentbit"
-	metricsPrefix         = "metrics"
-	tracesPrefix          = "traces"
+	kindLogsOTelAgent   string = "logs-otel-agent"
+	kindLogsOTelGateway string = "logs-otel-gateway"
+	kindLogsFluentbit   string = "logs-fluentbit"
+	kindMetrics         string = "metrics"
+	kindTraces          string = "traces"
 )
 
 func TestMain(m *testing.M) {
@@ -25,4 +26,19 @@ func TestMain(m *testing.M) {
 	}
 
 	m.Run()
+}
+
+func signalType(testKind string) kitbackend.SignalType {
+	switch testKind {
+	case kindLogsOTelAgent, kindLogsOTelGateway:
+		return kitbackend.SignalTypeLogsOTel
+	case kindLogsFluentbit:
+		return kitbackend.SignalTypeLogsFluentBit
+	case kindMetrics:
+		return kitbackend.SignalTypeMetrics
+	case kindTraces:
+		return kitbackend.SignalTypeTraces
+	default:
+		return ""
+	}
 }

--- a/test/selfmonitor/main_test.go
+++ b/test/selfmonitor/main_test.go
@@ -1,0 +1,28 @@
+package selfmonitor
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
+)
+
+const (
+	logsOTelAgentPrefix   = "logs-otel-agent"
+	logsOTelGatewayPrefix = "logs-otel-gateway"
+	logsFluentbitPrefix   = "logs-fluentbit"
+	metricsPrefix         = "metrics"
+	tracesPrefix          = "traces"
+)
+
+func TestMain(m *testing.M) {
+	const errorCode = 1
+
+	if err := suite.BeforeSuiteFuncErr(); err != nil {
+		log.Printf("Setup failed: %v", err)
+		os.Exit(errorCode)
+	}
+
+	m.Run()
+}

--- a/test/selfmonitor/outage_test.go
+++ b/test/selfmonitor/outage_test.go
@@ -1,4 +1,178 @@
 package selfmonitor
 
-// TODO: Implement a table-driven test for the outage self-monitoring scenario, covering all telemetry data types.
-// (this scenario requires istio as well)
+import (
+	"testing"
+
+	. "github.com/kyma-project/telemetry-manager/test/testkit/matchers/prometheus"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "github.com/kyma-project/telemetry-manager/internal/utils/test"
+	"github.com/kyma-project/telemetry-manager/test/testkit/assert"
+	kitk8s "github.com/kyma-project/telemetry-manager/test/testkit/k8s"
+	kitkyma "github.com/kyma-project/telemetry-manager/test/testkit/kyma"
+	kitbackend "github.com/kyma-project/telemetry-manager/test/testkit/mocks/backend"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/stdloggen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/mocks/telemetrygen"
+	"github.com/kyma-project/telemetry-manager/test/testkit/suite"
+	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
+)
+
+func TestOutage(t *testing.T) {
+	tests := []struct {
+		prefix         string
+		signalType     kitbackend.SignalType
+		pipeline       func(includeNs string, backend *kitbackend.Backend) client.Object
+		generator      func(ns string) client.Object
+		resourcesReady func()
+	}{
+		{
+			prefix:     logsOTelAgentPrefix,
+			signalType: kitbackend.SignalTypeLogsOTel,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewLogPipelineBuilder().
+					WithName(logsOTelAgentPrefix).
+					WithInput(testutils.BuildLogPipelineApplicationInput(testutils.ExtIncludeNamespaces(includeNs))).
+					WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return stdloggen.NewDeployment(ns).WithReplicas(3).K8sObject() // TODO: Any reason for 3 replicas?
+			},
+			resourcesReady: func() {
+				assert.DeploymentReady(t, kitkyma.LogGatewayName)
+				assert.DaemonSetReady(t, kitkyma.LogAgentName)
+				assert.OTelLogPipelineHealthy(t, logsOTelAgentPrefix)
+			},
+		},
+		{
+			prefix:     logsOTelGatewayPrefix,
+			signalType: kitbackend.SignalTypeLogsOTel,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewLogPipelineBuilder().
+					WithName(logsOTelGatewayPrefix).
+					WithInput(testutils.BuildLogPipelineOTLPInput(testutils.IncludeNamespaces(includeNs))).
+					WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return telemetrygen.NewDeployment(ns, telemetrygen.SignalTypeLogs).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DeploymentReady(t, kitkyma.LogGatewayName)
+				assert.OTelLogPipelineHealthy(t, logsOTelGatewayPrefix)
+			},
+		},
+		{
+			prefix:     logsFluentbitPrefix,
+			signalType: kitbackend.SignalTypeLogsFluentBit,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewLogPipelineBuilder().
+					WithName(logsFluentbitPrefix).
+					WithApplicationInput(true, testutils.ExtIncludeNamespaces(includeNs)).
+					WithHTTPOutput(testutils.HTTPHost(backend.Host()), testutils.HTTPPort(backend.Port())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return stdloggen.NewDeployment(ns).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
+				assert.FluentBitLogPipelineHealthy(t, logsFluentbitPrefix)
+			},
+		},
+		{
+			prefix:     metricsPrefix,
+			signalType: kitbackend.SignalTypeMetrics,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewMetricPipelineBuilder().
+					WithName(metricsPrefix).
+					WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return telemetrygen.NewPod(ns, telemetrygen.SignalTypeMetrics).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DeploymentReady(t, kitkyma.MetricGatewayName)
+				assert.MetricPipelineHealthy(t, metricsPrefix)
+			},
+		},
+		{
+			prefix:     tracesPrefix,
+			signalType: kitbackend.SignalTypeTraces,
+			pipeline: func(includeNs string, backend *kitbackend.Backend) client.Object {
+				p := testutils.NewTracePipelineBuilder().
+					WithName(tracesPrefix).
+					WithOTLPOutput(testutils.OTLPEndpoint(backend.Endpoint())).
+					Build()
+				return &p
+			},
+			generator: func(ns string) client.Object {
+				return telemetrygen.NewPod(ns, telemetrygen.SignalTypeTraces).K8sObject()
+			},
+			resourcesReady: func() {
+				assert.DeploymentReady(t, kitkyma.TraceGatewayName)
+				assert.TracePipelineHealthy(t, tracesPrefix)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.prefix, func(t *testing.T) {
+			suite.RegisterTestCase(t, suite.LabelSelfMonitoringOutage)
+
+			var (
+				uniquePrefix = unique.Prefix(tc.prefix)
+				backendNs    = uniquePrefix("backend")
+				genNs        = uniquePrefix("gen")
+			)
+
+			backend := kitbackend.New(backendNs, tc.signalType, kitbackend.WithReplicas(0)) // simulate outage
+
+			resources := []client.Object{
+				kitk8s.NewNamespace(backendNs).K8sObject(),
+				kitk8s.NewNamespace(genNs).K8sObject(),
+				tc.pipeline(genNs, backend),
+				tc.generator(genNs),
+			}
+			resources = append(resources, backend.K8sObjects()...)
+
+			t.Cleanup(func() {
+				Expect(kitk8s.DeleteObjects(resources...)).To(Succeed())
+			})
+			Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+
+			tc.resourcesReady()
+
+			assert.DeploymentReady(t, kitkyma.SelfMonitorName)
+			// TODO: checkBufferFillingUp if signalType is metrics/traces
+			// TODO: Stop sending data if signalType is metrics/traces
+			// TODO: checkAllDataDropped
+			checkMetricInstrumentation(t)
+		})
+	}
+}
+
+func checkMetricInstrumentation(t *testing.T) {
+	t.Helper()
+
+	// Pushing metrics to the metric gateway triggers an alert.
+	// It makes the self-monitor call the webhook, which in turn increases the counter.
+	assert.EmitsManagerMetrics(t,
+		HaveName(Equal("controller_runtime_webhook_requests_total")),
+		SatisfyAll(
+			HaveLabels(HaveKeyWithValue("webhook", "/api/v2/alerts")),
+			HaveMetricValue(BeNumerically(">", 0)),
+		))
+
+	assert.EmitsManagerMetrics(t,
+		HaveName(Equal("telemetry_self_monitor_prober_requests_total")),
+		HaveMetricValue(BeNumerically(">", 0)),
+	)
+
+}

--- a/test/selfmonitor/outage_test.go
+++ b/test/selfmonitor/outage_test.go
@@ -1,0 +1,4 @@
+package selfmonitor
+
+// TODO: Implement a table-driven test for the outage self-monitoring scenario, covering all telemetry data types.
+// (this scenario requires istio as well)

--- a/test/testkit/suite/suite.go
+++ b/test/testkit/suite/suite.go
@@ -129,6 +129,9 @@ const (
 	LabelSkip         = "skip"
 
 	// Self-monitoring test labels
+	LabelSelfMonitoringHealthy                   = "self-mon-healthy"
+	LabelSelfMonitoringBackpressure              = "self-mon-backpressure"
+	LabelSelfMonitoringOutage                    = "self-mon-outage"
 	LabelSelfMonitoringLogsFluentBitBackpressure = "self-mon-fluentbit-backpressure"
 	LabelSelfMonitoringLogsFluentBitOutage       = "self-mon-fluentbit-outage"
 	LabelSelfMonitoringLogsAgentBackpressure     = "self-mon-log-agent-backpressure"

--- a/test/testkit/suite/suite.go
+++ b/test/testkit/suite/suite.go
@@ -132,6 +132,8 @@ const (
 	LabelSelfMonitoringHealthy                   = "self-mon-healthy"
 	LabelSelfMonitoringBackpressure              = "self-mon-backpressure"
 	LabelSelfMonitoringOutage                    = "self-mon-outage"
+
+	// TODO(TeodorSAP): Delete after the migration to the new self-monitoring test suite
 	LabelSelfMonitoringLogsFluentBitBackpressure = "self-mon-fluentbit-backpressure"
 	LabelSelfMonitoringLogsFluentBitOutage       = "self-mon-fluentbit-outage"
 	LabelSelfMonitoringLogsAgentBackpressure     = "self-mon-log-agent-backpressure"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Migrate selfmonitor e2e tests to the new tests format
- Refactor tests as scenrio-based table-driven tests: `healthy`, `outage`, `backpressure`
- Isolate tests in individual folder

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/2146

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
