### PR TITLE
chore: bump directory-size-exporter to latest version

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ ENV_ISTIO_VERSION=1.20.2
 ENV_GORELEASER_VERSION=v1.23.0
 
 ## Default Docker Images
-ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4"
+ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250828-a2103691"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.8"
 ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.133.0-main"
 ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348"

--- a/helm/telemetry-module/values.yaml
+++ b/helm/telemetry-module/values.yaml
@@ -11,7 +11,7 @@ manager:
     env:
       alpineImage: europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.22.1
       appLogLevel: info
-      fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
+      fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250828-a2103691
       fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.8
       gomemlimit: 300MiB
       otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.133.0-main

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,7 @@ module-name: telemetry
 kind: kyma
 bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250724-d99b68f4
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250828-a2103691
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.0.8
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.133.0-main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.5.0-8d9d348


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump directory-size-exporter to latest version

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
