### PR TITLE
feat: bump OTel image version to 0.131.0

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.5"
-ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main"
+ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.131.0-main"
 ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348"
-ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.130.0"
+ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
         - name: FLUENT_BIT_EXPORTER_IMAGE
           value: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
         - name: OTEL_COLLECTOR_IMAGE
-          value: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main
+          value: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.131.0-main
         - name: SELF_MONITOR_IMAGE
           value: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348
       volumes:

--- a/internal/otelcollector/config/config.go
+++ b/internal/otelcollector/config/config.go
@@ -63,8 +63,9 @@ type MetricExporter struct {
 }
 
 type PrometheusMetricExporter struct {
-	Host string `yaml:"host"`
-	Port int32  `yaml:"port"`
+	Host         string `yaml:"host"`
+	Port         int32  `yaml:"port"`
+	WithoutUnits bool   `yaml:"without_units,omitempty"`
 }
 
 type Logs struct {
@@ -108,6 +109,7 @@ func DefaultService(pipelines Pipelines) Service {
 							Prometheus: PrometheusMetricExporter{
 								Host: fmt.Sprintf("${%s}", EnvVarCurrentPodIP),
 								Port: ports.Metrics,
+								WithoutUnits: true,
 							},
 						},
 					},

--- a/internal/otelcollector/config/config.go
+++ b/internal/otelcollector/config/config.go
@@ -107,8 +107,8 @@ func DefaultService(pipelines Pipelines) Service {
 					Pull: PullMetricReader{
 						Exporter: MetricExporter{
 							Prometheus: PrometheusMetricExporter{
-								Host: fmt.Sprintf("${%s}", EnvVarCurrentPodIP),
-								Port: ports.Metrics,
+								Host:         fmt.Sprintf("${%s}", EnvVarCurrentPodIP),
+								Port:         ports.Metrics,
 								WithoutUnits: true,
 							},
 						},

--- a/internal/otelcollector/config/log/agent/config_builder_test.go
+++ b/internal/otelcollector/config/log/agent/config_builder_test.go
@@ -131,6 +131,7 @@ func TestBuildAgentConfig(t *testing.T) {
 						Prometheus: config.PrometheusMetricExporter{
 							Host: "${MY_POD_IP}",
 							Port: ports.Metrics,
+							WithoutUnits: true,
 						},
 					},
 				},

--- a/internal/otelcollector/config/log/agent/config_builder_test.go
+++ b/internal/otelcollector/config/log/agent/config_builder_test.go
@@ -129,8 +129,8 @@ func TestBuildAgentConfig(t *testing.T) {
 				Pull: config.PullMetricReader{
 					Exporter: config.MetricExporter{
 						Prometheus: config.PrometheusMetricExporter{
-							Host: "${MY_POD_IP}",
-							Port: ports.Metrics,
+							Host:         "${MY_POD_IP}",
+							Port:         ports.Metrics,
 							WithoutUnits: true,
 						},
 					},

--- a/internal/otelcollector/config/log/agent/testdata/config.yaml
+++ b/internal/otelcollector/config/log/agent/testdata/config.yaml
@@ -20,6 +20,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/internal/otelcollector/config/log/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/log/gateway/config_builder_test.go
@@ -162,6 +162,7 @@ func TestBuildConfig(t *testing.T) {
 						Prometheus: config.PrometheusMetricExporter{
 							Host: "${MY_POD_IP}",
 							Port: ports.Metrics,
+							WithoutUnits: true,
 						},
 					},
 				},

--- a/internal/otelcollector/config/log/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/log/gateway/config_builder_test.go
@@ -160,8 +160,8 @@ func TestBuildConfig(t *testing.T) {
 				Pull: config.PullMetricReader{
 					Exporter: config.MetricExporter{
 						Prometheus: config.PrometheusMetricExporter{
-							Host: "${MY_POD_IP}",
-							Port: ports.Metrics,
+							Host:         "${MY_POD_IP}",
+							Port:         ports.Metrics,
 							WithoutUnits: true,
 						},
 					},

--- a/internal/otelcollector/config/log/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/log/gateway/testdata/config.yaml
@@ -28,6 +28,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/internal/otelcollector/config/metric/agent/config_builder_test.go
+++ b/internal/otelcollector/config/metric/agent/config_builder_test.go
@@ -55,6 +55,7 @@ func TestBuildAgentConfig(t *testing.T) {
 						Prometheus: config.PrometheusMetricExporter{
 							Host: "${MY_POD_IP}",
 							Port: ports.Metrics,
+							WithoutUnits: true,
 						},
 					},
 				},

--- a/internal/otelcollector/config/metric/agent/config_builder_test.go
+++ b/internal/otelcollector/config/metric/agent/config_builder_test.go
@@ -53,8 +53,8 @@ func TestBuildAgentConfig(t *testing.T) {
 				Pull: config.PullMetricReader{
 					Exporter: config.MetricExporter{
 						Prometheus: config.PrometheusMetricExporter{
-							Host: "${MY_POD_IP}",
-							Port: ports.Metrics,
+							Host:         "${MY_POD_IP}",
+							Port:         ports.Metrics,
 							WithoutUnits: true,
 						},
 					},

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_enabled.yaml
@@ -52,6 +52,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
+++ b/internal/otelcollector/config/metric/agent/testdata/config_istio_not_enabled.yaml
@@ -41,6 +41,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/internal/otelcollector/config/metric/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/metric/gateway/config_builder_test.go
@@ -194,8 +194,8 @@ func TestMakeConfig(t *testing.T) {
 				Pull: config.PullMetricReader{
 					Exporter: config.MetricExporter{
 						Prometheus: config.PrometheusMetricExporter{
-							Host: "${MY_POD_IP}",
-							Port: ports.Metrics,
+							Host:         "${MY_POD_IP}",
+							Port:         ports.Metrics,
 							WithoutUnits: true,
 						},
 					},

--- a/internal/otelcollector/config/metric/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/metric/gateway/config_builder_test.go
@@ -196,6 +196,7 @@ func TestMakeConfig(t *testing.T) {
 						Prometheus: config.PrometheusMetricExporter{
 							Host: "${MY_POD_IP}",
 							Port: ports.Metrics,
+							WithoutUnits: true,
 						},
 					},
 				},

--- a/internal/otelcollector/config/metric/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/metric/gateway/testdata/config.yaml
@@ -49,6 +49,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/internal/otelcollector/config/metric/gateway/testdata/config_otlp_disabled.yaml
+++ b/internal/otelcollector/config/metric/gateway/testdata/config_otlp_disabled.yaml
@@ -50,6 +50,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/internal/otelcollector/config/trace/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/trace/gateway/config_builder_test.go
@@ -155,8 +155,8 @@ func TestBuildConfig(t *testing.T) {
 				Pull: config.PullMetricReader{
 					Exporter: config.MetricExporter{
 						Prometheus: config.PrometheusMetricExporter{
-							Host: "${MY_POD_IP}",
-							Port: ports.Metrics,
+							Host:         "${MY_POD_IP}",
+							Port:         ports.Metrics,
 							WithoutUnits: true,
 						},
 					},

--- a/internal/otelcollector/config/trace/gateway/config_builder_test.go
+++ b/internal/otelcollector/config/trace/gateway/config_builder_test.go
@@ -157,6 +157,7 @@ func TestBuildConfig(t *testing.T) {
 						Prometheus: config.PrometheusMetricExporter{
 							Host: "${MY_POD_IP}",
 							Port: ports.Metrics,
+							WithoutUnits: true,
 						},
 					},
 				},

--- a/internal/otelcollector/config/trace/gateway/testdata/config.yaml
+++ b/internal/otelcollector/config/trace/gateway/testdata/config.yaml
@@ -26,6 +26,7 @@ service:
                         prometheus:
                             host: ${MY_POD_IP}
                             port: 8888
+                            without_units: true
         logs:
             level: info
             encoding: json

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -5,7 +5,7 @@ bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main-experimental
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.5
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.131.0-main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348
 mend:
   language: golang-mod

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -4,6 +4,6 @@
 package testkit
 
 const (
-	DefaultTelemetryGenImage  = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.130.0"
-	DefaultOTelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main"
+	DefaultTelemetryGenImage  = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0"
+	DefaultOTelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.131.0-main"
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump OTel image version to 0.131.0
- Bump `telemetrygen` version to 0.131.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
