### PR TITLE
docs: remove note in jaeger integration guide

### DIFF
--- a/docs/user/integration/jaeger/README.md
+++ b/docs/user/integration/jaeger/README.md
@@ -50,9 +50,6 @@ Learn how to use [Jaeger](https://github.com/jaegertracing/helm-charts/tree/main
 
 ### Install Jaeger
 
-> [!NOTE]
-> It is officially recommended to install Jaeger with the [Jaeger operator](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator). Because the operator requires a cert-manager to be installed, the following instructions use a plain Jaeger installation. However, the described installation is not meant to be used for production setups.
-
 Run the Helm upgrade command, which installs the chart if not present yet.
 
 ```bash


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- the jaeger-operator is not promoted anymore, let's remove the note

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
