### PR TITLE
chore: release preparation: bump version to 1.62.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 ### Default Environment Variables
 ## General
 # Image URL to use all building/pushing image targets
-ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.62.0
-ENV_HELM_RELEASE_VERSION=1.62.0
+ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.62.1
+ENV_HELM_RELEASE_VERSION=1.62.1
 
 # Use k3d tools image from registry to prevent timeouts
 ENV_K3D_IMAGE_TOOLS=europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/k3d-io/k3d-tools:5.8.3

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: telemetry-manager
 description: Kyma Telemetry Manager Helm Chart
-version: 1.62.0
+version: 1.62.1
 type: application
-appVersion: "1.62.0"
+appVersion: "1.62.1"
 keywords:
   - kyma
   - telemetry
@@ -17,8 +17,8 @@ maintainers:
     url: https://kyma-project.io
 dependencies:
   - name: experimental
-    version: 1.62.0
+    version: 1.62.1
     condition: experimental.enabled
   - name: default
-    version: 1.62.0
+    version: 1.62.1
     condition: default.enabled

--- a/helm/charts/default/Chart.yaml
+++ b/helm/charts/default/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: default
 description: Telemetry Manager Default CRDs
-version: 1.62.0
+version: 1.62.1

--- a/helm/charts/experimental/Chart.yaml
+++ b/helm/charts/experimental/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: experimental
 description: Telemetry Manager Experimental CRDs
-version: 1.62.0
+version: 1.62.1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -26,7 +26,7 @@ manager:
       operateInFipsMode: false
       selfMonitorFIPSImage: europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.10.0
     image:
-      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.62.0
+      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.62.1
       pullPolicy: "IfNotPresent"
     resources:
       limits:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.62.0
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.62.1
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260413-7d161633
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:4.2.3
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.149.0-1.62.0


### PR DESCRIPTION
## Release Preparation for 1.62.1

This PR prepares the release branch for version **1.62.1**.

### Changes
- Updated `ENV_HELM_RELEASE_VERSION` to `1.62.1`
- Updated `ENV_MANAGER_IMAGE` tag to `1.62.1`
- Updated `ENV_OTEL_COLLECTOR_IMAGE` tag to `0.149.0-1.62.0`
- Updated `ENV_SELFMONITOR_IMAGE` tag to `v20260311-e32d5d84`
- Updated `ENV_FLUENTBIT_EXPORTER_IMAGE` tag to `v20260413-7d161633`

### Review Checklist
- [ ] Version numbers are correct
- [ ] Generated files are up to date
- [ ] No unintended changes

**Merge this PR to continue with the release workflow.**