### PR TITLE
chore: update k3d image in cache

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -5,7 +5,7 @@ images:
     tag: "v1.32.8-k3s1" # used by k3d - current k8s version
   - source: "rancher/k3s@sha256:f9f125ef9c662a231a98c507afdd3ba9a94d5f02631f946d1d34000ef67f7263"
     tag: "v1.33.4-k3s1" # used by k3d - future k3s version
-  - source: "library/registry@sha256:31a85202039b95a75781d537b35e5756ded4b43949f8e1f9f3db8e69d3b73497"
+  - source: "library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
     tag: "2" # used by k3d
   - source: "library/alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1"
     tag: "3.22.1" # used for init containers in log agent and fluentbit

--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,9 +1,11 @@
 images:
   - source: "fluent/fluent-bit@sha256:131971bd67f4b3a115933c41188f4a92a1c098522a9d9c70a3171a4c35c3496b"
     tag: "4.0.8" # used by the kyma telemetry module
-  - source: "rancher/k3s@sha256:e8880a62f5ce10cd53d4a2dc401f50ea98f54bec45a39aa39215881e393a9d11"
-    tag: "v1.32.8-k3s1" # used by k3d
-  - source: "library/registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
+  - source: "rancher/k3s@sha256:f9f125ef9c662a231a98c507afdd3ba9a94d5f02631f946d1d34000ef67f7263"
+    tag: "v1.32.8-k3s1" # used by k3d - current k8s version
+  - source: "rancher/k3s@sha256:f9f125ef9c662a231a98c507afdd3ba9a94d5f02631f946d1d34000ef67f7263"
+    tag: "v1.33.4-k3s1" # used by k3d - future k3s version
+  - source: "library/registry@sha256:31a85202039b95a75781d537b35e5756ded4b43949f8e1f9f3db8e69d3b73497"
     tag: "2" # used by k3d
   - source: "library/alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1"
     tag: "3.22.1" # used for init containers in log agent and fluentbit


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- fixed sha used in https://github.com/kyma-project/telemetry-manager/pull/2460/files
- added next version for compatibility tests

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
