### PR TITLE
chore: fix code smells, patch potential bugs, and implement review comments

### DIFF
--- a/internal/otelcollector/config/otlpgateway/config_builder.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder.go
@@ -2,12 +2,15 @@ package otlpgateway
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1beta1 "github.com/kyma-project/telemetry-manager/apis/operator/v1beta1"
 	telemetryv1beta1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1beta1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/common"
+	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
+	commonresources "github.com/kyma-project/telemetry-manager/internal/resources/common"
 )
 
 type buildTraceComponentFunc = common.BuildComponentFunc[*telemetryv1beta1.TracePipeline]
@@ -69,4 +72,51 @@ func (b *Builder) Build(ctx context.Context, opts BuildOptions) (*common.Config,
 	}
 
 	return config, envVars, nil
+}
+
+// ================================================================================
+// SHARED COMPONENT CONFIG BUILDERS
+// ================================================================================
+
+// buildOTLPReceiverConfig returns the shared OTLP receiver configuration used by all signal types.
+//
+//nolint:mnd // port numbers are defined in the ports package
+func buildOTLPReceiverConfig() *common.OTLPReceiverConfig {
+	return &common.OTLPReceiverConfig{
+		Protocols: common.ReceiverProtocols{
+			HTTP: common.Endpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP)},
+			GRPC: common.Endpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC)},
+		},
+	}
+}
+
+// buildMemoryLimiterConfig returns the shared memory limiter configuration used by all signal types.
+//
+//nolint:mnd // hardcoded memory limiter values
+func buildMemoryLimiterConfig() *common.MemoryLimiterConfig {
+	return &common.MemoryLimiterConfig{
+		CheckInterval:        "1s",
+		LimitPercentage:      75,
+		SpikeLimitPercentage: 15,
+	}
+}
+
+// buildK8sAttributesProcessorConfig returns the shared K8s attributes processor configuration.
+func buildK8sAttributesProcessorConfig(opts BuildOptions) any {
+	useOTelServiceEnrichment := opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel
+	return common.K8sAttributesProcessor(opts.Enrichments, useOTelServiceEnrichment)
+}
+
+// buildServiceEnrichmentProcessorConfig returns the shared service enrichment processor configuration.
+func buildServiceEnrichmentProcessorConfig(opts BuildOptions) any {
+	if opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
+		return nil
+	}
+
+	return common.ResolveServiceName()
+}
+
+// buildIstioNoiseFilterProcessorConfig returns the shared Istio noise filter processor configuration.
+func buildIstioNoiseFilterProcessorConfig() *common.IstioNoiseFilterProcessorConfig {
+	return &common.IstioNoiseFilterProcessorConfig{}
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder.go
@@ -78,10 +78,10 @@ func (b *Builder) Build(ctx context.Context, opts BuildOptions) (*common.Config,
 // SHARED COMPONENT CONFIG BUILDERS
 // ================================================================================
 
-// buildOTLPReceiverConfig returns the shared OTLP receiver configuration used by all signal types.
+// otlpReceiverConfig returns the shared OTLP receiver configuration used by all signal types.
 //
 //nolint:mnd // port numbers are defined in the ports package
-func buildOTLPReceiverConfig() *common.OTLPReceiverConfig {
+func otlpReceiverConfig() *common.OTLPReceiverConfig {
 	return &common.OTLPReceiverConfig{
 		Protocols: common.ReceiverProtocols{
 			HTTP: common.Endpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP)},
@@ -90,10 +90,10 @@ func buildOTLPReceiverConfig() *common.OTLPReceiverConfig {
 	}
 }
 
-// buildMemoryLimiterConfig returns the shared memory limiter configuration used by all signal types.
+// memoryLimiterConfig returns the shared memory limiter configuration used by all signal types.
 //
 //nolint:mnd // hardcoded memory limiter values
-func buildMemoryLimiterConfig() *common.MemoryLimiterConfig {
+func memoryLimiterConfig() *common.MemoryLimiterConfig {
 	return &common.MemoryLimiterConfig{
 		CheckInterval:        "1s",
 		LimitPercentage:      75,
@@ -101,14 +101,14 @@ func buildMemoryLimiterConfig() *common.MemoryLimiterConfig {
 	}
 }
 
-// buildK8sAttributesProcessorConfig returns the shared K8s attributes processor configuration.
-func buildK8sAttributesProcessorConfig(opts BuildOptions) any {
+// k8sAttributesProcessorConfig returns the shared K8s attributes processor configuration.
+func k8sAttributesProcessorConfig(opts BuildOptions) any {
 	useOTelServiceEnrichment := opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel
 	return common.K8sAttributesProcessor(opts.Enrichments, useOTelServiceEnrichment)
 }
 
-// buildServiceEnrichmentProcessorConfig returns the shared service enrichment processor configuration.
-func buildServiceEnrichmentProcessorConfig(opts BuildOptions) any {
+// serviceEnrichmentProcessorConfig returns the shared service enrichment processor configuration.
+func serviceEnrichmentProcessorConfig(opts BuildOptions) any {
 	if opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
 		return nil
 	}
@@ -116,7 +116,7 @@ func buildServiceEnrichmentProcessorConfig(opts BuildOptions) any {
 	return common.ResolveServiceName()
 }
 
-// buildIstioNoiseFilterProcessorConfig returns the shared Istio noise filter processor configuration.
-func buildIstioNoiseFilterProcessorConfig() *common.IstioNoiseFilterProcessorConfig {
+// istioNoiseFilterProcessorConfig returns the shared Istio noise filter processor configuration.
+func istioNoiseFilterProcessorConfig() *common.IstioNoiseFilterProcessorConfig {
 	return &common.IstioNoiseFilterProcessorConfig{}
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_logs.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_logs.go
@@ -6,7 +6,6 @@ import (
 
 	telemetryv1beta1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1beta1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/common"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	commonresources "github.com/kyma-project/telemetry-manager/internal/resources/common"
 	sharedtypesutils "github.com/kyma-project/telemetry-manager/internal/utils/sharedtypes"
 )
@@ -60,16 +59,7 @@ func (b *Builder) addLogOTLPReceiver(builder *common.ComponentBuilder[*telemetry
 	return builder.AddReceiver(
 		builder.StaticComponentID(common.ComponentIDOTLPReceiver),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return &common.OTLPReceiverConfig{
-				Protocols: common.ReceiverProtocols{
-					HTTP: common.Endpoint{
-						Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP),
-					},
-					GRPC: common.Endpoint{
-						Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC),
-					},
-				},
-			}
+			return buildOTLPReceiverConfig()
 		},
 	)
 }
@@ -79,11 +69,7 @@ func (b *Builder) addLogMemoryLimiterProcessor(builder *common.ComponentBuilder[
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDMemoryLimiterProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return &common.MemoryLimiterConfig{
-				CheckInterval:        "1s",
-				LimitPercentage:      75,
-				SpikeLimitPercentage: 15,
-			}
+			return buildMemoryLimiterConfig()
 		},
 	)
 }
@@ -117,8 +103,7 @@ func (b *Builder) addLogK8sAttributesProcessor(builder *common.ComponentBuilder[
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			useOTelServiceEnrichment := opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel
-			return common.K8sAttributesProcessor(opts.Enrichments, useOTelServiceEnrichment)
+			return buildK8sAttributesProcessorConfig(opts)
 		},
 	)
 }
@@ -127,7 +112,7 @@ func (b *Builder) addLogIstioNoiseFilterProcessor(builder *common.ComponentBuild
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDIstioNoiseFilterProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return &common.IstioNoiseFilterProcessorConfig{}
+			return buildIstioNoiseFilterProcessorConfig()
 		},
 	)
 }
@@ -173,11 +158,7 @@ func (b *Builder) addLogServiceEnrichmentProcessor(builder *common.ComponentBuil
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDServiceEnrichmentProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			if opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
-				return nil // OTel service enrichment selected, skip this processor
-			}
-
-			return common.ResolveServiceName()
+			return buildServiceEnrichmentProcessorConfig(opts)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_logs.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_logs.go
@@ -59,7 +59,7 @@ func (b *Builder) addLogOTLPReceiver(builder *common.ComponentBuilder[*telemetry
 	return builder.AddReceiver(
 		builder.StaticComponentID(common.ComponentIDOTLPReceiver),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return buildOTLPReceiverConfig()
+			return otlpReceiverConfig()
 		},
 	)
 }
@@ -69,7 +69,7 @@ func (b *Builder) addLogMemoryLimiterProcessor(builder *common.ComponentBuilder[
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDMemoryLimiterProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return buildMemoryLimiterConfig()
+			return memoryLimiterConfig()
 		},
 	)
 }
@@ -103,7 +103,7 @@ func (b *Builder) addLogK8sAttributesProcessor(builder *common.ComponentBuilder[
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return buildK8sAttributesProcessorConfig(opts)
+			return k8sAttributesProcessorConfig(opts)
 		},
 	)
 }
@@ -112,7 +112,7 @@ func (b *Builder) addLogIstioNoiseFilterProcessor(builder *common.ComponentBuild
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDIstioNoiseFilterProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return buildIstioNoiseFilterProcessorConfig()
+			return istioNoiseFilterProcessorConfig()
 		},
 	)
 }
@@ -158,7 +158,7 @@ func (b *Builder) addLogServiceEnrichmentProcessor(builder *common.ComponentBuil
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDServiceEnrichmentProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
-			return buildServiceEnrichmentProcessorConfig(opts)
+			return serviceEnrichmentProcessorConfig(opts)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_metrics.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_metrics.go
@@ -6,7 +6,6 @@ import (
 
 	telemetryv1beta1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1beta1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/common"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	commonresources "github.com/kyma-project/telemetry-manager/internal/resources/common"
 	sharedtypesutils "github.com/kyma-project/telemetry-manager/internal/utils/sharedtypes"
 )
@@ -99,16 +98,7 @@ func (b *Builder) addMetricOTLPReceiver(builder *common.ComponentBuilder[*teleme
 	return builder.AddReceiver(
 		builder.StaticComponentID(common.ComponentIDOTLPReceiver),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			return &common.OTLPReceiverConfig{
-				Protocols: common.ReceiverProtocols{
-					HTTP: common.Endpoint{
-						Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP),
-					},
-					GRPC: common.Endpoint{
-						Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC),
-					},
-				},
-			}
+			return buildOTLPReceiverConfig()
 		},
 	)
 }
@@ -169,11 +159,7 @@ func (b *Builder) addMetricMemoryLimiterProcessor(builder *common.ComponentBuild
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDMemoryLimiterProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			return &common.MemoryLimiterConfig{
-				CheckInterval:        "1s",
-				LimitPercentage:      75,
-				SpikeLimitPercentage: 15,
-			}
+			return buildMemoryLimiterConfig()
 		},
 	)
 }
@@ -204,8 +190,7 @@ func (b *Builder) addMetricK8sAttributesProcessor(builder *common.ComponentBuild
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			useOTelServiceEnrichment := opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel
-			return common.K8sAttributesProcessor(opts.Enrichments, useOTelServiceEnrichment)
+			return buildK8sAttributesProcessorConfig(opts)
 		},
 	)
 }
@@ -214,11 +199,7 @@ func (b *Builder) addMetricServiceEnrichmentProcessor(builder *common.ComponentB
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDServiceEnrichmentProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			if opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
-				return nil
-			}
-
-			return common.ResolveServiceName()
+			return buildServiceEnrichmentProcessorConfig(opts)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_metrics.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_metrics.go
@@ -98,7 +98,7 @@ func (b *Builder) addMetricOTLPReceiver(builder *common.ComponentBuilder[*teleme
 	return builder.AddReceiver(
 		builder.StaticComponentID(common.ComponentIDOTLPReceiver),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			return buildOTLPReceiverConfig()
+			return otlpReceiverConfig()
 		},
 	)
 }
@@ -159,7 +159,7 @@ func (b *Builder) addMetricMemoryLimiterProcessor(builder *common.ComponentBuild
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDMemoryLimiterProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			return buildMemoryLimiterConfig()
+			return memoryLimiterConfig()
 		},
 	)
 }
@@ -190,7 +190,7 @@ func (b *Builder) addMetricK8sAttributesProcessor(builder *common.ComponentBuild
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			return buildK8sAttributesProcessorConfig(opts)
+			return k8sAttributesProcessorConfig(opts)
 		},
 	)
 }
@@ -199,7 +199,7 @@ func (b *Builder) addMetricServiceEnrichmentProcessor(builder *common.ComponentB
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDServiceEnrichmentProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
-			return buildServiceEnrichmentProcessorConfig(opts)
+			return serviceEnrichmentProcessorConfig(opts)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_traces.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_traces.go
@@ -6,7 +6,6 @@ import (
 
 	telemetryv1beta1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1beta1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/common"
-	"github.com/kyma-project/telemetry-manager/internal/otelcollector/ports"
 	commonresources "github.com/kyma-project/telemetry-manager/internal/resources/common"
 )
 
@@ -54,16 +53,7 @@ func (b *Builder) addTraceOTLPReceiver(builder *common.ComponentBuilder[*telemet
 	return builder.AddReceiver(
 		builder.StaticComponentID(common.ComponentIDOTLPReceiver),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return &common.OTLPReceiverConfig{
-				Protocols: common.ReceiverProtocols{
-					HTTP: common.Endpoint{
-						Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP),
-					},
-					GRPC: common.Endpoint{
-						Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC),
-					},
-				},
-			}
+			return buildOTLPReceiverConfig()
 		},
 	)
 }
@@ -73,11 +63,7 @@ func (b *Builder) addTraceMemoryLimiterProcessor(builder *common.ComponentBuilde
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDMemoryLimiterProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return &common.MemoryLimiterConfig{
-				CheckInterval:        "1s",
-				LimitPercentage:      75,
-				SpikeLimitPercentage: 15,
-			}
+			return buildMemoryLimiterConfig()
 		},
 	)
 }
@@ -118,8 +104,7 @@ func (b *Builder) addTraceK8sAttributesProcessor(builder *common.ComponentBuilde
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			useOTelServiceEnrichment := opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel
-			return common.K8sAttributesProcessor(opts.Enrichments, useOTelServiceEnrichment)
+			return buildK8sAttributesProcessorConfig(opts)
 		},
 	)
 }
@@ -128,7 +113,7 @@ func (b *Builder) addTraceIstioNoiseFilterProcessor(builder *common.ComponentBui
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDIstioNoiseFilterProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return &common.IstioNoiseFilterProcessorConfig{}
+			return buildIstioNoiseFilterProcessorConfig()
 		},
 	)
 }
@@ -147,11 +132,7 @@ func (b *Builder) addTraceServiceEnrichmentProcessor(builder *common.ComponentBu
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDServiceEnrichmentProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			if opts.ServiceEnrichment == commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
-				return nil
-			}
-
-			return common.ResolveServiceName()
+			return buildServiceEnrichmentProcessorConfig(opts)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_traces.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_traces.go
@@ -53,7 +53,7 @@ func (b *Builder) addTraceOTLPReceiver(builder *common.ComponentBuilder[*telemet
 	return builder.AddReceiver(
 		builder.StaticComponentID(common.ComponentIDOTLPReceiver),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return buildOTLPReceiverConfig()
+			return otlpReceiverConfig()
 		},
 	)
 }
@@ -63,7 +63,7 @@ func (b *Builder) addTraceMemoryLimiterProcessor(builder *common.ComponentBuilde
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDMemoryLimiterProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return buildMemoryLimiterConfig()
+			return memoryLimiterConfig()
 		},
 	)
 }
@@ -104,7 +104,7 @@ func (b *Builder) addTraceK8sAttributesProcessor(builder *common.ComponentBuilde
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return buildK8sAttributesProcessorConfig(opts)
+			return k8sAttributesProcessorConfig(opts)
 		},
 	)
 }
@@ -113,7 +113,7 @@ func (b *Builder) addTraceIstioNoiseFilterProcessor(builder *common.ComponentBui
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDIstioNoiseFilterProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return buildIstioNoiseFilterProcessorConfig()
+			return istioNoiseFilterProcessorConfig()
 		},
 	)
 }
@@ -132,7 +132,7 @@ func (b *Builder) addTraceServiceEnrichmentProcessor(builder *common.ComponentBu
 	return builder.AddProcessor(
 		builder.StaticComponentID(common.ComponentIDServiceEnrichmentProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
-			return buildServiceEnrichmentProcessorConfig(opts)
+			return serviceEnrichmentProcessorConfig(opts)
 		},
 	)
 }

--- a/internal/reconciler/logpipeline/otel/reconciler.go
+++ b/internal/reconciler/logpipeline/otel/reconciler.go
@@ -220,7 +220,11 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1beta1
 	if isPipelineReconcilable {
 		// Collect secret references and their current versions
 		secretRefs := secretref.GetSecretRefsLogPipeline(pipeline)
-		secretVersions := coordinationconfig.CollectSecretVersions(ctx, r.Client, secretRefs)
+
+		secretVersions, err := coordinationconfig.CollectSecretVersions(ctx, r.Client, secretRefs)
+		if err != nil {
+			return fmt.Errorf("failed to collect secret versions: %w", err)
+		}
 
 		// Write current pipeline reference to OTLP Gateway Coordination ConfigMap
 		logf.FromContext(ctx).V(1).Info("Writing pipeline reference to OTLP Gateway Coordination ConfigMap",

--- a/internal/reconciler/metricpipeline/reconciler.go
+++ b/internal/reconciler/metricpipeline/reconciler.go
@@ -283,7 +283,11 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1beta1
 	if isPipelineReconcilable {
 		// Collect secret references and their current versions
 		secretRefs := secretref.GetSecretRefsMetricPipeline(pipeline)
-		secretVersions := coordinationconfig.CollectSecretVersions(ctx, r.Client, secretRefs)
+
+		secretVersions, err := coordinationconfig.CollectSecretVersions(ctx, r.Client, secretRefs)
+		if err != nil {
+			return fmt.Errorf("failed to collect secret versions: %w", err)
+		}
 
 		// Write current pipeline reference to OTLP Gateway Coordination ConfigMap
 		logf.FromContext(ctx).V(1).Info("Writing pipeline reference to OTLP Gateway Coordination ConfigMap",

--- a/internal/reconciler/otlpgateway/reconciler.go
+++ b/internal/reconciler/otlpgateway/reconciler.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,48 +126,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	if err := r.ensureConfigMapExists(ctx); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if err := r.doReconcile(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// ensureConfigMapExists creates the coordination ConfigMap if it doesn't exist.
-func (r *Reconciler) ensureConfigMapExists(ctx context.Context) error {
-	var cm corev1.ConfigMap
-
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      names.OTLPGatewayCoordinationConfigMap,
-		Namespace: r.globals.TargetNamespace(),
-	}, &cm)
-	if err == nil {
-		return nil
-	}
-
-	if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get configmap: %w", err)
-	}
-
-	cm = corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.OTLPGatewayCoordinationConfigMap,
-			Namespace: r.globals.TargetNamespace(),
-		},
-		Data: map[string]string{
-			coordinationconfig.ConfigMapDataKey: "TracePipeline: []\n",
-		},
-	}
-
-	if err := r.Create(ctx, &cm); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create configmap: %w", err)
-	}
-
-	return nil
 }
 
 // processConfigAndBuildResources handles config building and resource deployment.

--- a/internal/reconciler/otlpgateway/reconciler_test.go
+++ b/internal/reconciler/otlpgateway/reconciler_test.go
@@ -124,18 +124,20 @@ func newReconcileRequest() ctrl.Request {
 	}
 }
 
-func TestReconcile_ConfigMapCreatedIfNotExists(t *testing.T) {
+func TestReconcile_MissingConfigMap_DeletesGateway(t *testing.T) {
 	ctx := context.Background()
-	fakeClient := newTestClient(t)
+	fakeClient := newTestClient(t) // no ConfigMap pre-created
 	mocks := newDefaultMocks()
 
 	mocks.istioStatusChecker.On("IsIstioActive", mock.Anything).Return(false, nil)
-	mocks.gatewayApplierDeleter.On("DeleteResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mocks.gatewayApplierDeleter.On("DeleteResources", mock.Anything, mock.Anything, false).Return(nil)
 
 	sut := newTestReconciler(fakeClient, mocks)
 
 	_, err := sut.Reconcile(ctx, newReconcileRequest())
 	require.NoError(t, err)
+
+	mocks.gatewayApplierDeleter.AssertCalled(t, "DeleteResources", mock.Anything, mock.Anything, false)
 
 	var cm corev1.ConfigMap
 
@@ -143,8 +145,7 @@ func TestReconcile_ConfigMapCreatedIfNotExists(t *testing.T) {
 		Name:      names.OTLPGatewayCoordinationConfigMap,
 		Namespace: "kyma-system",
 	}, &cm)
-	require.NoError(t, err)
-	assert.Contains(t, cm.Data, coordinationconfig.ConfigMapDataKey)
+	require.True(t, apierrors.IsNotFound(err), "ConfigMap should not be created by the OTLP gateway reconciler")
 }
 
 func TestReconcile_NoPipelines_DeletesGateway(t *testing.T) {

--- a/internal/reconciler/tracepipeline/reconciler.go
+++ b/internal/reconciler/tracepipeline/reconciler.go
@@ -240,7 +240,11 @@ func (r *Reconciler) doReconcile(ctx context.Context, pipeline *telemetryv1beta1
 	if isPipelineReconcilable {
 		// Collect secret references and their current versions
 		secretRefs := secretref.GetSecretRefsTracePipeline(pipeline)
-		secretVersions := coordinationconfig.CollectSecretVersions(ctx, r.Client, secretRefs)
+
+		secretVersions, err := coordinationconfig.CollectSecretVersions(ctx, r.Client, secretRefs)
+		if err != nil {
+			return fmt.Errorf("failed to collect secret versions: %w", err)
+		}
 
 		// Write current pipeline reference to OTLP Gateway Coordination ConfigMap
 		logf.FromContext(ctx).V(1).Info("Writing pipeline reference to OTLP Gateway Coordination ConfigMap",

--- a/internal/resources/coordinationconfig/otlp_gateway.go
+++ b/internal/resources/coordinationconfig/otlp_gateway.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	telemetryv1beta1 "github.com/kyma-project/telemetry-manager/apis/telemetry/v1beta1"
 	"github.com/kyma-project/telemetry-manager/internal/otelcollector/config/common"
@@ -20,9 +19,6 @@ import (
 const (
 	// ConfigMapDataKey is the key in the ConfigMap data that contains the pipeline references
 	ConfigMapDataKey = "pipelines.yaml"
-
-	// maxRetries is the maximum number of retry attempts for ConfigMap updates
-	maxRetries = 5
 )
 
 // OTLPGatewayConfigMap represents the structure of the OTLP Gateway coordination ConfigMap.
@@ -114,7 +110,7 @@ func CollectSecretVersions(ctx context.Context, c client.Client, refs []telemetr
 // AddPipelineReference adds or updates a pipeline reference of any type.
 // Uses optimistic locking with retry to handle concurrent updates safely.
 func AddPipelineReference(ctx context.Context, c client.Client, namespace string, pipelineType common.SignalType, input PipelineReferenceInput) error {
-	return updateConfigMapWithRetry(ctx, c, namespace, func(config *OTLPGatewayConfigMap) error {
+	return applyConfigUpdate(ctx, c, namespace, func(config *OTLPGatewayConfigMap) error {
 		pipelineSlice := getPipelineSlice(config, pipelineType)
 		if pipelineSlice == nil {
 			return fmt.Errorf("invalid pipeline type: %s", pipelineType)
@@ -141,7 +137,7 @@ func AddPipelineReference(ctx context.Context, c client.Client, namespace string
 // RemovePipelineReference removes a pipeline reference of any type.
 // Uses optimistic locking with retry. Idempotent operation.
 func RemovePipelineReference(ctx context.Context, c client.Client, namespace string, pipelineType common.SignalType, name string) error {
-	return updateConfigMapWithRetry(ctx, c, namespace, func(config *OTLPGatewayConfigMap) error {
+	return applyConfigUpdate(ctx, c, namespace, func(config *OTLPGatewayConfigMap) error {
 		pipelineSlice := getPipelineSlice(config, pipelineType)
 		if pipelineSlice == nil {
 			return fmt.Errorf("invalid pipeline type: %s", pipelineType)
@@ -175,57 +171,33 @@ func getPipelineSlice(config *OTLPGatewayConfigMap, pipelineType common.SignalTy
 	}
 }
 
-// updateConfigMapWithRetry implements optimistic locking with retry.
-// Retries on 409 Conflict errors with fresh data.
-func updateConfigMapWithRetry(ctx context.Context, c client.Client, namespace string, updateFn func(*OTLPGatewayConfigMap) error) error {
-	log := logf.FromContext(ctx)
-
-	for attempt := range maxRetries {
-		cm, exists, err := getConfigMap(ctx, c, namespace)
-		if err != nil {
-			return err
-		}
-
-		config, err := parseConfig(cm, exists)
-		if err != nil {
-			return err
-		}
-
-		if err := updateFn(&config); err != nil {
-			return fmt.Errorf("update function failed: %w", err)
-		}
-
-		yamlData, err := yaml.Marshal(&config)
-		if err != nil {
-			return fmt.Errorf("failed to marshal config: %w", err)
-		}
-
-		if !exists {
-			if err := createConfigMap(ctx, c, namespace, string(yamlData)); err != nil {
-				if apierrors.IsAlreadyExists(err) {
-					log.V(1).Info("configmap created by another controller, retrying", "attempt", attempt+1)
-					continue
-				}
-
-				return err
-			}
-
-			return nil
-		}
-
-		if err := updateConfigMap(ctx, c, cm, string(yamlData)); err != nil {
-			if apierrors.IsConflict(err) {
-				log.V(1).Info("configmap update conflict, retrying", "attempt", attempt+1)
-				continue
-			}
-
-			return err
-		}
-
-		return nil
+// applyConfigUpdate reads the coordination ConfigMap, applies updateFn to it, and writes it back.
+// Errors are returned directly and propagated to the caller's reconciliation loop.
+func applyConfigUpdate(ctx context.Context, c client.Client, namespace string, updateFn func(*OTLPGatewayConfigMap) error) error {
+	cm, exists, err := getConfigMap(ctx, c, namespace)
+	if err != nil {
+		return err
 	}
 
-	return fmt.Errorf("failed to update configmap after %d attempts", maxRetries)
+	config, err := parseConfig(cm, exists)
+	if err != nil {
+		return err
+	}
+
+	if err := updateFn(&config); err != nil {
+		return fmt.Errorf("update function failed: %w", err)
+	}
+
+	yamlData, err := yaml.Marshal(&config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if !exists {
+		return createConfigMap(ctx, c, namespace, string(yamlData))
+	}
+
+	return updateConfigMap(ctx, c, cm, string(yamlData))
 }
 
 // getConfigMap fetches the ConfigMap and returns whether it exists

--- a/internal/resources/coordinationconfig/otlp_gateway.go
+++ b/internal/resources/coordinationconfig/otlp_gateway.go
@@ -80,8 +80,8 @@ func ReadOTLPGatewayConfig(ctx context.Context, c client.Client, namespace strin
 
 // CollectSecretVersions fetches the resourceVersion for each secret reference.
 // Returns a map of "namespace/name" -> resourceVersion.
-// Missing or inaccessible secrets are omitted from the map.
-func CollectSecretVersions(ctx context.Context, c client.Client, refs []telemetryv1beta1.SecretKeyRef) map[string]string {
+// Secrets that are not found (404) are skipped. Any other error is returned.
+func CollectSecretVersions(ctx context.Context, c client.Client, refs []telemetryv1beta1.SecretKeyRef) (map[string]string, error) {
 	versions := make(map[string]string)
 	seen := make(map[types.NamespacedName]bool)
 
@@ -97,15 +97,18 @@ func CollectSecretVersions(ctx context.Context, c client.Client, refs []telemetr
 
 		var secret corev1.Secret
 		if err := c.Get(ctx, key, &secret); err != nil {
-			// Secret doesn't exist or can't be read - skip it
-			continue
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
+			return nil, fmt.Errorf("failed to get secret %s/%s: %w", ref.Namespace, ref.Name, err)
 		}
 
 		mapKey := fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)
 		versions[mapKey] = secret.ResourceVersion
 	}
 
-	return versions
+	return versions, nil
 }
 
 // AddPipelineReference adds or updates a pipeline reference of any type.

--- a/internal/resources/coordinationconfig/otlp_gateway.go
+++ b/internal/resources/coordinationconfig/otlp_gateway.go
@@ -108,7 +108,7 @@ func CollectSecretVersions(ctx context.Context, c client.Client, refs []telemetr
 }
 
 // AddPipelineReference adds or updates a pipeline reference of any type.
-// Uses optimistic locking with retry to handle concurrent updates safely.
+// Uses optimistic locking to handle concurrent updates safely.
 func AddPipelineReference(ctx context.Context, c client.Client, namespace string, pipelineType common.SignalType, input PipelineReferenceInput) error {
 	return applyConfigUpdate(ctx, c, namespace, func(config *OTLPGatewayConfigMap) error {
 		pipelineSlice := getPipelineSlice(config, pipelineType)
@@ -135,7 +135,7 @@ func AddPipelineReference(ctx context.Context, c client.Client, namespace string
 }
 
 // RemovePipelineReference removes a pipeline reference of any type.
-// Uses optimistic locking with retry. Idempotent operation.
+// Uses optimistic locking to handle concurrent updates safely.
 func RemovePipelineReference(ctx context.Context, c client.Client, namespace string, pipelineType common.SignalType, name string) error {
 	return applyConfigUpdate(ctx, c, namespace, func(config *OTLPGatewayConfigMap) error {
 		pipelineSlice := getPipelineSlice(config, pipelineType)

--- a/internal/resources/coordinationconfig/otlp_gateway_test.go
+++ b/internal/resources/coordinationconfig/otlp_gateway_test.go
@@ -670,13 +670,14 @@ func TestCollectSecretVersions(t *testing.T) {
 			},
 		}
 
-		versions := CollectSecretVersions(context.Background(), fakeClient, refs)
+		versions, err := CollectSecretVersions(context.Background(), fakeClient, refs)
 
+		require.NoError(t, err)
 		require.Len(t, versions, 1)
 		require.Equal(t, "12345", versions["kyma-system/my-secret"])
 	})
 
-	t.Run("SkipsMissingSecret", func(t *testing.T) {
+	t.Run("SkipsNotFoundSecret", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		refs := []telemetryv1beta1.SecretKeyRef{
@@ -687,9 +688,22 @@ func TestCollectSecretVersions(t *testing.T) {
 			},
 		}
 
-		versions := CollectSecretVersions(context.Background(), fakeClient, refs)
+		versions, err := CollectSecretVersions(context.Background(), fakeClient, refs)
 
+		require.NoError(t, err)
 		require.Empty(t, versions)
+	})
+
+	t.Run("ReturnsErrorOnNonNotFoundGetFailure", func(t *testing.T) {
+		refs := []telemetryv1beta1.SecretKeyRef{
+			{Name: "my-secret", Namespace: "kyma-system", Key: "endpoint"},
+		}
+
+		errClient := &errorGetClient{}
+
+		_, err := CollectSecretVersions(context.Background(), errClient, refs)
+
+		require.Error(t, err)
 	})
 
 	t.Run("DeduplicatesByNamespace", func(t *testing.T) {
@@ -720,8 +734,9 @@ func TestCollectSecretVersions(t *testing.T) {
 			},
 		}
 
-		versions := CollectSecretVersions(context.Background(), fakeClient, refs)
+		versions, err := CollectSecretVersions(context.Background(), fakeClient, refs)
 
+		require.NoError(t, err)
 		require.Len(t, versions, 1)
 		require.Equal(t, "12345", versions["kyma-system/my-secret"])
 	})
@@ -749,8 +764,9 @@ func TestCollectSecretVersions(t *testing.T) {
 			{Name: "secret2", Namespace: "default", Key: "key2"},
 		}
 
-		versions := CollectSecretVersions(context.Background(), fakeClient, refs)
+		versions, err := CollectSecretVersions(context.Background(), fakeClient, refs)
 
+		require.NoError(t, err)
 		require.Len(t, versions, 2)
 		require.Equal(t, "111", versions["kyma-system/secret1"])
 		require.Equal(t, "222", versions["default/secret2"])

--- a/internal/resources/coordinationconfig/otlp_gateway_test.go
+++ b/internal/resources/coordinationconfig/otlp_gateway_test.go
@@ -863,70 +863,7 @@ func TestWritePipelineReferenceWithSecretVersions(t *testing.T) {
 	})
 }
 
-// alreadyExistsOnFirstCreateClient returns AlreadyExists on the first Create call,
-// but still performs the actual create so the second loop iteration finds the object via Get.
-type alreadyExistsOnFirstCreateClient struct {
-	client.Client
-
-	createCalled bool
-}
-
-func (c *alreadyExistsOnFirstCreateClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
-	return c.Client.Get(ctx, key, obj, opts...)
-}
-
-func (c *alreadyExistsOnFirstCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if !c.createCalled {
-		c.createCalled = true
-		_ = c.Client.Create(ctx, obj, opts...)
-
-		return apierrors.NewAlreadyExists(schema.GroupResource{Resource: "configmaps"}, obj.GetName())
-	}
-
-	return c.Client.Create(ctx, obj, opts...)
-}
-
-// conflictOnFirstUpdateClient returns Conflict on the first Update call, succeeds on subsequent calls.
-type conflictOnFirstUpdateClient struct {
-	client.Client
-
-	updateCalled bool
-}
-
-func (c *conflictOnFirstUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if !c.updateCalled {
-		c.updateCalled = true
-
-		return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), fmt.Errorf("resource version mismatch"))
-	}
-
-	return c.Client.Update(ctx, obj, opts...)
-}
-
-// alwaysConflictUpdateClient always returns Conflict on Update to exhaust all retries.
-type alwaysConflictUpdateClient struct {
-	client.Client
-}
-
-func (c *alwaysConflictUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), fmt.Errorf("resource version mismatch"))
-}
-
-func TestWritePipelineReference_AlreadyExistsRetry(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-
-	innerFake := fake.NewClientBuilder().WithScheme(scheme).Build()
-	c := &alreadyExistsOnFirstCreateClient{Client: innerFake}
-
-	// First attempt: Create returns AlreadyExists (but object is stored); second attempt: Get still returns NotFound
-	// so it tries to Create again — this time it delegates to the real fake which returns AlreadyExists (object exists).
-	// The retry loop should handle this gracefully.
-	err := AddPipelineReference(context.Background(), c, "kyma-system", common.SignalTypeTrace, PipelineReferenceInput{Name: "my-pipeline", Generation: 1})
-	require.NoError(t, err)
-}
-
-func TestWritePipelineReference_ConflictRetry(t *testing.T) {
+func TestWritePipelineReference_ConflictReturnsError(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 
@@ -941,30 +878,18 @@ func TestWritePipelineReference_ConflictRetry(t *testing.T) {
 	}
 
 	innerFake := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
-	c := &conflictOnFirstUpdateClient{Client: innerFake}
-
-	err := AddPipelineReference(context.Background(), c, "kyma-system", common.SignalTypeTrace, PipelineReferenceInput{Name: "my-pipeline", Generation: 1})
-	require.NoError(t, err)
-}
-
-func TestWritePipelineReference_MaxRetriesExhausted(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      names.OTLPGatewayCoordinationConfigMap,
-			Namespace: "kyma-system",
-		},
-		Data: map[string]string{
-			ConfigMapDataKey: "tracePipelines: []",
-		},
-	}
-
-	innerFake := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
-	c := &alwaysConflictUpdateClient{Client: innerFake}
+	c := &conflictOnUpdateClient{Client: innerFake}
 
 	err := AddPipelineReference(context.Background(), c, "kyma-system", common.SignalTypeTrace, PipelineReferenceInput{Name: "my-pipeline", Generation: 1})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to update configmap after 5 attempts")
+	require.True(t, apierrors.IsConflict(err))
+}
+
+// conflictOnUpdateClient always returns Conflict on Update.
+type conflictOnUpdateClient struct {
+	client.Client
+}
+
+func (c *conflictOnUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.GetName(), fmt.Errorf("resource version mismatch"))
 }


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Remove OTLPGateway reconciler's coordination ConfigMap creation responsibility
- Handle errors when collecting secret versions in pipeline reconcilers
- Remove retry mechanism from coordination ConfigMap update logic (an error will be returned and propagated back to the reconcilers => reconciliation loop will be automatically re-triggered)
- Extract shared OTLP Gateway OTel component config builders (e.g. memory limiter)

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
