### PR TITLE
fix: uncomment cleanup code in filter test

### DIFF
--- a/test/e2e/traces/filter_test.go
+++ b/test/e2e/traces/filter_test.go
@@ -49,7 +49,7 @@ func TestFilter(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Cleanup(func() {
-		// Expect(kitk8s.DeleteObjects(resources...)).To(Succeed())
+		Expect(kitk8s.DeleteObjects(resources...)).To(Succeed())
 	})
 	Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Cleanup code was commented in traces filter test 

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
