### PR TITLE
fix: upgrade tests fail due to automatic resource cleanup

### DIFF
--- a/.github/workflows/pr-upgrade.yml
+++ b/.github/workflows/pr-upgrade.yml
@@ -43,19 +43,26 @@ jobs:
       - name: Setup Golang
         uses: "./.github/template/setup-golang"
 
-      - name: Checkout latest tag
+      - name: Checkout latest release
         id: latest-tag
         shell: bash
         run: |
-          git fetch --tags
-          LATEST_TAG=$(git tag --sort=-creatordate | sed -n 1p)
-          echo "Using tag ${LATEST_TAG}"
-          git checkout ${LATEST_TAG}
-          GIT_COMMIT_SHA=$(git rev-parse --short=8 HEAD)
-          GIT_COMMIT_DATE=$(git show -s --format=%cd --date=format:'v%Y%m%d' ${GIT_COMMIT_SHA})
-          echo "Deploying Manager using image europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA}"
-          MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${GIT_COMMIT_DATE}-${GIT_COMMIT_SHA} >> $GITHUB_OUTPUT
+          # Get the latest release tag from GitHub
+          LATEST_TAG=$(curl -s https://api.github.com/repos/kyma-project/telemetry-manager/releases/latest | jq -r '.tag_name')
+          echo "Latest release tag: ${LATEST_TAG}"
+          
+          MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:${LATEST_TAG}
+          echo "Deploying Manager using image ${MANAGER_IMAGE}"
           echo "manager-image=${MANAGER_IMAGE}" >> $GITHUB_OUTPUT
+          
+          # Extract major.minor version from tag (e.g., 1.54.0 -> 1.54)
+          RELEASE_BRANCH=$(echo ${LATEST_TAG} | sed -E 's/^v?([0-9]+\.[0-9]+)\.[0-9]+$/release-\1/')
+          echo "Checking out release branch: ${RELEASE_BRANCH}"
+          
+          # Checkout the corresponding release branch for tests
+          git fetch origin ${RELEASE_BRANCH}
+          git checkout ${RELEASE_BRANCH}
+          echo "release-branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Setup test environment
         uses: "./.github/template/test-setup"

--- a/test/e2e/upgrade/logs_fluentbit_upgrade_test.go
+++ b/test/e2e/upgrade/logs_fluentbit_upgrade_test.go
@@ -44,7 +44,7 @@ func TestLogsFluentBitUpgrade(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Run("before upgrade", func(t *testing.T) {
-		Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+		Expect(kitk8s.CreateObjectsWithoutAutomaticCleanup(t, resources...)).To(Succeed())
 
 		assert.DaemonSetReady(t, kitkyma.FluentBitDaemonSetName)
 		assert.FluentBitLogPipelineHealthy(t, pipelineName)

--- a/test/e2e/upgrade/logs_upgrade_test.go
+++ b/test/e2e/upgrade/logs_upgrade_test.go
@@ -44,7 +44,7 @@ func TestLogsUpgrade(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Run("before upgrade", func(t *testing.T) {
-		Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+		Expect(kitk8s.CreateObjectsWithoutAutomaticCleanup(t, resources...)).To(Succeed())
 
 		assert.DeploymentReady(t, kitkyma.LogGatewayName)
 		assert.OTelLogPipelineHealthy(t, pipelineName)

--- a/test/e2e/upgrade/metrics_upgrade_test.go
+++ b/test/e2e/upgrade/metrics_upgrade_test.go
@@ -44,7 +44,7 @@ func TestMetricsUpgrade(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Run("before upgrade", func(t *testing.T) {
-		Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+		Expect(kitk8s.CreateObjectsWithoutAutomaticCleanup(t, resources...)).To(Succeed())
 
 		assert.DeploymentReady(t, kitkyma.MetricGatewayName)
 		assert.MetricPipelineHealthy(t, pipelineName)

--- a/test/e2e/upgrade/traces_upgrade_test.go
+++ b/test/e2e/upgrade/traces_upgrade_test.go
@@ -44,7 +44,7 @@ func TestTracesUpgrade(t *testing.T) {
 	resources = append(resources, backend.K8sObjects()...)
 
 	t.Run("before upgrade", func(t *testing.T) {
-		Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
+		Expect(kitk8s.CreateObjectsWithoutAutomaticCleanup(t, resources...)).To(Succeed())
 
 		assert.DeploymentReady(t, kitkyma.TraceGatewayName)
 		assert.TracePipelineHealthy(t, pipelineName)

--- a/test/testkit/k8s/objects.go
+++ b/test/testkit/k8s/objects.go
@@ -31,17 +31,26 @@ import (
 func CreateObjects(t *testing.T, resources ...client.Object) error {
 	t.Helper()
 
-	// Sort resources:
-	// 1. namespaces
-	// 2. other resources
-	// 3. pipelines
-	sortedResources := sortObjects(resources)
-
 	t.Cleanup(func() {
 		// Delete created objects after test completion. We dont care for not found errors here.
 		gomega.Expect(deleteObjectsIgnoringNotFound(resources...)).To(gomega.Succeed())
 		gomega.Eventually(allObjectsDeleted(resources...), periodic.EventuallyTimeout).Should(gomega.Succeed())
 	})
+
+	return createObjects(t, resources...)
+}
+
+// CreateObjectsWithoutAutomaticCleanup creates k8s objects passed as a slice but does not delete them automatically after the test.
+func CreateObjectsWithoutAutomaticCleanup(t *testing.T, resources ...client.Object) error {
+	t.Helper()
+
+	return createObjects(t, resources...)
+}
+
+func createObjects(t *testing.T, resources ...client.Object) error {
+	t.Helper()
+
+	sortedResources := sortObjects(resources)
 
 	for _, resource := range sortedResources {
 		// Skip object creation if it already exists.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- automatic resource cleanup must not be done during upgrade tests

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
