### PR TITLE
fix: relax validation rule for ValueType API elements (#2597)

### DIFF
--- a/apis/telemetry/v1alpha1/logpipeline_conversion.go
+++ b/apis/telemetry/v1alpha1/logpipeline_conversion.go
@@ -45,12 +45,12 @@ func (lp *LogPipeline) ConvertTo(dstRaw conversion.Hub) error {
 			Dedot:     srcHTTPOutput.Dedot,
 		}
 
-		if srcHTTPOutput.User != nil {
+		if srcHTTPOutput.User != nil && (srcHTTPOutput.User.Value != "" || srcHTTPOutput.User.ValueFrom != nil) {
 			user := v1Alpha1ValueTypeToV1Beta1(*srcHTTPOutput.User)
 			dst.Spec.Output.HTTP.User = &user
 		}
 
-		if srcHTTPOutput.Password != nil {
+		if srcHTTPOutput.Password != nil && (srcHTTPOutput.Password.Value != "" || srcHTTPOutput.Password.ValueFrom != nil) {
 			password := v1Alpha1ValueTypeToV1Beta1(*srcHTTPOutput.Password)
 			dst.Spec.Output.HTTP.Password = &password
 		}

--- a/apis/telemetry/v1alpha1/shared_types.go
+++ b/apis/telemetry/v1alpha1/shared_types.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 // ValueType represents either a direct value or a reference to a value stored in a Secret.
-// +kubebuilder:validation:XValidation:rule="has(self.value) != has(self.valueFrom)",message="Exactly one of 'value' or 'valueFrom' must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))",message="Only one of 'value' or 'valueFrom' can be set"
 type ValueType struct {
 	// Value as plain text.
 	// +kubebuilder:validation:Optional

--- a/helm/charts/default/templates/telemetry.kyma-project.io_logpipelines.yaml
+++ b/helm/charts/default/templates/telemetry.kyma-project.io_logpipelines.yaml
@@ -228,8 +228,8 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         password:
                           description: Password defines the basic auth password.
                           properties:
@@ -264,8 +264,8 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         port:
                           description: Port defines the port of the HTTP backend. Default is 443.
                           type: string
@@ -306,8 +306,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             cert:
                               description: Cert defines a client certificate to use when using TLS. The certificate must be provided in PEM format.
                               properties:
@@ -342,8 +342,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             disabled:
                               description: Disabled specifies if TLS is disabled or enabled. Default is `false`.
                               type: boolean
@@ -381,8 +381,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             skipCertificateValidation:
                               description: If `true`, the validation of certificates is skipped. Default is `false`.
                               type: boolean
@@ -428,8 +428,8 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                       required:
                         - host
                       type: object
@@ -476,8 +476,8 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-validations:
-                                    - message: Exactly one of 'value' or 'valueFrom' must be set
-                                      rule: has(self.value) != has(self.valueFrom)
+                                    - message: Only one of 'value' or 'valueFrom' can be set
+                                      rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                                 user:
                                   description: User contains the basic auth username or a Secret reference.
                                   properties:
@@ -512,8 +512,8 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-validations:
-                                    - message: Exactly one of 'value' or 'valueFrom' must be set
-                                      rule: has(self.value) != has(self.valueFrom)
+                                    - message: Only one of 'value' or 'valueFrom' can be set
+                                      rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                               required:
                                 - password
                                 - user
@@ -553,8 +553,8 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         headers:
                           description: Headers defines custom headers to be added to outgoing HTTP or gRPC requests.
                           items:
@@ -600,8 +600,8 @@ spec:
                               - name
                             type: object
                             x-kubernetes-validations:
-                              - message: Exactly one of 'value' or 'valueFrom' must be set
-                                rule: has(self.value) != has(self.valueFrom)
+                              - message: Only one of 'value' or 'valueFrom' can be set
+                                rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                           type: array
                         path:
                           description: Path defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths `/v1/metrics` and `/v1/traces`
@@ -649,8 +649,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             cert:
                               description: Defines a client certificate to use when using TLS. The certificate must be provided in PEM format.
                               properties:
@@ -685,8 +685,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             insecure:
                               description: Insecure defines whether to send requests using plaintext instead of TLS.
                               type: boolean
@@ -727,8 +727,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                           type: object
                           x-kubernetes-validations:
                             - message: Can define either both 'cert' and 'key', or neither

--- a/helm/charts/default/templates/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/helm/charts/default/templates/telemetry.kyma-project.io_metricpipelines.yaml
@@ -291,8 +291,8 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-validations:
-                                    - message: Exactly one of 'value' or 'valueFrom' must be set
-                                      rule: has(self.value) != has(self.valueFrom)
+                                    - message: Only one of 'value' or 'valueFrom' can be set
+                                      rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                                 user:
                                   description: User contains the basic auth username or a Secret reference.
                                   properties:
@@ -327,8 +327,8 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-validations:
-                                    - message: Exactly one of 'value' or 'valueFrom' must be set
-                                      rule: has(self.value) != has(self.valueFrom)
+                                    - message: Only one of 'value' or 'valueFrom' can be set
+                                      rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                               required:
                                 - password
                                 - user
@@ -368,8 +368,8 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         headers:
                           description: Headers defines custom headers to be added to outgoing HTTP or gRPC requests.
                           items:
@@ -415,8 +415,8 @@ spec:
                               - name
                             type: object
                             x-kubernetes-validations:
-                              - message: Exactly one of 'value' or 'valueFrom' must be set
-                                rule: has(self.value) != has(self.valueFrom)
+                              - message: Only one of 'value' or 'valueFrom' can be set
+                                rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                           type: array
                         path:
                           description: Path defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths `/v1/metrics` and `/v1/traces`
@@ -464,8 +464,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             cert:
                               description: Defines a client certificate to use when using TLS. The certificate must be provided in PEM format.
                               properties:
@@ -500,8 +500,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             insecure:
                               description: Insecure defines whether to send requests using plaintext instead of TLS.
                               type: boolean
@@ -542,8 +542,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                           type: object
                           x-kubernetes-validations:
                             - message: Can define either both 'cert' and 'key', or neither

--- a/helm/charts/default/templates/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/helm/charts/default/templates/telemetry.kyma-project.io_tracepipelines.yaml
@@ -107,8 +107,8 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-validations:
-                                    - message: Exactly one of 'value' or 'valueFrom' must be set
-                                      rule: has(self.value) != has(self.valueFrom)
+                                    - message: Only one of 'value' or 'valueFrom' can be set
+                                      rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                                 user:
                                   description: User contains the basic auth username or a Secret reference.
                                   properties:
@@ -143,8 +143,8 @@ spec:
                                       type: object
                                   type: object
                                   x-kubernetes-validations:
-                                    - message: Exactly one of 'value' or 'valueFrom' must be set
-                                      rule: has(self.value) != has(self.valueFrom)
+                                    - message: Only one of 'value' or 'valueFrom' can be set
+                                      rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                               required:
                                 - password
                                 - user
@@ -184,8 +184,8 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         headers:
                           description: Headers defines custom headers to be added to outgoing HTTP or gRPC requests.
                           items:
@@ -231,8 +231,8 @@ spec:
                               - name
                             type: object
                             x-kubernetes-validations:
-                              - message: Exactly one of 'value' or 'valueFrom' must be set
-                                rule: has(self.value) != has(self.valueFrom)
+                              - message: Only one of 'value' or 'valueFrom' can be set
+                                rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                           type: array
                         path:
                           description: Path defines OTLP export URL path (only for the HTTP protocol). This value overrides auto-appended paths `/v1/metrics` and `/v1/traces`
@@ -280,8 +280,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             cert:
                               description: Defines a client certificate to use when using TLS. The certificate must be provided in PEM format.
                               properties:
@@ -316,8 +316,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                             insecure:
                               description: Insecure defines whether to send requests using plaintext instead of TLS.
                               type: boolean
@@ -358,8 +358,8 @@ spec:
                                   type: object
                               type: object
                               x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                - message: Only one of 'value' or 'valueFrom' can be set
+                                  rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                           type: object
                           x-kubernetes-validations:
                             - message: Can define either both 'cert' and 'key', or neither

--- a/helm/charts/experimental/templates/telemetry.kyma-project.io_logpipelines.yaml
+++ b/helm/charts/experimental/templates/telemetry.kyma-project.io_logpipelines.yaml
@@ -296,8 +296,8 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-validations:
-                        - message: Exactly one of 'value' or 'valueFrom' must be set
-                          rule: has(self.value) != has(self.valueFrom)
+                        - message: Only one of 'value' or 'valueFrom' can be set
+                          rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                       password:
                         description: Password defines the basic auth password.
                         properties:
@@ -339,8 +339,8 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-validations:
-                        - message: Exactly one of 'value' or 'valueFrom' must be set
-                          rule: has(self.value) != has(self.valueFrom)
+                        - message: Only one of 'value' or 'valueFrom' can be set
+                          rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                       port:
                         description: Port defines the port of the HTTP backend. Default
                           is 443.
@@ -391,9 +391,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           cert:
                             description: Cert defines a client certificate to use
                               when using TLS. The certificate must be provided in
@@ -437,9 +437,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           disabled:
                             description: Disabled specifies if TLS is disabled or
                               enabled. Default is `false`.
@@ -486,9 +486,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           skipCertificateValidation:
                             description: If `true`, the validation of certificates
                               is skipped. Default is `false`.
@@ -543,8 +543,8 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-validations:
-                        - message: Exactly one of 'value' or 'valueFrom' must be set
-                          rule: has(self.value) != has(self.valueFrom)
+                        - message: Only one of 'value' or 'valueFrom' can be set
+                          rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                     required:
                     - host
                     type: object
@@ -602,9 +602,10 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must
+                                - message: Only one of 'value' or 'valueFrom' can
                                     be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                  rule: '!(has(self.value) && size(self.value) > 0
+                                    && has(self.valueFrom))'
                               user:
                                 description: User contains the basic auth username
                                   or a Secret reference.
@@ -648,9 +649,10 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must
+                                - message: Only one of 'value' or 'valueFrom' can
                                     be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                  rule: '!(has(self.value) && size(self.value) > 0
+                                    && has(self.valueFrom))'
                             required:
                             - password
                             - user
@@ -698,8 +700,8 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-validations:
-                        - message: Exactly one of 'value' or 'valueFrom' must be set
-                          rule: has(self.value) != has(self.valueFrom)
+                        - message: Only one of 'value' or 'valueFrom' can be set
+                          rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                       headers:
                         description: Headers defines custom headers to be added to
                           outgoing HTTP or gRPC requests.
@@ -755,9 +757,8 @@ spec:
                           - name
                           type: object
                           x-kubernetes-validations:
-                          - message: Exactly one of 'value' or 'valueFrom' must be
-                              set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: Only one of 'value' or 'valueFrom' can be set
+                            rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         type: array
                       path:
                         description: Path defines OTLP export URL path (only for the
@@ -817,9 +818,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           cert:
                             description: Defines a client certificate to use when
                               using TLS. The certificate must be provided in PEM format.
@@ -862,9 +863,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           insecure:
                             description: Insecure defines whether to send requests
                               using plaintext instead of TLS.
@@ -915,9 +916,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                         type: object
                         x-kubernetes-validations:
                         - message: Can define either both 'cert' and 'key', or neither

--- a/helm/charts/experimental/templates/telemetry.kyma-project.io_metricpipelines.yaml
+++ b/helm/charts/experimental/templates/telemetry.kyma-project.io_metricpipelines.yaml
@@ -366,9 +366,10 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must
+                                - message: Only one of 'value' or 'valueFrom' can
                                     be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                  rule: '!(has(self.value) && size(self.value) > 0
+                                    && has(self.valueFrom))'
                               user:
                                 description: User contains the basic auth username
                                   or a Secret reference.
@@ -412,9 +413,10 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must
+                                - message: Only one of 'value' or 'valueFrom' can
                                     be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                  rule: '!(has(self.value) && size(self.value) > 0
+                                    && has(self.valueFrom))'
                             required:
                             - password
                             - user
@@ -462,8 +464,8 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-validations:
-                        - message: Exactly one of 'value' or 'valueFrom' must be set
-                          rule: has(self.value) != has(self.valueFrom)
+                        - message: Only one of 'value' or 'valueFrom' can be set
+                          rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                       headers:
                         description: Headers defines custom headers to be added to
                           outgoing HTTP or gRPC requests.
@@ -519,9 +521,8 @@ spec:
                           - name
                           type: object
                           x-kubernetes-validations:
-                          - message: Exactly one of 'value' or 'valueFrom' must be
-                              set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: Only one of 'value' or 'valueFrom' can be set
+                            rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         type: array
                       path:
                         description: Path defines OTLP export URL path (only for the
@@ -581,9 +582,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           cert:
                             description: Defines a client certificate to use when
                               using TLS. The certificate must be provided in PEM format.
@@ -626,9 +627,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           insecure:
                             description: Insecure defines whether to send requests
                               using plaintext instead of TLS.
@@ -679,9 +680,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                         type: object
                         x-kubernetes-validations:
                         - message: Can define either both 'cert' and 'key', or neither

--- a/helm/charts/experimental/templates/telemetry.kyma-project.io_tracepipelines.yaml
+++ b/helm/charts/experimental/templates/telemetry.kyma-project.io_tracepipelines.yaml
@@ -120,9 +120,10 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must
+                                - message: Only one of 'value' or 'valueFrom' can
                                     be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                  rule: '!(has(self.value) && size(self.value) > 0
+                                    && has(self.valueFrom))'
                               user:
                                 description: User contains the basic auth username
                                   or a Secret reference.
@@ -166,9 +167,10 @@ spec:
                                     type: object
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Exactly one of 'value' or 'valueFrom' must
+                                - message: Only one of 'value' or 'valueFrom' can
                                     be set
-                                  rule: has(self.value) != has(self.valueFrom)
+                                  rule: '!(has(self.value) && size(self.value) > 0
+                                    && has(self.valueFrom))'
                             required:
                             - password
                             - user
@@ -216,8 +218,8 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-validations:
-                        - message: Exactly one of 'value' or 'valueFrom' must be set
-                          rule: has(self.value) != has(self.valueFrom)
+                        - message: Only one of 'value' or 'valueFrom' can be set
+                          rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                       headers:
                         description: Headers defines custom headers to be added to
                           outgoing HTTP or gRPC requests.
@@ -273,9 +275,8 @@ spec:
                           - name
                           type: object
                           x-kubernetes-validations:
-                          - message: Exactly one of 'value' or 'valueFrom' must be
-                              set
-                            rule: has(self.value) != has(self.valueFrom)
+                          - message: Only one of 'value' or 'valueFrom' can be set
+                            rule: '!(has(self.value) && size(self.value) > 0 && has(self.valueFrom))'
                         type: array
                       path:
                         description: Path defines OTLP export URL path (only for the
@@ -335,9 +336,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           cert:
                             description: Defines a client certificate to use when
                               using TLS. The certificate must be provided in PEM format.
@@ -380,9 +381,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                           insecure:
                             description: Insecure defines whether to send requests
                               using plaintext instead of TLS.
@@ -433,9 +434,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of 'value' or 'valueFrom' must
-                                be set
-                              rule: has(self.value) != has(self.valueFrom)
+                            - message: Only one of 'value' or 'valueFrom' can be set
+                              rule: '!(has(self.value) && size(self.value) > 0 &&
+                                has(self.valueFrom))'
                         type: object
                         x-kubernetes-validations:
                         - message: Can define either both 'cert' and 'key', or neither

--- a/test/e2e/logs/misc/reject_creation_test.go
+++ b/test/e2e/logs/misc/reject_creation_test.go
@@ -64,7 +64,7 @@ func TestRejectLogPipelineCreation(t *testing.T) {
 					},
 				},
 			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
+			errorMsg: "Only one of 'value' or 'valueFrom' can be set",
 			field:    "spec.output.otlp.endpoint",
 		},
 		{
@@ -171,20 +171,6 @@ func TestRejectLogPipelineCreation(t *testing.T) {
 			errorMsg: "Unsupported value",
 			causes:   2,
 			field:    "spec.output.otlp.protocol",
-		},
-		{
-			pipeline: telemetryv1alpha1.LogPipeline{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "otlp-output-without-endpoint",
-				},
-				Spec: telemetryv1alpha1.LogPipelineSpec{
-					Output: telemetryv1alpha1.LogPipelineOutput{
-						OTLP: &telemetryv1alpha1.OTLPOutput{},
-					},
-				},
-			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
-			field:    "spec.output.otlp.endpoint",
 		},
 		{
 			pipeline: testutils.NewLogPipelineBuilder().
@@ -294,20 +280,6 @@ func TestRejectLogPipelineCreation(t *testing.T) {
 			},
 			errorMsg: "should match '^/.*$'",
 			field:    "spec.output.http.uri",
-		},
-		{
-			pipeline: telemetryv1alpha1.LogPipeline{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "http-output-host-required",
-				},
-				Spec: telemetryv1alpha1.LogPipelineSpec{
-					Output: telemetryv1alpha1.LogPipelineOutput{
-						HTTP: &telemetryv1alpha1.LogPipelineHTTPOutput{},
-					},
-				},
-			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
-			field:    "spec.output.http.host",
 		},
 		// application input
 		{

--- a/test/e2e/metrics/misc/reject_creation_test.go
+++ b/test/e2e/metrics/misc/reject_creation_test.go
@@ -66,7 +66,7 @@ func TestRejectPipelineCreation(t *testing.T) {
 					},
 				},
 			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
+			errorMsg: "Only one of 'value' or 'valueFrom' can be set",
 			field:    "spec.output.otlp.endpoint",
 		},
 		{
@@ -173,20 +173,6 @@ func TestRejectPipelineCreation(t *testing.T) {
 			errorMsg: "Unsupported value",
 			causes:   2,
 			field:    "spec.output.otlp.protocol",
-		},
-		{
-			pipeline: telemetryv1alpha1.MetricPipeline{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "otlp-output-without-endpoint",
-				},
-				Spec: telemetryv1alpha1.MetricPipelineSpec{
-					Output: telemetryv1alpha1.MetricPipelineOutput{
-						OTLP: &telemetryv1alpha1.OTLPOutput{},
-					},
-				},
-			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
-			field:    "spec.output.otlp.endpoint",
 		},
 		{
 			pipeline: testutils.NewMetricPipelineBuilder().

--- a/test/e2e/traces/reject_creation_test.go
+++ b/test/e2e/traces/reject_creation_test.go
@@ -65,7 +65,7 @@ func TestRejectTracePipelineCreation(t *testing.T) {
 					},
 				},
 			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
+			errorMsg: "Only one of 'value' or 'valueFrom' can be set",
 			field:    "spec.output.otlp.endpoint",
 		},
 		{
@@ -172,20 +172,6 @@ func TestRejectTracePipelineCreation(t *testing.T) {
 			errorMsg: "Unsupported value",
 			causes:   2,
 			field:    "spec.output.otlp.protocol",
-		},
-		{
-			pipeline: telemetryv1alpha1.TracePipeline{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "otlp-output-without-endpoint",
-				},
-				Spec: telemetryv1alpha1.TracePipelineSpec{
-					Output: telemetryv1alpha1.TracePipelineOutput{
-						OTLP: &telemetryv1alpha1.OTLPOutput{},
-					},
-				},
-			},
-			errorMsg: "Exactly one of 'value' or 'valueFrom' must be set",
-			field:    "spec.output.otlp.endpoint",
 		},
 		{
 			pipeline: testutils.NewTracePipelineBuilder().


### PR DESCRIPTION
(cherry picked from commit 658c12af0e5d48bfb0f9f679d1fbe71c019caa6e)

## Description

Changes proposed in this pull request (what was done and why):

- backport of https://github.com/kyma-project/telemetry-manager/pull/2597

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/pull/2597

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
