### PR TITLE
fix: add missing view in dashboard form for enrichment configurations

### DIFF
--- a/helm/files/telemetries-busola-config.yaml
+++ b/helm/files/telemetries-busola-config.yaml
@@ -118,7 +118,6 @@ details: |-
           visibility: $exists(spec.enrichments.cluster.name)
         - name: Pod Labels
           source: spec.enrichments.extractPodLabels[]
-          visibility: $exists(sspec.enrichments.extractPodLabels)
           widget: Panel
           children:
             - name: Key


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- In the linked ticket, only the edit view got adjusted, added missing view for enrichments

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/2553

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
