### PR TITLE
chore: release preparation: bump version to 0.0.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 ### Default Environment Variables
 ## General
 # Image URL to use all building/pushing image targets
-ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-ENV_HELM_RELEASE_VERSION=0.0.1-main
+ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:0.0.1
+ENV_HELM_RELEASE_VERSION=0.0.1
 
 # Use k3d tools image from registry to prevent timeouts
 ENV_K3D_IMAGE_TOOLS=europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/k3d-io/k3d-tools:5.8.3
@@ -19,12 +19,12 @@ ENV_ISTIO_VERSION=1.26.4
 ENV_GORELEASER_VERSION=v1.23.0
 
 ## Default Docker Images
-ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main"
+ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260306-9efb5da9"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.3"
-ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main"
+ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.147.0-1.61.0"
 # ENV_OTEL_COLLECTOR_CONTRIB_IMAGE is used for OAuth2 E2E tests only, since they require the OIDC extension, which is not needed in production code.
 ENV_OTEL_COLLECTOR_CONTRIB_IMAGE="otel/opentelemetry-collector-contrib:latest"
-ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main"
+ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260311-e32d5d84"
 ENV_SELFMONITOR_FIPS_IMAGE="europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.10.0"
 ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.147.0"
 ENV_ALPINE_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.3"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: telemetry-manager
 description: Kyma Telemetry Manager Helm Chart
-version: 0.0.1-main
+version: 0.0.1
 type: application
-appVersion: "0.0.1-main"
+appVersion: "0.0.1"
 keywords:
   - kyma
   - telemetry
@@ -17,8 +17,8 @@ maintainers:
     url: https://kyma-project.io
 dependencies:
   - name: experimental
-    version: 0.0.1-main
+    version: 0.0.1
     condition: experimental.enabled
   - name: default
-    version: 0.0.1-main
+    version: 0.0.1
     condition: default.enabled

--- a/helm/charts/default/Chart.yaml
+++ b/helm/charts/default/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: default
 description: Telemetry Manager Default CRDs
-version: 0.0.1-main
+version: 0.0.1

--- a/helm/charts/experimental/Chart.yaml
+++ b/helm/charts/experimental/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: experimental
 description: Telemetry Manager Experimental CRDs
-version: 0.0.1-main
+version: 0.0.1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,15 +18,15 @@ manager:
     env:
       alpineImage: europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.3
       appLogLevel: info
-      fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
+      fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260306-9efb5da9
       fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.3
       gomemlimit: 300MiB
-      otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
-      selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main
+      otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.147.0-1.61.0
+      selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260311-e32d5d84
       operateInFipsMode: false
       selfMonitorFIPSImage: europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.10.0
     image:
-      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:0.0.1
       pullPolicy: "IfNotPresent"
     resources:
       limits:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,11 +1,11 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:0.0.1
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260306-9efb5da9
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.3
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.147.0-1.61.0
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260311-e32d5d84
   - europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.10.0
   - europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.3
 mend:

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -6,8 +6,8 @@ package testkit
 const (
 	DefaultTelemetryGenImage         = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.147.0"
 	DefaultOTelCollectorContribImage = "otel/opentelemetry-collector-contrib:latest"
-	DefaultOTelCollectorImage        = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main"
-	SelfMonitorImage                 = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main"
+	DefaultOTelCollectorImage        = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.147.0-1.61.0"
+	SelfMonitorImage                 = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260311-e32d5d84"
 	SelfMonitorFIPSImage             = "europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.10.0"
 	FaultBackendImage                = "europe-docker.pkg.dev/kyma-project/prod/fault-backend:main"
 	AlpineImage                      = "europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.3"


### PR DESCRIPTION
## Release Preparation for 0.0.1

This PR prepares the release branch for version **0.0.1**.

### Changes
- Updated `ENV_HELM_RELEASE_VERSION` to `0.0.1`
- Updated `ENV_MANAGER_IMAGE` tag to `0.0.1`
- Updated `ENV_OTEL_COLLECTOR_IMAGE` tag to `0.147.0-1.61.0`
- Updated `ENV_SELFMONITOR_IMAGE` tag to `v20260311-e32d5d84`
- Updated `ENV_FLUENTBIT_EXPORTER_IMAGE` tag to `v20260306-9efb5da9`

### Review Checklist
- [ ] Version numbers are correct
- [ ] Generated files are up to date
- [ ] No unintended changes

**Merge this PR to continue with the release workflow.**