### PR TITLE
chore: add make targets for local Prometheus and Grafana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ $(POPULATE_IMAGES):
 # Sub-makefile
 include hack/make/provision.mk
 include hack/make/e2e.mk
+include hack/make/monitoring.mk
 
 ##@ General
 

--- a/hack/make/monitoring.mk
+++ b/hack/make/monitoring.mk
@@ -1,0 +1,28 @@
+##@ Monitoring
+
+MONITORING_NAMESPACE ?= monitoring
+
+.PHONY: deploy-monitoring
+deploy-monitoring: $(HELM) ## Deploy Prometheus and Grafana into the monitoring namespace
+	kubectl create ns $(MONITORING_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update
+	$(HELM) repo add grafana https://grafana.github.io/helm-charts --force-update
+	$(HELM) repo update
+	$(HELM) upgrade --install prometheus prometheus-community/prometheus \
+		-n $(MONITORING_NAMESPACE) \
+		-f hack/monitoring/prometheus-values.yaml \
+		--wait
+	$(HELM) upgrade --install grafana grafana/grafana \
+		-n $(MONITORING_NAMESPACE) \
+		-f hack/monitoring/grafana-values.yaml \
+		--wait
+	@echo ""
+	@echo "Monitoring deployed to namespace '$(MONITORING_NAMESPACE)'"
+	@echo "  Grafana:    kubectl port-forward -n $(MONITORING_NAMESPACE) svc/grafana 3000:80"
+	@echo "  Prometheus: kubectl port-forward -n $(MONITORING_NAMESPACE) svc/prometheus-server 9090:80"
+
+.PHONY: undeploy-monitoring
+undeploy-monitoring: $(HELM) ## Remove Prometheus and Grafana from the monitoring namespace
+	$(HELM) uninstall grafana -n $(MONITORING_NAMESPACE) --ignore-not-found
+	$(HELM) uninstall prometheus -n $(MONITORING_NAMESPACE) --ignore-not-found
+	kubectl delete ns $(MONITORING_NAMESPACE) --ignore-not-found

--- a/hack/monitoring/grafana-values.yaml
+++ b/hack/monitoring/grafana-values.yaml
@@ -1,0 +1,32 @@
+## Grafana values for local development monitoring
+## Deployed via: make deploy-monitoring
+
+## Anonymous access - no login required
+grafana.ini:
+  auth.anonymous:
+    enabled: true
+    org_role: Admin
+  auth:
+    disable_login_form: true
+
+## Prometheus datasource (auto-configured)
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://prometheus-server.monitoring.svc.cluster.local
+        access: proxy
+        isDefault: true
+
+## Lightweight defaults for local development
+persistence:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi

--- a/hack/monitoring/prometheus-values.yaml
+++ b/hack/monitoring/prometheus-values.yaml
@@ -1,0 +1,32 @@
+## Prometheus values for local development monitoring
+## Deployed via: make deploy-monitoring
+
+server:
+  ## Add the label required by telemetry-manager network policies to allow scraping
+  podLabels:
+    networking.kyma-project.io/metrics-scraping: allowed
+
+  ## Lightweight defaults for local development
+  retention: "2h"
+  persistentVolume:
+    enabled: false
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+## Disable components not needed for local development
+alertmanager:
+  enabled: false
+
+kube-state-metrics:
+  enabled: false
+
+prometheus-node-exporter:
+  enabled: false
+
+prometheus-pushgateway:
+  enabled: false


### PR DESCRIPTION
## Summary
- Adds `make deploy-monitoring` / `make undeploy-monitoring` targets to deploy Prometheus and Grafana into a `monitoring` namespace via Helm
- Prometheus server pod is labeled with `networking.kyma-project.io/metrics-scraping: allowed` to comply with telemetry-manager network policies
- Grafana runs in anonymous mode (no login) with Prometheus pre-configured as the default datasource
- Lightweight defaults: no persistence, disabled alertmanager/node-exporter/kube-state-metrics/pushgateway