### PR TITLE
test: adjust scope version checks in multi-pipeline fanout test

### DIFF
--- a/test/e2e/metrics/shared/multi_pipeline_fanout_test.go
+++ b/test/e2e/metrics/shared/multi_pipeline_fanout_test.go
@@ -111,8 +111,7 @@ func TestMultiPipelineFanout_Agent(t *testing.T) {
 				ContainElement(HaveScopeVersion(
 					SatisfyAny(
 						ContainSubstring("main"),
-						ContainSubstring("1."),
-						ContainSubstring("PR-"),
+						MatchRegexp("[0-9]+.[0-9]+.[0-9]+"),
 					))),
 			),
 		)),
@@ -147,8 +146,7 @@ func TestMultiPipelineFanout_Agent(t *testing.T) {
 				ContainElement(HaveScopeVersion(
 					SatisfyAny(
 						ContainSubstring("main"),
-						ContainSubstring("1."),
-						ContainSubstring("PR-"),
+						MatchRegexp("[0-9]+.[0-9]+.[0-9]+"),
 					),
 				)),
 			),
@@ -213,8 +211,7 @@ func checkInstrumentationScopeAndVersion(t *testing.T, g Gomega, body []byte, sc
 				HaveScopeVersion(
 					SatisfyAny(
 						ContainSubstring("main"),
-						ContainSubstring("1."),
-						ContainSubstring("PR-"),
+						MatchRegexp("[0-9]+.[0-9]+.[0-9]+"),
 					)),
 			)),
 	)), "scope '%v' must be sent to the given backend", scope)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Adjust scope version checks in multi_pipeline_fanout_test. We are checking the scope version in multiple tests and this is the only test which checks it in a different incorrect way.
  - Firstly, it assumes that if it is a release version, then the version will always have the substring `1.` and this will not be true once we have a major version `2.0.0`. 
  - Secondly, it assumes that the scope version might contain the substring `PR-`, but this is not true because the scope version get its value from `git describe --tags` when building the image.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
