### PR TITLE
chore: remove k8s 1.33 support

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ ENV_K3D_IMAGE_TOOLS=europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/k3d
 ENV_K3D_IMAGE_LOADBALANCER=europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/k3d-io/k3d-proxy:5.8.3
 
 ## Gardener
-ENV_GARDENER_K8S_VERSION=1.33
+ENV_GARDENER_K8S_VERSION=1.34
 ENV_GARDENER_MACHINE_TYPE=n1-standard-4
 ENV_GARDENER_MIN_NODES=1
 ENV_GARDENER_MAX_NODES=2

--- a/.github/workflows/gardener-integration.yml
+++ b/.github/workflows/gardener-integration.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false # if one version is not working, continue tests on other versions
       matrix:
-        k8s_version: [1.33,1.34]
+        k8s_version: [1.34]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- removed k8s 1.33 support as it is not used on any landscape anymore
- did not add k8s 1.35 yet to the matrix as it is not supported by gardener yet

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
