### PR TITLE
chore: update k3d version in image cache

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,10 +1,10 @@
 images:
   - source: "fluent/fluent-bit@sha256:7d727245767ae632eb296c2ff4d206bf2e205b5f244c1f37b8fdd61f9fb33985"
     tag: "4.2.2" # used by the kyma telemetry module
-  - source: "rancher/k3s@sha256:f9f125ef9c662a231a98c507afdd3ba9a94d5f02631f946d1d34000ef67f7263"
-    tag: "v1.32.8-k3s1" # used by k3d - current k8s version
-  - source: "rancher/k3s@sha256:f9f125ef9c662a231a98c507afdd3ba9a94d5f02631f946d1d34000ef67f7263"
-    tag: "v1.33.4-k3s1" # used by k3d - future k3s version
+  - source: "rancher/k3s@sha256:bfced830bf3a9b4624e0e569264c7bfebc0700bc36d20a7238faa8646825e36b"
+    tag: "v1.33.7-k3s1" # used by k3d - current k8s version
+  - source: "rancher/k3s@sha256:71abd3a56f57884c62732e0e0d87606052cb5f8555b7db7e8e33c04570b8175c"
+    tag: "v1.34.3-k3s1" # used by k3d - future k8s version
   - source: "library/registry@sha256:3725021071ec9383eb3d87ddbdff9ed602439b3f7c958c9c2fb941049ea6531d"
     tag: "3" # used by k3d
   - source: "library/alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- update k3d version in image cache

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
