### PR TITLE
fix: conversion of LogPipelines

### DIFF
--- a/apis/telemetry/v1alpha1/logpipeline_conversion.go
+++ b/apis/telemetry/v1alpha1/logpipeline_conversion.go
@@ -63,6 +63,12 @@ func (lp *LogPipeline) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.Output.Custom = srcCustomOutput
 	}
 
+	if src.Spec.Transforms != nil {
+		for _, t := range src.Spec.Transforms {
+			dst.Spec.Transforms = append(dst.Spec.Transforms, v1Alpha1TransformSpecToV1Beta1(t))
+		}
+	}
+
 	dst.Status = telemetryv1beta1.LogPipelineStatus(src.Status)
 
 	return nil
@@ -214,6 +220,16 @@ func v1Alpha1TLSToV1Beta1(src LogPipelineOutputTLS) telemetryv1beta1.OutputTLS {
 	return dst
 }
 
+func v1Alpha1TransformSpecToV1Beta1(src TransformSpec) telemetryv1beta1.TransformSpec {
+	var dst telemetryv1beta1.TransformSpec
+
+	dst.Conditions = append(dst.Conditions, src.Conditions...)
+
+	dst.Statements = append(dst.Statements, src.Statements...)
+
+	return dst
+}
+
 // ConvertFrom converts from the Hub version (v1beta1) to this version.
 func (lp *LogPipeline) ConvertFrom(srcRaw conversion.Hub) error {
 	dst := lp
@@ -263,6 +279,12 @@ func (lp *LogPipeline) ConvertFrom(srcRaw conversion.Hub) error {
 
 	if srcCustomOutput := src.Spec.Output.Custom; srcCustomOutput != "" {
 		dst.Spec.Output.Custom = srcCustomOutput
+	}
+
+	if src.Spec.Transforms != nil {
+		for _, t := range src.Spec.Transforms {
+			dst.Spec.Transforms = append(dst.Spec.Transforms, v1Beta1TransformSpecToV1Alpha1(t))
+		}
 	}
 
 	dst.Status = LogPipelineStatus(src.Status)
@@ -414,4 +436,14 @@ func v1Beta1ValueTypeToV1Alpha1(src telemetryv1beta1.ValueType) ValueType {
 	return ValueType{
 		Value: src.Value,
 	}
+}
+
+func v1Beta1TransformSpecToV1Alpha1(src telemetryv1beta1.TransformSpec) TransformSpec {
+	var dst TransformSpec
+
+	dst.Conditions = append(dst.Conditions, src.Conditions...)
+
+	dst.Statements = append(dst.Statements, src.Statements...)
+
+	return dst
 }

--- a/apis/telemetry/v1alpha1/logpipeline_conversion_test.go
+++ b/apis/telemetry/v1alpha1/logpipeline_conversion_test.go
@@ -47,6 +47,12 @@ func TestConvertTo(t *testing.T) {
 			Filters: []LogPipelineFilter{
 				{Custom: "name stdout"},
 			},
+			Transforms: []TransformSpec{
+				{
+					Conditions: []string{"resource.attributes[\"k8s.pod.name\"] == nil"},
+					Statements: []string{"set(resource.attributes[\"k8s.pod.name\"]", "nginx"},
+				},
+			},
 			Output: LogPipelineOutput{
 				Custom: "custom-output",
 				HTTP: &LogPipelineHTTPOutput{
@@ -192,6 +198,12 @@ func TestConvertFrom(t *testing.T) {
 			},
 			Filters: []telemetryv1beta1.LogPipelineFilter{
 				{Custom: "name stdout"},
+			},
+			Transforms: []telemetryv1beta1.TransformSpec{
+				{
+					Conditions: []string{"resource.attributes[\"k8s.pod.name\"] == nil"},
+					Statements: []string{"set(resource.attributes[\"k8s.pod.name\"]", "nginx"},
+				},
 			},
 			Output: telemetryv1beta1.LogPipelineOutput{
 				Custom: "custom-output",
@@ -362,4 +374,13 @@ func requireLogPipelinesEquivalent(t *testing.T, x *LogPipeline, y *telemetryv1b
 
 	require.Equal(t, x.Status.UnsupportedMode, y.Status.UnsupportedMode, "status unsupported mode mismatch")
 	require.ElementsMatch(t, x.Status.Conditions, y.Status.Conditions, "status conditions mismatch")
+
+	xTransforms := x.Spec.Transforms
+	yTransforms := y.Spec.Transforms
+	require.Len(t, xTransforms, len(yTransforms), "expected same number of transforms")
+
+	for i := range xTransforms {
+		require.Equal(t, xTransforms[i].Conditions, yTransforms[i].Conditions, "transform conditions mismatch at index %d", i)
+		require.Equal(t, xTransforms[i].Statements, yTransforms[i].Statements, "transform statements mismatch at index %d", i)
+	}
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add TransformSpec conversion to the conversion webhook, which was forgotten when implementing https://github.com/kyma-project/telemetry-manager/issues/2349

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
