### PR TITLE
fix: remove initContainer for Log Agent and revert to tmp folder

### DIFF
--- a/controllers/telemetry/logpipeline_controller.go
+++ b/controllers/telemetry/logpipeline_controller.go
@@ -262,7 +262,7 @@ func configureOtelReconciler(client client.Client, config LogPipelineControllerC
 		gatewayFlowHealthProber,
 		agentFlowHealthProber,
 		agentConfigBuilder,
-		otelcollector.NewLogAgentApplierDeleter(config.OTelCollectorImage, config.ChownInitContainerImage, config.TelemetryNamespace, config.LogAgentPriorityClassName),
+		otelcollector.NewLogAgentApplierDeleter(config.OTelCollectorImage, config.TelemetryNamespace, config.LogAgentPriorityClassName),
 		&workloadstatus.DaemonSetProber{Client: client},
 		otelcollector.NewLogGatewayApplierDeleter(config.OTelCollectorImage, config.TelemetryNamespace, config.LogGatewayPriorityClassName),
 		&loggateway.Builder{Reader: client},

--- a/internal/otelcollector/config/common/types.go
+++ b/internal/otelcollector/config/common/types.go
@@ -26,7 +26,8 @@ type K8sLeaderElector struct {
 }
 
 type FileStorage struct {
-	Directory string `yaml:"directory,omitempty"`
+	CreateDirectory bool   `yaml:"create_directory,omitempty"`
+	Directory       string `yaml:"directory,omitempty"`
 }
 
 // =============================================================================

--- a/internal/otelcollector/config/logagent/config_builder.go
+++ b/internal/otelcollector/config/logagent/config_builder.go
@@ -3,6 +3,7 @@ package logagent
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/common"
 	"github.com/kyma-project/telemetry-manager/internal/resources/otelcollector"
 )
+
+const checkpointVolumePathSubdir = "telemetry-log-agent/file-log-receiver"
 
 type buildComponentFunc = common.BuildComponentFunc[*telemetryv1alpha1.LogPipeline]
 
@@ -34,7 +37,7 @@ func (b *Builder) Build(ctx context.Context, pipelines []telemetryv1alpha1.LogPi
 	b.Config = common.NewConfig()
 	b.AddExtension(common.ComponentIDFileStorageExtension, &common.FileStorage{
 		CreateDirectory: true,
-		Directory:       otelcollector.CheckpointVolumePath,
+		Directory:       filepath.Join(otelcollector.CheckpointVolumePath, checkpointVolumePathSubdir),
 	})
 	b.EnvVars = make(common.EnvVars)
 

--- a/internal/otelcollector/config/logagent/config_builder.go
+++ b/internal/otelcollector/config/logagent/config_builder.go
@@ -32,7 +32,10 @@ type BuildOptions struct {
 
 func (b *Builder) Build(ctx context.Context, pipelines []telemetryv1alpha1.LogPipeline, opts BuildOptions) (*common.Config, common.EnvVars, error) {
 	b.Config = common.NewConfig()
-	b.AddExtension(common.ComponentIDFileStorageExtension, &common.FileStorage{Directory: otelcollector.CheckpointVolumePath})
+	b.AddExtension(common.ComponentIDFileStorageExtension, &common.FileStorage{
+		CreateDirectory: true,
+		Directory:       otelcollector.CheckpointVolumePath,
+	})
 	b.EnvVars = make(common.EnvVars)
 
 	for _, pipeline := range pipelines {

--- a/internal/otelcollector/config/logagent/testdata/http-protocol-with-custom-path.yaml
+++ b/internal/otelcollector/config/logagent/testdata/http-protocol-with-custom-path.yaml
@@ -1,6 +1,7 @@
 extensions:
     file_storage:
-        directory: /var/lib/telemetry-log-agent/file-log-receiver
+        create_directory: true
+        directory: /tmp/telemetry-log-agent/file-log-receiver
     health_check:
         endpoint: ${MY_POD_IP}:13133
     pprof:

--- a/internal/otelcollector/config/logagent/testdata/http-protocol-without-custom-path.yaml
+++ b/internal/otelcollector/config/logagent/testdata/http-protocol-without-custom-path.yaml
@@ -1,6 +1,7 @@
 extensions:
     file_storage:
-        directory: /var/lib/telemetry-log-agent/file-log-receiver
+        create_directory: true
+        directory: /tmp/telemetry-log-agent/file-log-receiver
     health_check:
         endpoint: ${MY_POD_IP}:13133
     pprof:

--- a/internal/otelcollector/config/logagent/testdata/single-pipeline-namespace-excluded.yaml
+++ b/internal/otelcollector/config/logagent/testdata/single-pipeline-namespace-excluded.yaml
@@ -1,6 +1,7 @@
 extensions:
     file_storage:
-        directory: /var/lib/telemetry-log-agent/file-log-receiver
+        create_directory: true
+        directory: /tmp/telemetry-log-agent/file-log-receiver
     health_check:
         endpoint: ${MY_POD_IP}:13133
     pprof:

--- a/internal/otelcollector/config/logagent/testdata/single-pipeline-namespace-included.yaml
+++ b/internal/otelcollector/config/logagent/testdata/single-pipeline-namespace-included.yaml
@@ -1,6 +1,7 @@
 extensions:
     file_storage:
-        directory: /var/lib/telemetry-log-agent/file-log-receiver
+        create_directory: true
+        directory: /tmp/telemetry-log-agent/file-log-receiver
     health_check:
         endpoint: ${MY_POD_IP}:13133
     pprof:

--- a/internal/otelcollector/config/logagent/testdata/single-pipeline.yaml
+++ b/internal/otelcollector/config/logagent/testdata/single-pipeline.yaml
@@ -1,6 +1,7 @@
 extensions:
     file_storage:
-        directory: /var/lib/telemetry-log-agent/file-log-receiver
+        create_directory: true
+        directory: /tmp/telemetry-log-agent/file-log-receiver
     health_check:
         endpoint: ${MY_POD_IP}:13133
     pprof:

--- a/internal/otelcollector/config/logagent/testdata/two-pipelines-with-transforms.yaml
+++ b/internal/otelcollector/config/logagent/testdata/two-pipelines-with-transforms.yaml
@@ -1,6 +1,7 @@
 extensions:
     file_storage:
-        directory: /var/lib/telemetry-log-agent/file-log-receiver
+        create_directory: true
+        directory: /tmp/telemetry-log-agent/file-log-receiver
     health_check:
         endpoint: ${MY_POD_IP}:13133
     pprof:

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestAgent_ApplyResources(t *testing.T) {
 	collectorImage := "opentelemetry/collector:dummy"
-	alpineImage := "alpine:latest"
 	namespace := "kyma-system"
 	priorityClassName := "normal"
 
@@ -38,7 +37,7 @@ func TestAgent_ApplyResources(t *testing.T) {
 		},
 		{
 			name:           "log agent",
-			sut:            NewLogAgentApplierDeleter(collectorImage, alpineImage, namespace, priorityClassName),
+			sut:            NewLogAgentApplierDeleter(collectorImage, namespace, priorityClassName),
 			goldenFilePath: "testdata/log-agent.yaml",
 			collectorEnvVars: map[string][]byte{
 				"DUMMY_ENV_VAR": []byte("foo"),

--- a/internal/resources/otelcollector/testdata/log-agent.yaml
+++ b/internal/resources/otelcollector/testdata/log-agent.yaml
@@ -153,38 +153,8 @@ spec:
         - mountPath: /var/log/pods
           name: varlogpods
           readOnly: true
-        - mountPath: /var/lib/telemetry-log-agent/file-log-receiver
-          name: varlibfilelogreceiver
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - "10001:0"
-        - /var/lib/telemetry-log-agent/file-log-receiver
-        image: alpine:latest
-        name: checkpoint-dir-ownership-modifier
-        resources:
-          limits:
-            memory: 50Mi
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - CHOWN
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: false
-          runAsUser: 0
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /var/lib/telemetry-log-agent/file-log-receiver
-          name: varlibfilelogreceiver
+        - mountPath: /tmp
+          name: tmp
       priorityClassName: normal
       securityContext:
         runAsNonRoot: true
@@ -210,9 +180,9 @@ spec:
           path: /var/log/pods
         name: varlogpods
       - hostPath:
-          path: /var/lib/telemetry-log-agent/file-log-receiver
+          path: /tmp
           type: DirectoryOrCreate
-        name: varlibfilelogreceiver
+        name: tmp
   updateStrategy: {}
 status:
   currentNumberScheduled: 0


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Revert back changes from #2389 for OTel log agent

Changes refer to particular issues, PRs or documents:

- #2459 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
