### PR TITLE
fix: retry the api version migration until it succeeds

### DIFF
--- a/internal/storagemigration/migrator.go
+++ b/internal/storagemigration/migrator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,7 +20,7 @@ import (
 const (
 	oldVersion = "v1alpha1"
 
-	migrationTimeout = 5 * time.Minute
+	retryInterval = 10 * time.Second
 )
 
 var pipelineCRDs = []string{
@@ -44,18 +45,25 @@ func New(c client.Client, logger logr.Logger) *Migrator {
 }
 
 func (m *Migrator) Start(ctx context.Context) error {
-	if err := m.migratePipelinesIfNeeded(ctx); err != nil {
-		// Log the error but don't return it, as we don't want to crash the manager if migration fails.
-		m.logger.Error(err, "migration failed")
-	}
+	for {
+		err := m.migratePipelinesIfNeeded(ctx)
+		if err == nil {
+			return nil
+		}
 
-	return nil
+		m.logger.Error(err, "Migration failed, will retry", "retryInterval", retryInterval)
+
+		select {
+		case <-ctx.Done():
+			m.logger.Info("Migration stopped due to context cancellation")
+			return nil
+		case <-time.After(retryInterval):
+			// Continue with retry
+		}
+	}
 }
 
 func (m *Migrator) migratePipelinesIfNeeded(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, migrationTimeout)
-	defer cancel()
-
 	m.logger.Info("Checking if storage version migration is needed")
 
 	// Collect all CRDs that need migration
@@ -135,6 +143,11 @@ func (m *Migrator) migrateLogPipelines(ctx context.Context) error {
 
 	for i := range list.Items {
 		if err := m.client.Update(ctx, &list.Items[i]); err != nil {
+			// Ignore NotFound errors - the resource was deleted during migration
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
 			return fmt.Errorf("failed to migrate LogPipeline %s: %w", list.Items[i].Name, err)
 		}
 	}
@@ -153,6 +166,11 @@ func (m *Migrator) migrateMetricPipelines(ctx context.Context) error {
 
 	for i := range list.Items {
 		if err := m.client.Update(ctx, &list.Items[i]); err != nil {
+			// Ignore NotFound errors - the resource was deleted during migration
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
 			return fmt.Errorf("failed to migrate MetricPipeline %s: %w", list.Items[i].Name, err)
 		}
 	}
@@ -171,6 +189,11 @@ func (m *Migrator) migrateTracePipelines(ctx context.Context) error {
 
 	for i := range list.Items {
 		if err := m.client.Update(ctx, &list.Items[i]); err != nil {
+			// Ignore NotFound errors - the resource was deleted during migration
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
 			return fmt.Errorf("failed to migrate TracePipeline %s: %w", list.Items[i].Name, err)
 		}
 	}
@@ -189,6 +212,11 @@ func (m *Migrator) migrateTelemetries(ctx context.Context) error {
 
 	for i := range list.Items {
 		if err := m.client.Update(ctx, &list.Items[i]); err != nil {
+			// Ignore NotFound errors - the resource was deleted during migration
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
 			return fmt.Errorf("failed to migrate Telemetry %s/%s: %w", list.Items[i].Namespace, list.Items[i].Name, err)
 		}
 	}

--- a/internal/storagemigration/migrator_test.go
+++ b/internal/storagemigration/migrator_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -569,7 +571,7 @@ func TestClearStoredVersion_CRDNotFound(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to get CRD")
 }
 
-func TestStart_MigrationError_LogsButDoesNotFail(t *testing.T) {
+func TestStart_MigrationError_RetriesUntilContextCancelled(t *testing.T) {
 	scheme := newTestScheme(t)
 
 	// Missing CRDs will cause migration check to fail
@@ -579,9 +581,52 @@ func TestStart_MigrationError_LogsButDoesNotFail(t *testing.T) {
 
 	migrator := New(fakeClient, logr.Discard())
 
-	// Start should not return an error even if migration fails internally
+	// Use a context with cancellation to stop the retry loop
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after a short delay to allow at least one retry attempt
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// Start should return nil when context is canceled (graceful shutdown)
+	err := migrator.Start(ctx)
+	require.NoError(t, err)
+}
+
+func TestStart_MigrationSucceedsAfterRetry(t *testing.T) {
+	scheme := newTestScheme(t)
+
+	// CRDs with v1alpha1 that need migration
+	logCRD := newTestCRD("logpipelines.telemetry.kyma-project.io", []string{"v1alpha1", "v1beta1"})
+	metricCRD := newTestCRD("metricpipelines.telemetry.kyma-project.io", []string{"v1alpha1", "v1beta1"})
+	traceCRD := newTestCRD("tracepipelines.telemetry.kyma-project.io", []string{"v1alpha1", "v1beta1"})
+	telemetryCRDObj := newTestCRD(telemetryCRD, []string{"v1alpha1", "v1beta1"})
+
+	attemptCount := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(logCRD, metricCRD, traceCRD, telemetryCRDObj).
+		WithStatusSubresource(logCRD, metricCRD, traceCRD, telemetryCRDObj).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				attemptCount++
+				// Fail the first attempt, succeed on retry
+				if attemptCount == 1 {
+					return errors.New("transient error")
+				}
+
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	migrator := New(fakeClient, logr.Discard())
+
 	err := migrator.Start(context.Background())
 	require.NoError(t, err)
+	require.GreaterOrEqual(t, attemptCount, 2, "Should have retried at least once")
 }
 
 func TestMigrateLogPipelines_ListError(t *testing.T) {
@@ -771,4 +816,33 @@ func TestMigrateTelemetries_UpdateError(t *testing.T) {
 	err := migrator.migrateTelemetries(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to migrate Telemetry")
+}
+
+func TestMigrateLogPipelines_NotFoundError_NoRetry(t *testing.T) {
+	scheme := newTestScheme(t)
+
+	logPipeline := &telemetryv1beta1.LogPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-log-pipeline",
+		},
+	}
+
+	callCount := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(logPipeline).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.UpdateOption) error {
+				callCount++
+				return apierrors.NewNotFound(telemetryv1beta1.GroupVersion.WithResource("logpipelines").GroupResource(), "test-log-pipeline")
+			},
+		}).
+		Build()
+
+	migrator := New(fakeClient, logr.Discard())
+
+	err := migrator.migrateLogPipelines(context.Background())
+	// NotFound error should not be retried, so migration should succeed (resource was deleted)
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount, "Update should only be called once for NotFound errors")
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Without retries the storage migrator fails if reconciliations happen in parallel. The next time the migrator runs is on the next restart of the migrator. This is obviously not enough. now we retry the migration until it succeeds.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/2729

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
