### PR TITLE
chore: remove experimental image from scanner config

### DIFF
--- a/dependencies/populateimages/main.go
+++ b/dependencies/populateimages/main.go
@@ -94,7 +94,6 @@ func generateSecScanConfig(data map[string]string) error {
 
 	imgs := []string{
 		data["ENV_MANAGER_IMAGE"],
-		data["ENV_MANAGER_IMAGE"] + "-experimental",
 		data["ENV_FLUENTBIT_EXPORTER_IMAGE"],
 		data["ENV_FLUENTBIT_IMAGE"],
 		data["ENV_OTEL_COLLECTOR_IMAGE"],

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,6 @@ module-name: telemetry
 kind: kyma
 bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main-experimental
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.5
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- the scanner config is not required for experimental releases. Listing the image there will lead to duplicated triaging of the same image

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
