### PR TITLE
docs: fix broken docu link

### DIFF
--- a/docs/user/_sidebar.ts
+++ b/docs/user/_sidebar.ts
@@ -7,7 +7,7 @@ export default [
   { text: 'Set Up the OTLP Input', link: './otlp-input' },
   {
     text: 'Collecting Logs', link: './collecting-logs/README', collapsed: true, items: [
-      { text: 'Configure Application Logs', link: './collecting-logs/application-input' },
+      { text: 'Configure Application Logs', link: './collecting-logs/runtime-input' },
       { text: 'Configure Istio Access Logs', link: './collecting-logs/istio-support' },
     ]
   },


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- beta API removal change the page but did not adjust the sidebar accordingly

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
