### PR TITLE
fix: gardener has exposed kubelet CA to end user

### DIFF
--- a/internal/otelcollector/config/metricagent/kubeletstats_receivers.go
+++ b/internal/otelcollector/config/metricagent/kubeletstats_receivers.go
@@ -15,8 +15,7 @@ func kubeletStatsReceiver(runtimeResources runtimeResourceSources) *KubeletStats
 	return &KubeletStatsReceiverConfig{
 		CollectionInterval: collectionInterval,
 		AuthType:           "serviceAccount",
-		// This should be fixed with: https://github.com/kyma-project/telemetry-manager/issues/1792
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: false,
 		Endpoint:           fmt.Sprintf("https://${%s}:%d", common.EnvVarCurrentNodeName, portKubelet),
 		MetricGroups:       kubeletStatsMetricGroups(runtimeResources),
 		Metrics: KubeletStatsMetrics{

--- a/internal/otelcollector/config/metricagent/kubeletstats_receivers.go
+++ b/internal/otelcollector/config/metricagent/kubeletstats_receivers.go
@@ -15,6 +15,7 @@ func kubeletStatsReceiver(runtimeResources runtimeResourceSources) *KubeletStats
 	return &KubeletStatsReceiverConfig{
 		CollectionInterval: collectionInterval,
 		AuthType:           "serviceAccount",
+		// This should be fixed with: https://github.com/kyma-project/telemetry-manager/issues/1792
 		InsecureSkipVerify: true,
 		Endpoint:           fmt.Sprintf("https://${%s}:%d", common.EnvVarCurrentNodeName, portKubelet),
 		MetricGroups:       kubeletStatsMetricGroups(runtimeResources),

--- a/internal/otelcollector/config/metricagent/kubeletstats_receivers_test.go
+++ b/internal/otelcollector/config/metricagent/kubeletstats_receivers_test.go
@@ -170,7 +170,7 @@ func TestKubeletStatsReceiverConfig(t *testing.T) {
 				CollectionInterval: "30s",
 				AuthType:           "serviceAccount",
 				Endpoint:           "https://${MY_NODE_NAME}:10250",
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: false,
 				MetricGroups:       test.expectedMetricGroups,
 				Metrics: KubeletStatsMetrics{
 					ContainerCPUUsage:            Metric{Enabled: true},

--- a/internal/otelcollector/config/metricagent/prometheus_receiver.go
+++ b/internal/otelcollector/config/metricagent/prometheus_receiver.go
@@ -136,9 +136,14 @@ func tlsConfig(istioCertPath string) *TLS {
 	istioKeyFile := filepath.Join(istioCertPath, "key.pem")
 
 	return &TLS{
-		CAFile:             istioCAFile,
-		CertFile:           istioCertFile,
-		KeyFile:            istioKeyFile,
+		CAFile:   istioCAFile,
+		CertFile: istioCertFile,
+		KeyFile:  istioKeyFile,
+		// The server side validation of the certificate needs to be disabled as there is no simple way
+		// to inject the istio server side certificate. That is a recommendation by istio itself,
+		// see https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings.
+		// The risk is, that for this internal communication the target cannot be verified and someone could provide a fake target.
+		// However, to be able to do so attacker need to have cluster admin access to the kubernetes cluster, thus attack complexity is high.
 		InsecureSkipVerify: true,
 	}
 }

--- a/internal/otelcollector/config/metricagent/testdata/http-with-custom-path.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/http-with-custom-path.yaml
@@ -109,7 +109,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/http-without-custom-path.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/http-without-custom-path.yaml
@@ -109,7 +109,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/istio-installed-and-disabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/istio-installed-and-disabled.yaml
@@ -123,7 +123,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/istio-installed-and-enabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/istio-installed-and-enabled.yaml
@@ -136,7 +136,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/istio-not-installed-and-disabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/istio-not-installed-and-disabled.yaml
@@ -123,7 +123,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/istio-not-installed-and-enabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/istio-not-installed-and-enabled.yaml
@@ -136,7 +136,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/multiple-inputs-mixed.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/multiple-inputs-mixed.yaml
@@ -162,7 +162,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/runtime-namespace-filters.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/runtime-namespace-filters.yaml
@@ -110,7 +110,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/runtime-only.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/runtime-only.yaml
@@ -109,7 +109,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/runtime-resources-all-disabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/runtime-resources-all-disabled.yaml
@@ -158,7 +158,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups: []
         metrics:
             container.cpu.usage:

--- a/internal/otelcollector/config/metricagent/testdata/runtime-resources-all-enabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/runtime-resources-all-enabled.yaml
@@ -109,7 +109,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/runtime-resources-some-disabled.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/runtime-resources-some-disabled.yaml
@@ -122,7 +122,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
         metrics:

--- a/internal/otelcollector/config/metricagent/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/service-enrichment-otel.yaml
@@ -109,7 +109,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/setup-comprehensive.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/setup-comprehensive.yaml
@@ -138,7 +138,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/user-defined-filters.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/user-defined-filters.yaml
@@ -123,7 +123,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/user-defined-transform-filter.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/user-defined-transform-filter.yaml
@@ -111,7 +111,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/otelcollector/config/metricagent/testdata/user-defined-transforms.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/user-defined-transforms.yaml
@@ -123,7 +123,7 @@ receivers:
         collection_interval: 30s
         auth_type: serviceAccount
         endpoint: https://${MY_NODE_NAME}:10250
-        insecure_skip_verify: true
+        insecure_skip_verify: false
         metric_groups:
             - container
             - pod

--- a/internal/selfmonitor/config/config_builder.go
+++ b/internal/selfmonitor/config/config_builder.go
@@ -39,6 +39,9 @@ func makeAlertConfig(webhookURL string) AlertingConfig {
 				Targets: []string{webhookURL},
 			}},
 			TLSConfig: TLSConfig{
+				// The alert manager is used for reporting the signals for health of pipeline flow. Tampering that
+				// communication cannot cause any availability or confidentiality problems.
+				// Implementing a TLS Certificate would be technically too complex for the gains we get.
 				InsecureSkipVerify: true,
 			},
 		}},


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Gardener has exposed kubelet CA to end user so we can enable TLS verification for `kubelet stats receiver`
- Also add some comments to explain why `insecure_skip_verify is set to false`

Changes refer to particular issues, PRs or documents:

- https://github.com/gardener/gardener/issues/11362
- https://github.com/kyma-project/telemetry-manager/issues/1792

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
