### PR TITLE
docs: improve dynakube example

### DIFF
--- a/docs/user/integration/dynatrace/README.md
+++ b/docs/user/integration/dynatrace/README.md
@@ -85,7 +85,7 @@ There are different ways to deploy Dynatrace on Kubernetes. All [deployment opti
                 - kyma
     ```
 
-    If you are using the `oneAgent.applicationMonitoring` mode instead, please configure the `namespaceSelector` on that instead.
+    If you are using the `oneAgent.applicationMonitoring` mode instead, configure the `namespaceSelector` on that.
 
 1. In the DynaKube resource, enable OTLP ingestion using the OTel Collector (see [Enable Dynatrace telemetry ingest endpoints](https://docs.dynatrace.com/managed/ingest-from/setup-on-k8s/extend-observability-k8s/telemetry-ingest)):
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- added the dynakube version as the attributes are not available on older versions
- as oneAgent.cloudNativeFullStack and oneAgent.applicationMonitoring cannot be configured in parallel but both support namespace selection, I added a sentence for applicationMonitoring

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
