### PR TITLE
chore: bump images for 1.45.0 release

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ### Default Environment Variables
 ## General
-ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main # Image URL to use all building/pushing image targets
+ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.45.0 # Image URL to use all building/pushing image targets
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.31
@@ -15,6 +15,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.5"
-ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main"
+ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-1.45.0"
 ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348"
 ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.130.0"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager
-  newTag: main
+  newTag: 1.45.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
         - name: FLUENT_BIT_EXPORTER_IMAGE
           value: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
         - name: OTEL_COLLECTOR_IMAGE
-          value: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main
+          value: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-1.45.0
         - name: SELF_MONITOR_IMAGE
           value: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348
       volumes:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,10 +1,10 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.45.0
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.5
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-1.45.0
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348
 mend:
   language: golang-mod

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -5,5 +5,5 @@ package testkit
 
 const (
 	DefaultTelemetryGenImage  = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.130.0"
-	DefaultOTelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main"
+	DefaultOTelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-1.45.0"
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump images to 1.45.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
