### PR TITLE
chore: bump telemetry version to 1.57.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 ### Default Environment Variables
 ## General
 # Image URL to use all building/pushing image targets
-ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.57.1
-ENV_HELM_RELEASE_VERSION=1.57.1
+ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.57.2
+ENV_HELM_RELEASE_VERSION=1.57.2
 
 ## Gardener
 ENV_GARDENER_K8S_VERSION=1.33

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: telemetry-manager
 description: Kyma Telemetry Manager Helm Chart
-version: 1.57.1
+version: 1.57.2
 type: application
-appVersion: "1.57.1"
+appVersion: "1.57.2"
 keywords:
   - kyma
   - telemetry
@@ -17,8 +17,8 @@ maintainers:
     url: https://kyma-project.io
 dependencies:
   - name: experimental
-    version: 1.57.1
+    version: 1.57.2
     condition: experimental.enabled
   - name: default
-    version: 1.57.1
+    version: 1.57.2
     condition: default.enabled

--- a/helm/charts/default/Chart.yaml
+++ b/helm/charts/default/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: default
 description: Telemetry Manager Default CRDs
-version: 1.57.1
+version: 1.57.2

--- a/helm/charts/experimental/Chart.yaml
+++ b/helm/charts/experimental/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: experimental
 description: Telemetry Manager Experimental CRDs
-version: 1.57.1
+version: 1.57.2

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,7 +25,7 @@ manager:
       selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:3.9.1-0877cc3
       operateInFipsMode: false
     image:
-      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.57.1
+      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.57.2
       pullPolicy: "IfNotPresent"
     resources:
       limits:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.57.1
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.57.2
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260116-88440ede
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.2
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.144.0-1.57.0


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump telemetry version to 1.57.2

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
