### PR TITLE
chore: fix flaky test

### DIFF
--- a/test/e2e/logs/shared/resources_test.go
+++ b/test/e2e/logs/shared/resources_test.go
@@ -79,7 +79,7 @@ func TestResources_OTel(t *testing.T) {
 }
 
 func TestResources_FluentBit(t *testing.T) {
-	suite.SetupTestWithOptions(t, []string{suite.LabelLogs, suite.LabelFluentBit}, kubeprep.WithIstio(), kubeprep.WithOverrideFIPSMode(false))
+	suite.SetupTestWithOptions(t, []string{suite.LabelLogs, suite.LabelFluentBit}, kubeprep.WithOverrideFIPSMode(false))
 
 	const hostKey = "host"
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- In https://github.com/kyma-project/telemetry-manager/pull/3031
, the newly added Istio PeerAuthentication resource checks were removed because they caused tests to time out. The Fluent Bit resource test was accidentally omitted, which is fixed in this PR.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
