### PR TITLE
chore: bump images to release telemetry version 1.55.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 ### Default Environment Variables
 ## General
 # Image URL to use all building/pushing image targets
-ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-ENV_HELM_RELEASE_VERSION=0.0.1-main
+ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.55.0
+ENV_HELM_RELEASE_VERSION=1.55.0
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.33
@@ -17,7 +17,7 @@ ENV_GORELEASER_VERSION=v1.23.0
 ## Default Docker Images
 ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20251210-3d7f23ad"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.2"
-ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-main"
+ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-1.55.0"
 # ENV_OTEL_COLLECTOR_CONTRIB_IMAGE is used for OAuth2 E2E tests only, since they require the OIDC extension, which is not needed in production code.
 ENV_OTEL_COLLECTOR_CONTRIB_IMAGE="otel/opentelemetry-collector-contrib:latest"
 ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.8.0-3d7f23a"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: telemetry-manager
 description: Kyma Telemetry Manager Helm Chart
-version: 0.0.1-main
+version: 1.55.0
 type: application
-appVersion: "0.0.1-main"
+appVersion: "1.55.0"
 keywords:
   - kyma
   - telemetry
@@ -17,8 +17,8 @@ maintainers:
     url: https://kyma-project.io
 dependencies:
   - name: experimental
-    version: 0.0.1-main
+    version: 1.55.0
     condition: experimental.enabled
   - name: default
-    version: 0.0.1-main
+    version: 1.55.0
     condition: default.enabled

--- a/helm/charts/default/Chart.yaml
+++ b/helm/charts/default/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: default
 description: Telemetry Manager Default CRDs
-version: 0.0.1-main
+version: 1.55.0

--- a/helm/charts/experimental/Chart.yaml
+++ b/helm/charts/experimental/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: experimental
 description: Telemetry Manager Experimental CRDs
-version: 0.0.1-main
+version: 1.55.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,11 +21,11 @@ manager:
       fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20251210-3d7f23ad
       fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.2
       gomemlimit: 300MiB
-      otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-main
+      otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-1.55.0
       selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.8.0-3d7f23a
       operateInFipsMode: false
     image:
-      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.55.0
       pullPolicy: "IfNotPresent"
     resources:
       limits:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,10 +1,10 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.55.0
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20251210-3d7f23ad
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.2
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-1.55.0
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.8.0-3d7f23a
   - europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.2
 mend:

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -6,5 +6,5 @@ package testkit
 const (
 	DefaultTelemetryGenImage         = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.141.0"
 	DefaultOTelCollectorContribImage = "otel/opentelemetry-collector-contrib:latest"
-	DefaultOTelCollectorImage        = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-main"
+	DefaultOTelCollectorImage        = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.141.0-1.55.0"
 )


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump images for release telemetry version 1.55.0

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
