### PR TITLE
fix: incorrect busola config indentation for Resource widget

### DIFF
--- a/helm/files/logpipelines-busola-config.yaml
+++ b/helm/files/logpipelines-busola-config.yaml
@@ -546,18 +546,18 @@ form: |
             children:
               - path: '[]'
                 widget: Resource
-                  resource:
-                    kind: Namespace
-                    version: v1
+                resource:
+                  kind: Namespace
+                  version: v1
           - name: Exclude Namespaces
             widget: SimpleList
             path: namespaces.exclude
             children:
               - path: '[]'
                 widget: Resource
-                  resource:
-                    kind: Namespace
-                    version: v1
+                resource:
+                  kind: Namespace
+                  version: v1
   - name: Filters
     widget: GenericList
     path: spec.filters


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- FormGroup for LogPipeline is not displayed properly because of incorrent busola indentation for Resource widget

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
