### PR TITLE
chore: fix perf result download in load test setup

### DIFF
--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -128,9 +128,11 @@ jobs:
           repository: ${{ github.repository }}
       - name: Download Results
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          path: perf-results
       - name: Print Results
         run: |
           ls -la
-          python3 hack/load-tests/convert-results.py Results-*
+          python3 hack/load-tests/convert-results.py perf-results
       - name: Send to GitHub Summary
-        run: python3 hack/load-tests/convert-results.py -m Results-* >> $GITHUB_STEP_SUMMARY
+        run: python3 hack/load-tests/convert-results.py -m perf-results >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -130,9 +130,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: perf-results
+          merge-multiple: true
       - name: Print Results
         run: |
-          ls -la
+          ls -la perf-results
           python3 hack/load-tests/convert-results.py perf-results
       - name: Send to GitHub Summary
         run: python3 hack/load-tests/convert-results.py -m perf-results >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

After the upgrade of the https://github.com/actions/download-artifact/releases/tag/v5.0.0, the download path changed for single file downloads.

See the problem here: https://github.com/kyma-project/telemetry-manager/actions/runs/18092500102/job/51483365965
versus https://github.com/kyma-project/telemetry-manager/actions/runs/17967349590/job/51112854465

Changes proposed in this pull request (what was done and why):

- Adjusted the download config to have a fixed output folder
- Use the merge-multiple option to have same behaviour for single and multiple downloads

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
