### PR TITLE
docs: fixed loki integration guide

### DIFF
--- a/docs/user/integration/loki/README.md
+++ b/docs/user/integration/loki/README.md
@@ -65,7 +65,8 @@ helm upgrade --install --create-namespace -n ${K8S_NAMESPACE} ${HELM_LOKI_RELEAS
   -f https://raw.githubusercontent.com/grafana/loki/main/production/helm/loki/single-binary-values.yaml \
   --set-string 'loki.podLabels.sidecar\.istio\.io/inject=true' \
   --set 'singleBinary.resources.requests.cpu=1' \
-  --set 'loki.auth_enabled=false'
+  --set 'loki.auth_enabled=false' \
+  --set 'log.storage.type: filesystem'
 ```
 
 The previous command uses an example [values.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/single-binary-values.yaml) from the Loki repository for setting up Loki in the 'SingleBinary' mode. Additionally, it applies:
@@ -73,6 +74,7 @@ The previous command uses an example [values.yaml](https://github.com/grafana/lo
 - Istio sidecar injection for the Loki instance
 - a reduced CPU request setting for smaller cluster setups
 - disabled multi-tenancy for easier setup
+- enabled filesystem storage for a demo setup (not recommended)
 
 Alternatively, you can create your own `values.yaml` file and adjust the command.
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The loki helm chart uses a s3 storage by default which requires additional settings. For the tutorial, a filesystem storage gets configured for the ease of setup

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
