### PR TITLE
feat: revert FIPS mode for self-monitor

### DIFF
--- a/dependencies/telemetry-self-monitor/Dockerfile
+++ b/dependencies/telemetry-self-monitor/Dockerfile
@@ -27,7 +27,7 @@ COPY plugins.yml plugins.yml
 # Only the plain build should use the targetarch, not the utilities like plugins, that's why the make call is divided into its parts, see
 # https://github.com/prometheus/prometheus/blob/f1db64f4c513f9b0abaed6cac96646fadfe485ca/Makefile#L163C8-L163C51
 RUN make plugins
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOFIPS140=v1.0.0 make assets npm_licenses assets-compress common-build
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make assets npm_licenses assets-compress common-build
 
 FROM scratch
 
@@ -37,8 +37,5 @@ COPY --from=builder /prometheus/prometheus /bin/prometheus
 
 USER       nobody
 EXPOSE     9090
-
-# Enable FIPS only mode and disable TLS ML-KEM as it is not FIPS compliant (https://pkg.go.dev/crypto/tls#Config.CurvePreferences)
-ENV GODEBUG=fips140=only,tlsmlkem=0
 
 ENTRYPOINT [ "/bin/prometheus" ]


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

-  revert FIPS mode for self-monitor to have more time to check if there are issues with running prometheus in FIPS mode

Changes refer to particular issues, PRs or documents:

- #2123

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
