### PR TITLE
docs: fix path in loki integration guide

### DIFF
--- a/docs/user/integration/loki/README.md
+++ b/docs/user/integration/loki/README.md
@@ -109,7 +109,7 @@ Apply the LogPipeline:
             protocol: http
             endpoint:
                value: http://${HELM_LOKI_RELEASE}.${K8S_NAMESPACE}.svc.cluster.local:3100
-            path: otlp
+            path: otlp/v1/logs
    EOF
    ```
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- the integration guide was migrated wrongly to the otlp approach, the path need to list the /v1/logs suffix as well

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
