### PR TITLE
test: use generic pipeline names in shuffle tests and add oauth2 to metricagent shuffle test

### DIFF
--- a/internal/otelcollector/config/logagent/config_builder_test.go
+++ b/internal/otelcollector/config/logagent/config_builder_test.go
@@ -235,23 +235,23 @@ func TestBuildConfigShuffled(t *testing.T) {
 
 	pipelines := []telemetryv1beta1.LogPipeline{
 		testutils.NewLogPipelineBuilder().
-			WithName("calm-sandbox").
+			WithName("pipeline-1").
 			WithRuntimeInput(true).
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("sandbox-client-id"),
-				testutils.OAuth2ClientSecret("sandbox-client-secret"),
+				testutils.OAuth2ClientID("pipeline-1-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-1-client-secret"),
 				testutils.OAuth2TokenURL("https://auth.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"logs"}),
 			).Build(),
 		testutils.NewLogPipelineBuilder().
-			WithName("calm-france").
+			WithName("pipeline-2").
 			WithRuntimeInput(true).
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("france-client-id"),
-				testutils.OAuth2ClientSecret("france-client-secret"),
-				testutils.OAuth2TokenURL("https://auth.france.example.com/oauth2/token"),
+				testutils.OAuth2ClientID("pipeline-2-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-2-client-secret"),
+				testutils.OAuth2TokenURL("https://auth2.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"logs"}),
 			).Build(),
 	}

--- a/internal/otelcollector/config/loggateway/config_builder_test.go
+++ b/internal/otelcollector/config/loggateway/config_builder_test.go
@@ -221,21 +221,21 @@ func TestBuildConfigShuffled(t *testing.T) {
 
 	pipelines := []telemetryv1beta1.LogPipeline{
 		testutils.NewLogPipelineBuilder().
-			WithName("calm-sandbox").
+			WithName("pipeline-1").
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("sandbox-client-id"),
-				testutils.OAuth2ClientSecret("sandbox-client-secret"),
+				testutils.OAuth2ClientID("pipeline-1-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-1-client-secret"),
 				testutils.OAuth2TokenURL("https://auth.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"logs"}),
 			).Build(),
 		testutils.NewLogPipelineBuilder().
-			WithName("calm-france").
+			WithName("pipeline-2").
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("france-client-id"),
-				testutils.OAuth2ClientSecret("france-client-secret"),
-				testutils.OAuth2TokenURL("https://auth.france.example.com/oauth2/token"),
+				testutils.OAuth2ClientID("pipeline-2-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-2-client-secret"),
+				testutils.OAuth2TokenURL("https://auth2.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"logs"}),
 			).Build(),
 	}

--- a/internal/otelcollector/config/metricagent/config_builder_test.go
+++ b/internal/otelcollector/config/metricagent/config_builder_test.go
@@ -498,32 +498,31 @@ func TestBuildConfigShuffled(t *testing.T) {
 
 	pipelines := []telemetryv1beta1.MetricPipeline{
 		testutils.NewMetricPipelineBuilder().
-			WithName("test1").
-			WithRuntimeInput(true, testutils.IncludeNamespaces("default")).
-			WithPrometheusInput(true, testutils.ExcludeNamespaces("kube-system")).
-			WithIstioInput(false).
-			WithOTLPOutput(testutils.OTLPEndpoint("https://foo")).Build(),
-		testutils.NewMetricPipelineBuilder().
-			WithName("test2").
-			WithRuntimeInput(false).
-			WithPrometheusInput(false).
-			WithIstioInput(true).
-			WithOTLPOutput(testutils.OTLPEndpoint("https://foo")).Build(),
-		testutils.NewMetricPipelineBuilder().
-			WithName("test3").
+			WithName("pipeline-1").
 			WithRuntimeInput(true).
-			WithPrometheusInput(false).
-			WithIstioInput(false).
-			WithOTLPOutput(testutils.OTLPEndpoint("https://bar")).Build(),
+			WithOTLPOutput(testutils.OTLPProtocol("http")).
+			WithOAuth2(
+				testutils.OAuth2ClientID("pipeline-1-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-1-client-secret"),
+				testutils.OAuth2TokenURL("https://auth.example.com/oauth2/token"),
+				testutils.OAuth2Scopes([]string{"metrics"}),
+			).Build(),
+		testutils.NewMetricPipelineBuilder().
+			WithName("pipeline-2").
+			WithRuntimeInput(true).
+			WithOTLPOutput(testutils.OTLPProtocol("http")).
+			WithOAuth2(
+				testutils.OAuth2ClientID("pipeline-2-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-2-client-secret"),
+				testutils.OAuth2TokenURL("https://auth2.example.com/oauth2/token"),
+				testutils.OAuth2Scopes([]string{"metrics"}),
+			).Build(),
 	}
 
-	config1, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[0], pipelines[1], pipelines[2]}, buildOptions)
+	config1, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[0], pipelines[1]}, buildOptions)
 	require.NoError(t, err)
 
-	config2, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[1], pipelines[0], pipelines[2]}, buildOptions)
-	require.NoError(t, err)
-
-	config3, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[2], pipelines[1], pipelines[0]}, buildOptions)
+	config2, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[1], pipelines[0]}, buildOptions)
 	require.NoError(t, err)
 
 	config1YAML, err := yaml.Marshal(config1)
@@ -532,10 +531,5 @@ func TestBuildConfigShuffled(t *testing.T) {
 	config2YAML, err := yaml.Marshal(config2)
 	require.NoError(t, err, "failed to marshal config2")
 
-	config3YAML, err := yaml.Marshal(config3)
-	require.NoError(t, err, "failed to marshal config3")
-
-	require.Equal(t, string(config1YAML), string(config2YAML), "config1 and config2 should be equal regardless of pipeline order")
-	require.Equal(t, string(config2YAML), string(config3YAML), "config2 and config3 should be equal regardless of pipeline order")
-	require.Equal(t, string(config1YAML), string(config3YAML), "config1 and config3 should be equal regardless of pipeline order")
+	require.Equal(t, string(config1YAML), string(config2YAML), "config should be equal regardless of pipeline order")
 }

--- a/internal/otelcollector/config/metricagent/config_builder_test.go
+++ b/internal/otelcollector/config/metricagent/config_builder_test.go
@@ -499,7 +499,9 @@ func TestBuildConfigShuffled(t *testing.T) {
 	pipelines := []telemetryv1beta1.MetricPipeline{
 		testutils.NewMetricPipelineBuilder().
 			WithName("pipeline-1").
-			WithRuntimeInput(true).
+			WithRuntimeInput(true, testutils.IncludeNamespaces("default")).
+			WithPrometheusInput(true, testutils.ExcludeNamespaces("kube-system")).
+			WithIstioInput(false).
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
 				testutils.OAuth2ClientID("pipeline-1-client-id"),
@@ -509,7 +511,9 @@ func TestBuildConfigShuffled(t *testing.T) {
 			).Build(),
 		testutils.NewMetricPipelineBuilder().
 			WithName("pipeline-2").
-			WithRuntimeInput(true).
+			WithRuntimeInput(false).
+			WithPrometheusInput(false).
+			WithIstioInput(true).
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
 				testutils.OAuth2ClientID("pipeline-2-client-id"),
@@ -517,12 +521,22 @@ func TestBuildConfigShuffled(t *testing.T) {
 				testutils.OAuth2TokenURL("https://auth2.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"metrics"}),
 			).Build(),
+		testutils.NewMetricPipelineBuilder().
+			WithName("pipeline-3").
+			WithRuntimeInput(true).
+			WithPrometheusInput(false).
+			WithIstioInput(false).
+			WithOTLPOutput(testutils.OTLPEndpoint("https://backend.example.com")).
+			Build(),
 	}
 
-	config1, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[0], pipelines[1]}, buildOptions)
+	config1, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[0], pipelines[1], pipelines[2]}, buildOptions)
 	require.NoError(t, err)
 
-	config2, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[1], pipelines[0]}, buildOptions)
+	config2, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[1], pipelines[0], pipelines[2]}, buildOptions)
+	require.NoError(t, err)
+
+	config3, _, err := sut.Build(t.Context(), []telemetryv1beta1.MetricPipeline{pipelines[2], pipelines[1], pipelines[0]}, buildOptions)
 	require.NoError(t, err)
 
 	config1YAML, err := yaml.Marshal(config1)
@@ -531,5 +545,10 @@ func TestBuildConfigShuffled(t *testing.T) {
 	config2YAML, err := yaml.Marshal(config2)
 	require.NoError(t, err, "failed to marshal config2")
 
+	config3YAML, err := yaml.Marshal(config3)
+	require.NoError(t, err, "failed to marshal config3")
+
 	require.Equal(t, string(config1YAML), string(config2YAML), "config should be equal regardless of pipeline order")
+	require.Equal(t, string(config2YAML), string(config3YAML), "config should be equal regardless of pipeline order")
+	require.Equal(t, string(config1YAML), string(config3YAML), "config should be equal regardless of pipeline order")
 }

--- a/internal/otelcollector/config/metricgateway/config_builder_test.go
+++ b/internal/otelcollector/config/metricgateway/config_builder_test.go
@@ -261,21 +261,21 @@ func TestBuildConfigShuffled(t *testing.T) {
 
 	pipelines := []telemetryv1beta1.MetricPipeline{
 		testutils.NewMetricPipelineBuilder().
-			WithName("calm-sandbox").
+			WithName("pipeline-1").
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("sandbox-client-id"),
-				testutils.OAuth2ClientSecret("sandbox-client-secret"),
+				testutils.OAuth2ClientID("pipeline-1-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-1-client-secret"),
 				testutils.OAuth2TokenURL("https://auth.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"metrics"}),
 			).Build(),
 		testutils.NewMetricPipelineBuilder().
-			WithName("calm-france").
+			WithName("pipeline-2").
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("france-client-id"),
-				testutils.OAuth2ClientSecret("france-client-secret"),
-				testutils.OAuth2TokenURL("https://auth.france.example.com/oauth2/token"),
+				testutils.OAuth2ClientID("pipeline-2-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-2-client-secret"),
+				testutils.OAuth2TokenURL("https://auth2.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"metrics"}),
 			).Build(),
 	}

--- a/internal/otelcollector/config/tracegateway/config_builder_test.go
+++ b/internal/otelcollector/config/tracegateway/config_builder_test.go
@@ -195,21 +195,21 @@ func TestBuildConfigShuffled(t *testing.T) {
 
 	pipelines := []telemetryv1beta1.TracePipeline{
 		testutils.NewTracePipelineBuilder().
-			WithName("calm-sandbox").
+			WithName("pipeline-1").
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("sandbox-client-id"),
-				testutils.OAuth2ClientSecret("sandbox-client-secret"),
+				testutils.OAuth2ClientID("pipeline-1-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-1-client-secret"),
 				testutils.OAuth2TokenURL("https://auth.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"traces"}),
 			).Build(),
 		testutils.NewTracePipelineBuilder().
-			WithName("calm-france").
+			WithName("pipeline-2").
 			WithOTLPOutput(testutils.OTLPProtocol("http")).
 			WithOAuth2(
-				testutils.OAuth2ClientID("france-client-id"),
-				testutils.OAuth2ClientSecret("france-client-secret"),
-				testutils.OAuth2TokenURL("https://auth.france.example.com/oauth2/token"),
+				testutils.OAuth2ClientID("pipeline-2-client-id"),
+				testutils.OAuth2ClientSecret("pipeline-2-client-secret"),
+				testutils.OAuth2TokenURL("https://auth2.example.com/oauth2/token"),
 				testutils.OAuth2Scopes([]string{"traces"}),
 			).Build(),
 	}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- 

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
