### PR TITLE
chore: fix prometheus scraping in load test

### DIFF
--- a/hack/load-tests/values.yaml
+++ b/hack/load-tests/values.yaml
@@ -1,3 +1,5 @@
+## values are documented at https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+## to install manually call: helm upgrade --install prometheus prometheus-community/kube-prometheus-stack -n prometheus -f values.yaml
 
 ####### This block configures resource limits for the tooling and disables scaping of them via annotations
 
@@ -76,6 +78,10 @@ prometheus:
       requests:
         cpu: 125m
         memory: 256m
+
+    podMetadata:
+      labels:
+        networking.kyma-project.io/metrics-scraping: allowed
 
 
 ####### This block enabled scrape discovery based on typical prometheus annotations


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The prometheus in the load test setup is not allowed anymore to scrape the telemetry compnents
- adding the required label to the prometheus pod which allows scraping

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
