### PR TITLE
chore: derive the istio annotation includeOutboundPorts from the backend ports

### DIFF
--- a/internal/otelcollector/config/common/otlpexporter_env_vars.go
+++ b/internal/otelcollector/config/common/otlpexporter_env_vars.go
@@ -59,12 +59,12 @@ func makeEnvVars(ctx context.Context, c client.Reader, output *telemetryv1alpha1
 
 func makeAuthenticationEnvVar(ctx context.Context, c client.Reader, secretData map[string][]byte, output *telemetryv1alpha1.OTLPOutput, pipelineName string) error {
 	if output.Authentication != nil && sharedtypesutils.IsValid(&output.Authentication.Basic.User) && sharedtypesutils.IsValid(&output.Authentication.Basic.Password) {
-		username, err := resolveValue(ctx, c, output.Authentication.Basic.User)
+		username, err := ResolveValue(ctx, c, output.Authentication.Basic.User)
 		if err != nil {
 			return err
 		}
 
-		password, err := resolveValue(ctx, c, output.Authentication.Basic.Password)
+		password, err := ResolveValue(ctx, c, output.Authentication.Basic.Password)
 		if err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ func makeHeaderEnvVar(ctx context.Context, c client.Reader, secretData map[strin
 	for _, header := range output.Headers {
 		key := makeHeaderVariable(header, pipelineName)
 
-		value, err := resolveValue(ctx, c, header.ValueType)
+		value, err := ResolveValue(ctx, c, header.ValueType)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ func makeHeaderEnvVar(ctx context.Context, c client.Reader, secretData map[strin
 func makeTLSEnvVar(ctx context.Context, c client.Reader, secretData map[string][]byte, output *telemetryv1alpha1.OTLPOutput, pipelineName string) error {
 	if output.TLS != nil {
 		if sharedtypesutils.IsValid(output.TLS.CA) {
-			ca, err := resolveValue(ctx, c, *output.TLS.CA)
+			ca, err := ResolveValue(ctx, c, *output.TLS.CA)
 			if err != nil {
 				return err
 			}
@@ -118,12 +118,12 @@ func makeTLSEnvVar(ctx context.Context, c client.Reader, secretData map[string][
 		}
 
 		if sharedtypesutils.IsValid(output.TLS.Cert) && sharedtypesutils.IsValid(output.TLS.Key) {
-			cert, err := resolveValue(ctx, c, *output.TLS.Cert)
+			cert, err := ResolveValue(ctx, c, *output.TLS.Cert)
 			if err != nil {
 				return err
 			}
 
-			key, err := resolveValue(ctx, c, *output.TLS.Key)
+			key, err := ResolveValue(ctx, c, *output.TLS.Key)
 			if err != nil {
 				return err
 			}
@@ -152,7 +152,7 @@ func prefixHeaderValue(header telemetryv1alpha1.Header, value []byte) []byte {
 }
 
 func resolveEndpointURL(ctx context.Context, c client.Reader, output *telemetryv1alpha1.OTLPOutput) ([]byte, error) {
-	endpoint, err := resolveValue(ctx, c, output.Endpoint)
+	endpoint, err := ResolveValue(ctx, c, output.Endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func formatBasicAuthHeader(username string, password string) string {
 	return fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
 }
 
-func resolveValue(ctx context.Context, c client.Reader, value telemetryv1alpha1.ValueType) ([]byte, error) {
+func ResolveValue(ctx context.Context, c client.Reader, value telemetryv1alpha1.ValueType) ([]byte, error) {
 	if value.Value != "" {
 		return []byte(value.Value), nil
 	}

--- a/internal/resources/otelcollector/agent_test.go
+++ b/internal/resources/otelcollector/agent_test.go
@@ -28,6 +28,7 @@ func TestAgent_ApplyResources(t *testing.T) {
 		sut              *AgentApplierDeleter
 		collectorEnvVars map[string][]byte
 		istioEnabled     bool
+		backendPorts     []string
 		goldenFilePath   string
 		saveGoldenFile   bool
 	}{
@@ -40,6 +41,7 @@ func TestAgent_ApplyResources(t *testing.T) {
 			name:           "metric agent with istio",
 			sut:            NewMetricAgentApplierDeleter(collectorImage, namespace, priorityClassName),
 			istioEnabled:   true,
+			backendPorts:   []string{"4317", "9090"},
 			goldenFilePath: "testdata/metric-agent-istio.yaml",
 		},
 		{
@@ -81,6 +83,7 @@ func TestAgent_ApplyResources(t *testing.T) {
 				IstioEnabled:        tt.istioEnabled,
 				CollectorConfigYAML: "dummy",
 				CollectorEnvVars:    tt.collectorEnvVars,
+				BackendPorts:        tt.backendPorts,
 			})
 			require.NoError(t, err)
 

--- a/internal/resources/otelcollector/testdata/metric-agent-istio.yaml
+++ b/internal/resources/otelcollector/testdata/metric-agent-istio.yaml
@@ -78,7 +78,7 @@ spec:
         sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
         traffic.sidecar.istio.io/excludeInboundPorts: "8888"
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""
-        traffic.sidecar.istio.io/includeOutboundPorts: "4317"
+        traffic.sidecar.istio.io/includeOutboundPorts: 4317,9090
       labels:
         app.kubernetes.io/component: agent
         app.kubernetes.io/managed-by: telemetry-manager


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Set the value of istio annotation `traffic.sidecar.istio.io/includeOutboundPorts` with the list of the backend ports. For the reasoning behind this change, check the ADR: https://github.com/kyma-project/telemetry-manager/blob/main/docs/contributor/arch/026-istio-outgoing-communication-for-metric-agent.md

Changes refer to particular issues, PRs or documents:

- #2376 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
