### PR TITLE
docs: add missing body check to the log parser example

### DIFF
--- a/docs/user/filter-and-process/ottl-transform-and-filter/ottl-transform.md
+++ b/docs/user/filter-and-process/ottl-transform-and-filter/ottl-transform.md
@@ -71,7 +71,9 @@ spec:
   transform:
     # Try to parse the body as custom parser (default spring boot logback)
     # 2025-11-12T14:40:36.828Z  INFO 1 --- [demo] [           main] c.e.restservice.RestServiceApplication   : Started Application
-    - statements:
+    - conditions:
+        - log.body != nil
+      statements:
         - merge_maps(log.attributes, ExtractPatterns(log.body,"^(?P<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z)\\s+(?P<level>[A-Z]+)\\s+(?P<pid>\\d+)\\s+---\\s+\\[(?P<mdc>[^\\]]+)\\]\\s+\\[\\s*(?P<thread>[^\\]]+)\\s*\\]\\s+(?P<logger>[^\\s:]+)\\s*:\\s*(?P<msg>.*)$"), "upsert")
 
     # Try to enrich core attributes if custom parsing was successful


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The example causes warnings on logs having no log body, potentially resulting in messages like:
   ```txt
   {"level":"warn","ts":"2026-03-25T11:56:11.111Z","caller":"ottl@v0.147.0/parser.go:410","msg":"failed to execute statement","resource":{"service.instance.id":"579cee3b-af03-41bd-8ab4-2cc1fccd697c","service.name":"kyma-otelcol","service.version":"0.147.0"},"otelcol.component.id":"transform/user-defined-cloud-logging-otlp-logs","otelcol.component.kind":"processor","otelcol.pipeline.id":"logs/cloud-logging-otlp-logs","otelcol.signal":"logs","error":"error getting value in ottl.StandardPMapGetter[*github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog.TransformContext]: expected string but got nil","statement":"merge_maps(log.attributes, ExtractPatterns(log.body,\"^(?P<timestamp>\\\\d{4}-\\\\d{2}-\\\\d{2}T\\\\d{2}:\\\\d{2}:\\\\d{2}\\\\.\\\\d+Z)\\\\s+(?P<level>[A-Z]+)\\\\s+(?P<pid>\\\\d+)\\\\s+---\\\\s+\\\\[(?P<mdc>[^\\\\]]+)\\\\]\\\\s+\\\\[\\\\s*(?P<thread>[^\\\\]]+)\\\\s*\\\\]\\\\s+(?P<logger>[^\\\\s:]+)\\\\s*:\\\\s*(?P<msg>.*)$\"), \"upsert\")"}
   ```
- Added a body check to avoid this nasty warnings

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
