### PR TITLE
docs: fixed bad formatted md not valid in Vitepress (markdown-it)

### DIFF
--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -36,7 +36,7 @@ type OTLPOutput struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Enum=grpc;http
 	Protocol string `json:"protocol,omitempty"`
-	// Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint.
+	// Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
 	// Path defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths `/v1/metrics` and `/v1/traces`

--- a/apis/telemetry/v1beta1/shared_types.go
+++ b/apis/telemetry/v1beta1/shared_types.go
@@ -37,7 +37,7 @@ type OTLPOutput struct {
 	// Protocol defines the OTLP protocol (`http` or `grpc`). Default is `grpc``.
 	// +kubebuilder:validation:Enum=grpc;http
 	Protocol OTLPProtocol `json:"protocol,omitempty"`
-	// Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint.
+	// Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint.
 	// +kubebuilder:validation:Required
 	Endpoint ValueType `json:"endpoint"`
 	// Path defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths `/v1/metrics` and `/v1/traces`

--- a/docs/user/02-logs.md
+++ b/docs/user/02-logs.md
@@ -480,7 +480,7 @@ The Telemetry module ensures that the log agent instances are operational and he
 
 To detect and fix such situations, check the [pipeline status](./resources/02-logpipeline.md#logpipeline-status) and check out [Troubleshooting](#troubleshooting). If you have set up [pipeline health monitoring](./04-metrics.md#5-monitor-pipeline-health), check the alerts and reports in an integrated backend like [SAP Cloud Logging](./integration/sap-cloud-logging/README.md#use-sap-cloud-logging-alerts).
 
-> [! WARNING]
+> [!WARNING]
 > It's not recommended to access the metrics endpoint of the used FluentBit instances directly, because the exposed metrics are no official API of the Kyma Telemetry module. Breaking changes can happen if the underlying FluentBit version introduces such.
 > Instead, use the [pipeline status](./resources/02-logpipeline.md#logpipeline-status).
 

--- a/docs/user/03-traces.md
+++ b/docs/user/03-traces.md
@@ -409,7 +409,7 @@ To enable the propagation of the [W3C Trace Context](https://www.w3.org/TR/trace
       randomSamplingPercentage: 0
   ```
 
- <!-- tabs:end -->
+<!-- tabs:end -->
 
 ### Eventing
 

--- a/docs/user/04-metrics.md
+++ b/docs/user/04-metrics.md
@@ -379,7 +379,7 @@ Metric Attributes for Monitoring:
 
 To set up alerting, use an alert rule. In the following example, the alert is triggered if metrics are not delivered to the backend:
 
-```promql
+```text
  min by (k8s_resource_name) ((kyma_resource_status_conditions{type="TelemetryFlowHealthy",k8s_resource_kind="metricpipelines"})) == 0
 ```
 

--- a/docs/user/logs.md
+++ b/docs/user/logs.md
@@ -614,4 +614,4 @@ To detect and fix such situations, check the [pipeline status](./resources/02-lo
 
 **Cause**: Gateway cannot receive logs at the given rate.
 
-**Solution**: Manually scale out the gateway by increasing the number of replicas for the log gateway. See [Module Configuration and Status](https://kyma-project.io/#/telemetry-manager/user/01-manager?id=module-configuration).
+**Solution**: Manually scale out the gateway by increasing the number of replicas for the log gateway. See [Module Configuration and Status](https://kyma-project.io/#/telemetry-manager/user/01-manager?id=module-configuration).**Solution**: Manually scale out the gateway by increasing the number of replicas for the log gateway. See [Module Configuration and Status](https://kyma-project.io/#/telemetry-manager/user/01-manager?id=module-configuration).

--- a/docs/user/logs.md
+++ b/docs/user/logs.md
@@ -614,4 +614,4 @@ To detect and fix such situations, check the [pipeline status](./resources/02-lo
 
 **Cause**: Gateway cannot receive logs at the given rate.
 
-**Solution**: Manually scale out the gateway by increasing the number of replicas for the log gateway. See [Module Configuration and Status](https://kyma-project.io/#/telemetry-manager/user/01-manager?id=module-configuration).**Solution**: Manually scale out the gateway by increasing the number of replicas for the log gateway. See [Module Configuration and Status](https://kyma-project.io/#/telemetry-manager/user/01-manager?id=module-configuration).
+**Solution**: Manually scale out the gateway by increasing the number of replicas for the log gateway. See [Module Configuration and Status](https://kyma-project.io/#/telemetry-manager/user/01-manager?id=module-configuration).

--- a/docs/user/resources/02-logpipeline.md
+++ b/docs/user/resources/02-logpipeline.md
@@ -172,7 +172,7 @@ For details, see the [LogPipeline specification file](https://github.com/kyma-pr
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key** (required) | string | Key defines the name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name** (required) | string | Name of the Secret containing the referenced value. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace** (required) | string | Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;endpoint** (required) | object | Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint. |
+| **output.&#x200b;otlp.&#x200b;endpoint** (required) | object | Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;value**  | string | Value as plain text. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;valueFrom**  | object | ValueFrom is the value as a reference to a resource. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;valueFrom.&#x200b;secretKeyRef**  | object | SecretKeyRef refers to the value of a specific key in a Secret. You must provide `name` and `namespace` of the Secret, as well as the name of the `key`. |

--- a/docs/user/resources/04-tracepipeline.md
+++ b/docs/user/resources/04-tracepipeline.md
@@ -72,7 +72,7 @@ For details, see the [TracePipeline specification file](https://github.com/kyma-
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key** (required) | string | Key defines the name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name** (required) | string | Name of the Secret containing the referenced value. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace** (required) | string | Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;endpoint** (required) | object | Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint. |
+| **output.&#x200b;otlp.&#x200b;endpoint** (required) | object | Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;value**  | string | Value as plain text. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;valueFrom**  | object | ValueFrom is the value as a reference to a resource. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;valueFrom.&#x200b;secretKeyRef**  | object | SecretKeyRef refers to the value of a specific key in a Secret. You must provide `name` and `namespace` of the Secret, as well as the name of the `key`. |

--- a/docs/user/resources/05-metricpipeline.md
+++ b/docs/user/resources/05-metricpipeline.md
@@ -130,7 +130,7 @@ For details, see the [MetricPipeline specification file](https://github.com/kyma
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;key** (required) | string | Key defines the name of the attribute of the Secret holding the referenced value. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;name** (required) | string | Name of the Secret containing the referenced value. |
 | **output.&#x200b;otlp.&#x200b;authentication.&#x200b;basic.&#x200b;user.&#x200b;valueFrom.&#x200b;secretKeyRef.&#x200b;namespace** (required) | string | Namespace containing the Secret with the referenced value. |
-| **output.&#x200b;otlp.&#x200b;endpoint** (required) | object | Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint. |
+| **output.&#x200b;otlp.&#x200b;endpoint** (required) | object | Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;value**  | string | Value as plain text. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;valueFrom**  | object | ValueFrom is the value as a reference to a resource. |
 | **output.&#x200b;otlp.&#x200b;endpoint.&#x200b;valueFrom.&#x200b;secretKeyRef**  | object | SecretKeyRef refers to the value of a specific key in a Secret. You must provide `name` and `namespace` of the Secret, as well as the name of the `key`. |

--- a/helm/telemetry-module/charts/experimental/templates/telemetry.kyma-project.io_logpipelines.yaml
+++ b/helm/telemetry-module/charts/experimental/templates/telemetry.kyma-project.io_logpipelines.yaml
@@ -568,7 +568,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
+                        description: Endpoint defines the host and port (`<host>:<port>`)
                           of an OTLP endpoint.
                         properties:
                           value:
@@ -1509,7 +1509,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
+                        description: Endpoint defines the host and port (`<host>:<port>`)
                           of an OTLP endpoint.
                         properties:
                           value:

--- a/helm/telemetry-module/charts/experimental/templates/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/helm/telemetry-module/charts/experimental/templates/telemetry.kyma-project.io_metricpipelines.yaml
@@ -407,7 +407,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
+                        description: Endpoint defines the host and port (`<host>:<port>`)
                           of an OTLP endpoint.
                         properties:
                           value:
@@ -1114,7 +1114,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
+                        description: Endpoint defines the host and port (`<host>:<port>`)
                           of an OTLP endpoint.
                         properties:
                           value:

--- a/helm/telemetry-module/charts/experimental/templates/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/helm/telemetry-module/charts/experimental/templates/telemetry.kyma-project.io_tracepipelines.yaml
@@ -157,7 +157,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
+                        description: Endpoint defines the host and port (`<host>:<port>`)
                           of an OTLP endpoint.
                         properties:
                           value:
@@ -616,7 +616,7 @@ spec:
                             type: object
                         type: object
                       endpoint:
-                        description: Endpoint defines the host and port (<host>:<port>)
+                        description: Endpoint defines the host and port (`<host>:<port>`)
                           of an OTLP endpoint.
                         properties:
                           value:

--- a/helm/telemetry-module/charts/regular/templates/telemetry.kyma-project.io_logpipelines.yaml
+++ b/helm/telemetry-module/charts/regular/templates/telemetry.kyma-project.io_logpipelines.yaml
@@ -439,7 +439,7 @@ spec:
                               type: object
                           type: object
                         endpoint:
-                          description: Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint.
+                          description: Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint.
                           properties:
                             value:
                               description: Value as plain text.

--- a/helm/telemetry-module/charts/regular/templates/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/helm/telemetry-module/charts/regular/templates/telemetry.kyma-project.io_metricpipelines.yaml
@@ -319,7 +319,7 @@ spec:
                               type: object
                           type: object
                         endpoint:
-                          description: Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint.
+                          description: Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint.
                           properties:
                             value:
                               description: Value as plain text.

--- a/helm/telemetry-module/charts/regular/templates/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/helm/telemetry-module/charts/regular/templates/telemetry.kyma-project.io_tracepipelines.yaml
@@ -135,7 +135,7 @@ spec:
                               type: object
                           type: object
                         endpoint:
-                          description: Endpoint defines the host and port (<host>:<port>) of an OTLP endpoint.
+                          description: Endpoint defines the host and port (`<host>:<port>`) of an OTLP endpoint.
                           properties:
                             value:
                               description: Value as plain text.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- fixed bad formatted md not valid in Vitepress (markdown-it)

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/kyma/pull/18817

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
