### PR TITLE
chore: add runAsNonRoot flag to telemetry-manager container security context

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -30,6 +30,7 @@ manager:
       allowPrivilegeEscalation: false
       privileged: false
       readOnlyRootFilesystem: true
+      runAsNonRoot: true
       capabilities:
         drop:
           - ALL


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- For all components the flag exists on the container securitxyContext but not for the manager, fixing it here

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
