### PR TITLE
fix: add missing gcloud authentication for fips tests

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -218,6 +218,12 @@ jobs:
       - name: Setup Golang
         uses: ./.github/template/setup-golang
 
+      - name: Authenticate to Google Cloud
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CLOUD_SA_KEY }}
+
       - name: Setup Google Cloud SDK
         if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
@@ -232,7 +238,7 @@ jobs:
       - name: Run selfmonitor-${{ matrix.scenario }}-${{ matrix.component.name }} tests
         run: |
           # For PR events, only run no-fips tests since we can't pull the prometheus-fips image
-          # For push events, run fips tests (not no-fips) since we have access to the restricted registry
+          # For scheduled/other events, run fips tests since we have access to the restricted registry
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             FIPS_LABEL="no-fips"
           else


### PR DESCRIPTION
## Description

The scheduled integration tests (pr-integration.yml) have been failing consistently because the selfmonitor tests could not pull the prometheus-fips image from the restricted Google Artifact Registry (europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips).

## Root Cause

After the e2e test refactoring in #3013, the google-github-actions/auth step was missing from the selfmonitor job. While the workflow had setup-gcloud and gcloud auth configure-docker steps, these don't work without first authenticating to Google Cloud.

## Fix

Added the Authenticate to Google Cloud step using google-github-actions/auth@v2.1.10 with the GOOGLE_CLOUD_SA_KEY secret. This step runs only for non-pull_request events (schedule, merge_group, workflow_dispatch), allowing scheduled runs to pull the FIPS image and run selfmonitor tests in FIPS mode.
