### PR TITLE
chore: fix flaky fluentbit selfmonitoring e2e tests

### DIFF
--- a/test/selfmonitor/backpressure_test.go
+++ b/test/selfmonitor/backpressure_test.go
@@ -100,7 +100,7 @@ func TestBackpressure(t *testing.T) {
 				return &p
 			},
 			generator: func(ns string) *appsv1.Deployment {
-				return stdoutloggen.NewDeployment(ns, stdoutloggen.WithRate(4000)).K8sObject()
+				return stdoutloggen.NewDeployment(ns, stdoutloggen.WithRate(5000)).K8sObject()
 			},
 			assertions: func(t *testing.T) {
 				assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)

--- a/test/selfmonitor/outage_test.go
+++ b/test/selfmonitor/outage_test.go
@@ -102,7 +102,7 @@ func TestOutage(t *testing.T) {
 				return &p
 			},
 			generator: func(ns string) *appsv1.Deployment {
-				return stdoutloggen.NewDeployment(ns, stdoutloggen.WithRate(4000)).K8sObject()
+				return stdoutloggen.NewDeployment(ns, stdoutloggen.WithRate(5000)).K8sObject()
 			},
 			assert: func(t *testing.T) {
 				assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- fix flaky fluentbit selfmonitoring e2e tests

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
