### PR TITLE
fix: gardener tests cannot find required files

### DIFF
--- a/.github/workflows/gardener-integration.yml
+++ b/.github/workflows/gardener-integration.yml
@@ -90,12 +90,12 @@ jobs:
 
       - name: Create Telemetry CR
         shell: bash
-        run: kubectl apply -f samples/operator_v1alpha1_telemetry.yaml -n kyma-system
+        run: kubectl apply -f test/fixtures/operator_v1alpha1_telemetry.yaml -n kyma-system
 
       # Deploying  a deny-all Network Policy to simulate a typical setup on a Kyma cluster
       - name: Create Network Policy
         shell: bash
-        run: kubectl apply -f samples/networkpolicy-deny-all.yaml -n kyma-system
+        run: kubectl apply -f test/fixtures/networkpolicy-deny-all.yaml -n kyma-system
 
       - name: Execute istio tests subset
         uses: "./.github/template/test-execute"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- gardener tests still referenced test fixtures from the samples folder

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
