### PR TITLE
feat: bump self-monitor image version to 3.7.2

### DIFF
--- a/.env
+++ b/.env
@@ -18,6 +18,6 @@ ENV_GORELEASER_VERSION=v1.23.0
 ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250910-86122076"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.1.1"
 ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.136.0-main"
-ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.7.1-a38d6f7"
+ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.7.2-d25aebc"
 ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.136.0"
 ENV_ALPINE_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.22.1"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,7 +16,7 @@ manager:
       fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.1.1
       gomemlimit: 300MiB
       otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.136.0-main
-      selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.7.1-a38d6f7
+      selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.7.2-d25aebc
     image:
       repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
       pullPolicy: "IfNotPresent"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -5,7 +5,7 @@ bdba:
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20250910-86122076
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.1.1
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.136.0-main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.7.1-a38d6f7
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.7.2-d25aebc
   - europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.22.1
 mend:
   language: golang-mod


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Bump self-monitor image version to 3.7.2

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
