### PR TITLE
test: add appLogLevel so that tests don't constantly reconfigure

### DIFF
--- a/test/testkit/kubeprep/manager.go
+++ b/test/testkit/kubeprep/manager.go
@@ -257,6 +257,7 @@ func buildHelmValues(cfg Config, imageOverride string) map[string]any {
 			"container": map[string]any{
 				"env": map[string]any{
 					"operateInFipsMode": cfg.OperateInFIPSMode,
+					"appLogLevel":       "debug",
 				},
 			},
 		},

--- a/test/testkit/kubeprep/reconfigure.go
+++ b/test/testkit/kubeprep/reconfigure.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,6 +75,11 @@ func ensureManagerDeployed(t TestingT, k8sClient client.Client, cfg Config) erro
 	newValues := buildHelmValues(cfg, cfg.ManagerImage)
 	currentValues := getReleaseValues(ctx)
 	valuesChanged := !valuesEqual(currentValues, newValues)
+
+	if valuesChanged {
+		newYAML, _ := yaml.Marshal(newValues)
+		t.Logf("Helm values changed.\nCurrent release values:\n%s\nNew values:\n%s", currentValues, string(newYAML))
+	}
 
 	// If values changed and release exists, decide whether to undeploy first
 	if valuesChanged && releaseExists(ctx) {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- E2E tests constantly delete and redeploy the manager because the cluster state comparison logic is missing the appLogLevel arg in the manager

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
