### PR TITLE
chore: fix for code scanning alert

### DIFF
--- a/.github/workflows/gardener-integration.yml
+++ b/.github/workflows/gardener-integration.yml
@@ -67,11 +67,13 @@ jobs:
         uses: "./.github/template/setup-golang"
 
       - name: Prepare environment variables
+        env:
+          GITHUB_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             # For PR events, use dev image with PR number
             PR_NUMBER="${{ github.event.number }}"
-            TAG="${{ github.event.pull_request.head.ref }}"
+            TAG="$GITHUB_PR_HEAD_REF"
             MANAGER_IMAGE="europe-docker.pkg.dev/kyma-project/dev/telemetry-manager:${TAG}"
             echo "Using dev image for PR: $MANAGER_IMAGE"
           else


### PR DESCRIPTION
Potential fix for [https://github.com/kyma-project/telemetry-manager/security/code-scanning/5](https://github.com/kyma-project/telemetry-manager/security/code-scanning/5)

To resolve the code injection risk, the workflow should not use `${{ github.event.pull_request.head.ref }}` directly in the `run` block. Instead, assign the value to an environment variable in the `env` section of the step, and then use that environment variable inside the shell script using the shell-native form (`$TAG`), not `${{ env.TAG }}` or similar. This change should only be made in the step where the insecure interpolation occurs—specifically, in the "Prepare environment variables" step at line 70-88, with emphasis on the usage of `${{ github.event.pull_request.head.ref }}` at line 74.

Necessary steps:
- Add an appropriate environment variable assignment for the untrusted value in the step's `env:` (e.g., `GITHUB_PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}`).
- Use the env variable via shell syntax (e.g., `TAG="$GITHUB_PR_HEAD_REF"`) in the shell script.
- Remove the direct use of `${{ github.event.pull_request.head.ref }}` in the shell `run`.

No new imports or steps are needed, just restructuring of the environment variable assignment and the shell code in this step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
