### PR TITLE
chore: bump alpine and fluentbit image in cache

### DIFF
--- a/.k3d-kyma.yaml
+++ b/.k3d-kyma.yaml
@@ -3,7 +3,7 @@ apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: kyma
-image: europe-docker.pkg.dev/kyma-project/prod/external/rancher/k3s:v1.33.4-k3s1 # refers to the image used by k3d
+image: europe-docker.pkg.dev/kyma-project/prod/external/rancher/k3s:v1.32.8-k3s1 # refers to the image used by k3d
 
 servers: 1
 agents: 0


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump alpine image to 3.22.2
- bump fluentbit image to 4.2.0 in cache

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
