### PR TITLE
chore: revert metric producer image after updating sample app

### DIFF
--- a/test/testkit/mocks/prommetricgen/metric_producer.go
+++ b/test/testkit/mocks/prommetricgen/metric_producer.go
@@ -16,7 +16,7 @@ import (
 const (
 	// A sample app instrumented with OpenTelemetry to generate metrics in the Prometheus exposition format
 	// https://github.com/kyma-project/telemetry-manager/tree/main/docs/user/integration/sample-app
-	metricProducerImage = "europe-docker.pkg.dev/kyma-project/dev/samples/telemetry-sample-app:PR-2512"
+	metricProducerImage = "europe-docker.pkg.dev/kyma-project/prod/samples/telemetry-sample-app:latest"
 )
 
 type Metric struct {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- revert metric producer image changes after updating sample app

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
