### PR TITLE
chore: bump fluentbit image in cache

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,6 +1,6 @@
 images:
-  - source: "fluent/fluent-bit@sha256:906c8ad6e682f72ea3050da8b3e384a07e3b5db8c093173a9ed9adfe0be5c21a"
-    tag: "4.2.3" # used by the kyma telemetry module
+  - source: "fluent/fluent-bit@sha256:ed82cb1f929b6f5a11c70d34e417e8ae25f130f7cc467460b718a946df84d562"
+    tag: "5.0.3" # used by the kyma telemetry module
   - source: "rancher/k3s@sha256:4607083d3cac07e1ccde7317297271d13ed5f60f35a78f33fcef84858a9f1d69"
     tag: "v1.35.3-k3s1" # used by k3d - current k8s version
   - source: "rancher/k3s@sha256:4607083d3cac07e1ccde7317297271d13ed5f60f35a78f33fcef84858a9f1d69"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- bump fluentbit image in cache to 5.0.3

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
