### PR TITLE
chore: support PR-based self-monitor image in load test workflow

### DIFF
--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -24,6 +24,10 @@ on:
         description: "Duration of the test in seconds"
         required: true
         default: "1200"
+      selfmonitor_image:
+        type: string
+        description: "Self-monitor image override (optional, defaults to the production image)"
+        required: false
 
 run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }}"
 
@@ -91,7 +95,11 @@ jobs:
           GARDENER_MAX_NODES: 2
 
       - name: Deploy telemetry
-        run: hack/deploy-telemetry.sh
+        run: |
+          if [ -n "${{ github.event.inputs.selfmonitor_image }}" ]; then
+            export SELF_MONITOR_IMAGE="${{ github.event.inputs.selfmonitor_image }}"
+          fi
+          hack/deploy-telemetry.sh
 
       - name: Deploy Istio module
         run: hack/deploy-istio.sh

--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -24,10 +24,10 @@ on:
         description: "Duration of the test in seconds"
         required: true
         default: "1200"
-      selfmonitor_image:
-        type: string
-        description: "Self-monitor image override (optional, defaults to the production image)"
-        required: false
+      selfmonitor_pr_image:
+        type: boolean
+        description: "Use self-monitor image built from the PR"
+        default: false
 
 run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }}"
 
@@ -96,8 +96,8 @@ jobs:
 
       - name: Deploy telemetry
         run: |
-          if [ -n "${{ github.event.inputs.selfmonitor_image }}" ]; then
-            export SELF_MONITOR_IMAGE="${{ github.event.inputs.selfmonitor_image }}"
+          if [ "${{ github.event.inputs.selfmonitor_pr_image }}" = "true" ]; then
+            export SELF_MONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/dev/tpi/telemetry-self-monitor:PR-${{ github.event.inputs.pr_number }}"
           fi
           hack/deploy-telemetry.sh
 

--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,7 @@ deploy-no-fips: manifests $(HELM) ## Deploy telemetry manager with FIPS mode dis
 		--set manager.container.image.repository=${MANAGER_IMAGE} \
 		--set manager.container.image.pullPolicy="Always" \
 		--set manager.container.env.operateInFipsMode=false \
+		--set manager.container.env.selfMonitorImage=${SELF_MONITOR_IMAGE} \
 		--namespace kyma-system \
 	| kubectl apply -f -
 

--- a/hack/load-tests/run-load-test.sh
+++ b/hack/load-tests/run-load-test.sh
@@ -194,49 +194,65 @@ function wait_for_resources() {
   echo -e "\nAll resources are ready\n"
 }
 
+function wait_for_rollout() {
+    local namespace=$1
+    local resource=$2
+    local label=${3:-$(echo "$resource" | sed 's|.*/||')}
+    if ! kubectl -n "$namespace" rollout status "$resource" --timeout=60s; then
+        echo -e "\nERROR: Rollout timed out for $resource in namespace $namespace"
+        echo -e "\nPod status:"
+        kubectl -n "$namespace" get pods -o wide
+        echo -e "\nPod descriptions:"
+        kubectl -n "$namespace" describe pods -l "app.kubernetes.io/name=$label"
+        echo -e "\nPod logs:"
+        kubectl -n "$namespace" logs -l "app.kubernetes.io/name=$label" --tail=50 --all-containers
+        exit 1
+    fi
+}
+
 function wait_for_prometheus_resources() {
-    kubectl -n "$PROMETHEUS_NAMESPACE" rollout status statefulset prometheus-prometheus-kube-prometheus-prometheus --timeout=60s
+    wait_for_rollout "$PROMETHEUS_NAMESPACE" "statefulset/prometheus-prometheus-kube-prometheus-prometheus"
 }
 
 function wait_for_trace_resources() {
-    kubectl -n kyma-system rollout status daemonset telemetry-otlp-gateway --timeout=60s
-    kubectl -n ${TRACE_NAMESPACE} rollout status deployment trace-load-generator --timeout=60s
-    kubectl -n ${TRACE_NAMESPACE} rollout status deployment trace-receiver --timeout=60s
+    wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
+    wait_for_rollout ${TRACE_NAMESPACE} "deployment/trace-load-generator"
+    wait_for_rollout ${TRACE_NAMESPACE} "deployment/trace-receiver"
 }
 
 function wait_for_metric_resources() {
-    kubectl -n kyma-system rollout status daemonset telemetry-otlp-gateway --timeout=60s
-    kubectl -n ${METRIC_NAMESPACE} rollout status deployment metric-load-generator --timeout=60s
-    kubectl -n ${METRIC_NAMESPACE} rollout status deployment metric-receiver --timeout=60s
+    wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
+    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-load-generator"
+    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-receiver"
 }
 
 function wait_for_metric_agent_resources() {
-    kubectl -n kyma-system rollout status daemonset telemetry-otlp-gateway --timeout=60s
-    kubectl -n kyma-system rollout status daemonset telemetry-metric-agent --timeout=60s
-    kubectl -n ${METRIC_NAMESPACE} rollout status deployment metric-agent-load-generator --timeout=60s
-    kubectl -n ${METRIC_NAMESPACE} rollout status deployment metric-receiver --timeout=60s
+    wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
+    wait_for_rollout kyma-system "daemonset/telemetry-metric-agent"
+    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-agent-load-generator"
+    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-receiver"
 }
 
 function wait_for_fluentbit_resources() {
-    kubectl -n ${LOG_NAMESPACE} rollout status deployment log-receiver --timeout=60s
-    kubectl -n kyma-system rollout status daemonset telemetry-fluent-bit --timeout=60s
-    kubectl -n ${LOG_NAMESPACE} rollout status deployment log-load-generator --timeout=60s
+    wait_for_rollout ${LOG_NAMESPACE} "deployment/log-receiver"
+    wait_for_rollout kyma-system "daemonset/telemetry-fluent-bit" "fluent-bit"
+    wait_for_rollout ${LOG_NAMESPACE} "deployment/log-load-generator"
 }
 
 function wait_for_otel_log_resources() {
-    kubectl -n ${LOG_NAMESPACE} rollout status deployment log-receiver --timeout=60s
-    kubectl -n ${LOG_NAMESPACE} rollout status deployment log-gateway --timeout=60s
-    kubectl -n ${LOG_NAMESPACE} rollout status deployment log-load-generator --timeout=60s
+    wait_for_rollout ${LOG_NAMESPACE} "deployment/log-receiver"
+    wait_for_rollout ${LOG_NAMESPACE} "deployment/log-gateway"
+    wait_for_rollout ${LOG_NAMESPACE} "deployment/log-load-generator"
 }
 
 function wait_for_selfmonitor_resources() {
-    kubectl -n kyma-system rollout status daemonset telemetry-otlp-gateway --timeout=60s
-    kubectl -n kyma-system rollout status daemonset telemetry-metric-agent --timeout=60s
-    kubectl -n kyma-system rollout status daemonset telemetry-fluent-bit --timeout=60s
-    kubectl -n ${SELF_MONITOR_NAMESPACE} rollout status deployment telemetry-receiver --timeout=60s
-    kubectl -n ${SELF_MONITOR_NAMESPACE} rollout status deployment trace-load-generator --timeout=60s
-    kubectl -n ${SELF_MONITOR_NAMESPACE} rollout status deployment metric-load-generator --timeout=60s
-    kubectl -n ${SELF_MONITOR_NAMESPACE} rollout status deployment metric-agent-load-generator --timeout=60s
+    wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
+    wait_for_rollout kyma-system "daemonset/telemetry-metric-agent"
+    wait_for_rollout kyma-system "daemonset/telemetry-fluent-bit" "fluent-bit"
+    wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/telemetry-receiver"
+    wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/trace-load-generator"
+    wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/metric-load-generator"
+    wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/metric-agent-load-generator"
 }
 
 function cleanup() {


### PR DESCRIPTION
## Summary
- Add a boolean `selfmonitor_pr_image` checkbox to the PR Load Test workflow to use the self-monitor image built from the PR
- Add explicit `--set manager.container.env.selfMonitorImage` to the `deploy-no-fips` Makefile target so the image can be overridden via the `SELF_MONITOR_IMAGE` env var (defaults to the production image from `.env`)
- Print diagnostic output in case a component is not rolling out in time
