### PR TITLE
feat: bump OTel version to 0.132.0

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.7"
-ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main"
+ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.132.0-main"
 ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348"
-ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.130.0"
+ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.132.0"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
         - name: FLUENT_BIT_EXPORTER_IMAGE
           value: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
         - name: OTEL_COLLECTOR_IMAGE
-          value: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main
+          value: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.132.0-main
         - name: SELF_MONITOR_IMAGE
           value: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348
       volumes:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -4,7 +4,7 @@ bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.7
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.132.0-main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348
 mend:
   language: golang-mod

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -4,6 +4,6 @@
 package testkit
 
 const (
-	DefaultTelemetryGenImage  = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.130.0"
-	DefaultOTelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.130.1-main"
+	DefaultTelemetryGenImage  = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.132.0"
+	DefaultOTelCollectorImage = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.132.0-main"
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump OTel image version to 0.132.0
- Bump `telemetrygen` version to 0.132.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
