### PR TITLE
fix: upgrade tests after 1.47 release

### DIFF
--- a/.github/workflows/pr-upgrade.yml
+++ b/.github/workflows/pr-upgrade.yml
@@ -60,17 +60,16 @@ jobs:
           MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} make deploy-experimental
 
       - name: Deploy test K8S prerequisites
-        uses: "./.github/template/deploy-test-prerequisites" # TODO(TeodorSAP): Replace with "deploy-test-k8s-prerequisites" after 1.47.0 release
+        uses: "./.github/template/deploy-test-k8s-prerequisites"
 
       - name: Wait for manager readiness
         shell: bash
         run: kubectl -n kyma-system rollout status deployment telemetry-manager --timeout=90s
 
-      # TODO(TeodorSAP): Rename TestLogsUpgrade to TestLogsFluentBitUpgrade and TestLogsOTelUpgrade to TestLogsUpgrade after 1.47 release
       - name: Run tests on latest tag
         shell: bash
         run: |
-          go test -v -timeout=10m -run="^(TestLogsUpgrade|TestLogsOTelUpgrade|TestMetricsUpgrade|TestTracesUpgrade)/before_upgrade$" ./test/e2e/upgrade/...
+          go test -v -timeout=10m -run="^(TestLogsFluentBitUpgrade|TestLogsUpgrade|TestMetricsUpgrade|TestTracesUpgrade)/before_upgrade$" ./test/e2e/upgrade/...
 
       - name: Switch back to current revision
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/test/e2e/upgrade/logs_fluentbit_upgrade_test.go
+++ b/test/e2e/upgrade/logs_fluentbit_upgrade_test.go
@@ -52,19 +52,9 @@ func TestLogsFluentBitUpgrade(t *testing.T) {
 	})
 
 	t.Run("after upgrade", func(t *testing.T) {
-		// TODO(TeodorSAP): Delete after 1.47 release ---
 		assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-		assert.FluentBitLogPipelineHealthy(t, "logs-upgrade")
-
-		backend = kitbackend.New("logs-upgrade-backend", kitbackend.SignalTypeLogsFluentBit)
+		assert.FluentBitLogPipelineHealthy(t, pipelineName)
 		assert.BackendReachable(t, backend)
-		assert.FluentBitLogsFromNamespaceDelivered(t, backend, "logs-upgrade-gen")
-		// ---
-
-		// TODO(TeodorSAP): Uncomment after 1.47 release
-		// assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
-		// assert.FluentBitLogPipelineHealthy(t, pipelineName)
-		// assert.BackendReachable(t, backend)
-		// assert.FluentBitLogsFromNamespaceDelivered(t, backend, genNs)
+		assert.FluentBitLogsFromNamespaceDelivered(t, backend, genNs)
 	})
 }

--- a/test/e2e/upgrade/logs_upgrade_test.go
+++ b/test/e2e/upgrade/logs_upgrade_test.go
@@ -52,19 +52,9 @@ func TestLogsUpgrade(t *testing.T) {
 	})
 
 	t.Run("after upgrade", func(t *testing.T) {
-		// TODO(TeodorSAP): Delete after 1.47 release ---
 		assert.DeploymentReady(t, kitkyma.LogGatewayName)
-		assert.OTelLogPipelineHealthy(t, "logs-otel-upgrade-otel")
-
-		backend = kitbackend.New("logs-otel-upgrade-otel-backend", kitbackend.SignalTypeLogsOTel)
+		assert.OTelLogPipelineHealthy(t, pipelineName)
 		assert.BackendReachable(t, backend)
-		assert.OTelLogsFromNamespaceDelivered(t, backend, "logs-otel-upgrade-otel-gen")
-		// ---
-
-		// TODO(TeodorSAP): Uncomment after 1.47 release
-		// assert.DeploymentReady(t, kitkyma.LogGatewayName)
-		// assert.OTelLogPipelineHealthy(t, pipelineName)
-		// assert.BackendReachable(t, backend)
-		// assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)
+		assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)
 	})
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix upgrade tests after 1.47 release

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
