### PR TITLE
docs: fix links to quick-install

### DIFF
--- a/docs/user/collecting-logs/istio-support.md
+++ b/docs/user/collecting-logs/istio-support.md
@@ -4,7 +4,7 @@ To monitor traffic in your service mesh, configure Istio to send access logs. Th
 
 ## Prerequisites
 
-- You have the Istio module in your cluster. See [Quick Install](https://kyma-project.io/#/02-get-started/01-quick-install).
+- You have the Istio module in your cluster. See [Quick Install](https://kyma-project.io/02-get-started/01-quick-install).
 - You have access to Kyma dashboard. Alternatively, if you prefer CLI, you need [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 ## Context

--- a/docs/user/collecting-traces/istio-support.md
+++ b/docs/user/collecting-traces/istio-support.md
@@ -4,7 +4,7 @@ To get an end-to-end view of requests in your service mesh, configure Istio to s
 
 ## Prerequisites
 
-- You have the Istio module in your cluster. See [Quick Install](https://kyma-project.io/#/02-get-started/01-quick-install).
+- You have the Istio module in your cluster. See [Quick Install](https://kyma-project.io/02-get-started/01-quick-install).
 - You have access to Kyma dashboard. Alternatively, if you prefer CLI, you need [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 ## Context

--- a/docs/user/integration/aws-cloudwatch/README.md
+++ b/docs/user/integration/aws-cloudwatch/README.md
@@ -28,7 +28,7 @@ Because CloudWatch doesn't support native OTLP ingestion for metrics, and OTLP s
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [added](https://kyma-project.io/#/02-get-started/01-quick-install)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [added](https://kyma-project.io/02-get-started/01-quick-install)
 - [Kubectl version that is within one minor version (older or newer) of `kube-apiserver`](https://kubernetes.io/releases/version-skew-policy/#kubectl)
 - AWS account with permissions to create new users and security policies
 - AWS CloudWatch configured with a [LogGroup and LogStream](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html)

--- a/docs/user/integration/dynatrace/README.md
+++ b/docs/user/integration/dynatrace/README.md
@@ -30,7 +30,7 @@ Combined with the Kyma Telemetry module, you can collect custom spans and metric
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [added](https://kyma-project.io/#/02-get-started/01-quick-install)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [added](https://kyma-project.io/02-get-started/01-quick-install)
 - Active Dynatrace environment with permissions to create new access tokens
 - Helm 3.x if you want to deploy the [OpenTelemetry sample application](../opentelemetry-demo/README.md)
 

--- a/docs/user/integration/jaeger/README.md
+++ b/docs/user/integration/jaeger/README.md
@@ -21,7 +21,7 @@ Learn how to use [Jaeger](https://github.com/jaegertracing/helm-charts/tree/main
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/#/02-get-started/01-quick-install)
+- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/02-get-started/01-quick-install)
 - [Kubectl version that is within one minor version (older or newer) of `kube-apiserver`](https://kubernetes.io/releases/version-skew-policy/#kubectl)
 - Helm 3.x
 

--- a/docs/user/integration/k8s-events/README.md
+++ b/docs/user/integration/k8s-events/README.md
@@ -27,7 +27,7 @@ Learn how to collect Kubernetes cluster events and forward them as OTLP  logs to
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/#/02-get-started/01-quick-install)
+- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/02-get-started/01-quick-install)
 - You have set up a `LogPipeline` to send logs to a backend, for example, by following the [SAP CLoud Logging guide](./../sap-cloud-logging/) or [Loki](./../loki/)
 - [Kubectl version that is within one minor version (older or newer) of `kube-apiserver`](https://kubernetes.io/releases/version-skew-policy/#kubectl)
 - Helm 3.x

--- a/docs/user/integration/loki/README.md
+++ b/docs/user/integration/loki/README.md
@@ -27,7 +27,7 @@ Learn how to use [Loki](https://github.com/grafana/loki/tree/main/production/hel
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [added](https://kyma-project.io/#/02-get-started/01-quick-install)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [added](https://kyma-project.io/02-get-started/01-quick-install)
 - [Kubectl version that is within one minor version (older or newer) of `kube-apiserver`](https://kubernetes.io/releases/version-skew-policy/#kubectl)
 - Helm 3.x
 

--- a/docs/user/integration/opentelemetry-demo/README.md
+++ b/docs/user/integration/opentelemetry-demo/README.md
@@ -21,7 +21,7 @@ Learn how to install the OpenTelemetry [demo application](https://github.com/ope
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/#/02-get-started/01-quick-install)
+- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/02-get-started/01-quick-install)
 - The [Telemetry module](../../README.md) is configured with pipelines for traces and metrics, for example, by following the [SAP CLoud Logging guide](./../sap-cloud-logging/) or [Prometheus](./../prometheus/) and [Loki](./../loki/)
 - [Istio Tracing](../../collecting-traces/istio-support.md) is enabled
 - [Kubectl version that is within one minor version (older or newer) of `kube-apiserver`](https://kubernetes.io/releases/version-skew-policy/#kubectl)

--- a/docs/user/integration/prometheus/README.md
+++ b/docs/user/integration/prometheus/README.md
@@ -25,7 +25,7 @@ Learn how to configure the Telemetry module to ingest metrics in a custom [Prome
 ## Prerequisites
 
 - Kyma as the target deployment environment.
-- The [Telemetry module](../../README.md) is added. For details, see [Quick Install](https://kyma-project.io/#/02-get-started/01-quick-install). <!-- This link differs for OS and SKR -->
+- The [Telemetry module](../../README.md) is added. For details, see [Quick Install](https://kyma-project.io/02-get-started/01-quick-install). <!-- This link differs for OS and SKR -->
 - If you want to use Istio metrics, make sure that the [Istio module](https://kyma-project.io/#/istio/user/README) is added. This is mandatory for the use with Kiali.
 <!-- markdown-link-check-disable -->
 - Kubernetes CLI (kubectl) (see [Install the Kubernetes Command Line Tool](https://developers.sap.com/tutorials/cp-kyma-download-cli.html)).

--- a/docs/user/integration/sample-app/README.md
+++ b/docs/user/integration/sample-app/README.md
@@ -24,7 +24,7 @@ For examples using the OTel SDK in a different language, refer to the official [
 ## Prerequisites
 
 - Kyma as the target deployment environment.
-- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/#/02-get-started/01-quick-install).
+- The [Telemetry module](../../README.md) is [added](https://kyma-project.io/02-get-started/01-quick-install).
 
 - [Kubectl version that is within one minor version (older or newer) of `kube-apiserver`](https://kubernetes.io/releases/version-skew-policy/#kubectl).
 

--- a/docs/user/integration/sap-cloud-logging/README.md
+++ b/docs/user/integration/sap-cloud-logging/README.md
@@ -21,7 +21,7 @@ Configure the Telemetry module to send logs, metrics, and traces from your clust
 
 ## Prerequisites
 
-- Kyma as the target deployment environment, with the following modules added (see [Quick Install](https://kyma-project.io/#/02-get-started/01-quick-install)):
+- Kyma as the target deployment environment, with the following modules added (see [Quick Install](https://kyma-project.io/02-get-started/01-quick-install)):
   - Telemetry module
   - To collect data from your Istio service mesh: Istio module (default module)
   - SAP BTP Operator module (default module)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- the quick install links were broken, fixed t

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
