### PR TITLE
chore: disable batching in telemetrygen for perf tests and migrate to beta api

### DIFF
--- a/hack/load-tests/log-agent-test-setup.yaml
+++ b/hack/load-tests/log-agent-test-setup.yaml
@@ -1,8 +1,11 @@
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: LogPipeline
 metadata:
   name: load-test-1
 spec:
+  input:
+    runtime:
+      enabled: true
   output:
     otlp:
       endpoint:

--- a/hack/load-tests/log-fluentbit-max-pipeline.yaml
+++ b/hack/load-tests/log-fluentbit-max-pipeline.yaml
@@ -1,8 +1,11 @@
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: LogPipeline
 metadata:
   name: load-test-2
 spec:
+  input:
+    runtime:
+      enabled: true
   output:
     http:
       dedot: true
@@ -11,16 +14,19 @@ spec:
         value: log-receiver.log-load-test
       port: "9880"
       tls:
-        disabled: true
-        skipCertificateValidation: true
+        insecure: true
+        insecureSkipVerify: true
       uri: "/"
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: LogPipeline
 metadata:
   name: load-test-3
 spec:
+  input:
+    runtime:
+      enabled: true
   output:
     http:
       dedot: true
@@ -29,6 +35,6 @@ spec:
         value: log-receiver.log-load-test
       port: "9880"
       tls:
-        disabled: true
-        skipCertificateValidation: true
+        insecure: true
+        insecureSkipVerify: true
       uri: "/"

--- a/hack/load-tests/log-fluentbit-test-setup.yaml
+++ b/hack/load-tests/log-fluentbit-test-setup.yaml
@@ -131,11 +131,14 @@ spec:
     app.kubernetes.io/name: log-receiver
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: LogPipeline
 metadata:
   name: load-test-1
 spec:
+  input:
+    runtime:
+      enabled: true
   output:
     http:
       dedot: true
@@ -144,8 +147,8 @@ spec:
         value: log-receiver.log-load-test
       port: "9880"
       tls:
-        disabled: true
-        skipCertificateValidation: true
+        insecure: true
+        insecureSkipVerify: true
       uri: "/"
 
 ---

--- a/hack/load-tests/metric-agent-test-setup.yaml
+++ b/hack/load-tests/metric-agent-test-setup.yaml
@@ -1,4 +1,4 @@
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: MetricPipeline
 metadata:
   name: load-test-1

--- a/hack/load-tests/metric-load-test-setup.yaml
+++ b/hack/load-tests/metric-load-test-setup.yaml
@@ -1,4 +1,4 @@
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: MetricPipeline
 metadata:
   name: load-test-1
@@ -64,6 +64,7 @@ spec:
           - "10000000"
           - --interval
           - "30s"
+          - --batch=false
           - --telemetry-attributes
           - "key1=\"SimSimulates a client generating metrics. (Stability level: Development)\""
           - --telemetry-attributes

--- a/hack/load-tests/metric-max-pipeline.yaml
+++ b/hack/load-tests/metric-max-pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: MetricPipeline
 metadata:
   name: load-test-2
@@ -12,7 +12,7 @@ spec:
         value: http://metric-receiver.metric-load-test:4317
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: MetricPipeline
 metadata:
   name: load-test-3

--- a/hack/load-tests/otel-logs/base/log-generator.yaml
+++ b/hack/load-tests/otel-logs/base/log-generator.yaml
@@ -69,6 +69,7 @@ spec:
             - "90m"
             - --rate
             - "LOG_RATE_PLACEHOLDER"
+            - --batch=false
             - --body
             - '{"foo":"LOG_CONTENT_PLACEHOLDER"}'
           imagePullPolicy: IfNotPresent

--- a/hack/load-tests/otel-logs/big/log-generator.yaml
+++ b/hack/load-tests/otel-logs/big/log-generator.yaml
@@ -69,6 +69,7 @@ spec:
             - "90m"
             - --rate
             - "LOG_RATE"
+            - --batch=false
             - --body
             - '{"foo":"LOG_CONTENT"}'
           imagePullPolicy: IfNotPresent

--- a/hack/load-tests/run-load-test.sh
+++ b/hack/load-tests/run-load-test.sh
@@ -3,6 +3,7 @@
 # standard bash error handling
 set -o nounset  # treat unset variables as an error and exit immediately.
 set -o errexit  # exit immediately when a command fails.
+set -E          # ensure ERR trap is inherited by functions, command substitutions, and subshells.
 set -o pipefail # prevents errors in a pipeline from being masked
 
 source .env
@@ -194,10 +195,11 @@ function wait_for_resources() {
 }
 
 function wait_for_rollout() {
+    echo -e "\nWaiting for rollout of $2 in namespace $1"
     local namespace=$1
     local resource=$2
     local label=${3:-$(echo "$resource" | sed 's|.*/||')}
-    if ! kubectl -n "$namespace" rollout status "$resource" --timeout=90s; then
+    if ! kubectl -n "$namespace" rollout status "$resource" --timeout=60s; then
         echo -e "\nERROR: Rollout timed out for $resource in namespace $namespace"
         echo -e "\nPod status:"
         kubectl -n "$namespace" get pods -o wide

--- a/hack/load-tests/self-monitor-test-setup.yaml
+++ b/hack/load-tests/self-monitor-test-setup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: self-monitor-load-test
 
 ---
-apiVersion: operator.kyma-project.io/v1alpha1
+apiVersion: operator.kyma-project.io/v1beta1
 kind: Telemetry
 metadata:
   labels:
@@ -17,89 +17,77 @@ metadata:
   namespace: kyma-system
 spec: {}
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: LogPipeline
-metadata:
-  name: load-test-1
-spec:
-  output:
-    http:
-      dedot: true
-      format: json
-      host:
-        value: telemetry-receiver.self-monitor-load-test
-      port: "9880"
-      tls:
-        disabled: true
-        skipCertificateValidation: true
-      uri: "/"
-
----
-apiVersion: telemetry.kyma-project.io/v1alpha1
-kind: LogPipeline
-metadata:
-  name: load-test-2
-spec:
-  output:
-    http:
-      dedot: true
-      format: json
-      host:
-        value: telemetry-receiver.self-monitor-load-test
-      port: "9880"
-      tls:
-        disabled: true
-        skipCertificateValidation: true
-      uri: "/"
-
----
-apiVersion: telemetry.kyma-project.io/v1alpha1
-kind: LogPipeline
-metadata:
-  name: load-test-3
-spec:
-  output:
-    http:
-      dedot: true
-      format: json
-      host:
-        value: telemetry-receiver.self-monitor-load-test
-      port: "9880"
-      tls:
-        disabled: true
-        skipCertificateValidation: true
-      uri: "/"
-
----
-apiVersion: telemetry.kyma-project.io/v1alpha1
-kind: MetricPipeline
 metadata:
   name: load-test-1
 spec:
   input:
     runtime:
       enabled: true
-    prometheus:
-      enabled: true
-    istio:
-      enabled: true
   output:
-    otlp:
+    http:
+      dedot: true
+      format: json
+      host:
+        value: telemetry-receiver.self-monitor-load-test
+      port: "9880"
       tls:
         insecure: true
         insecureSkipVerify: true
-      endpoint:
-        value: http://telemetry-receiver.self-monitor-load-test:4317
+      uri: "/"
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
-kind: MetricPipeline
+apiVersion: telemetry.kyma-project.io/v1beta1
+kind: LogPipeline
 metadata:
   name: load-test-2
 spec:
   input:
     runtime:
       enabled: true
+  output:
+    http:
+      dedot: true
+      format: json
+      host:
+        value: telemetry-receiver.self-monitor-load-test
+      port: "9880"
+      tls:
+        insecure: true
+        insecureSkipVerify: true
+      uri: "/"
+
+---
+apiVersion: telemetry.kyma-project.io/v1beta1
+kind: LogPipeline
+metadata:
+  name: load-test-3
+spec:
+  input:
+    runtime:
+      enabled: true
+  output:
+    http:
+      dedot: true
+      format: json
+      host:
+        value: telemetry-receiver.self-monitor-load-test
+      port: "9880"
+      tls:
+        insecure: true
+        insecureSkipVerify: true
+      uri: "/"
+
+---
+apiVersion: telemetry.kyma-project.io/v1beta1
+kind: MetricPipeline
+metadata:
+  name: load-test-1
+spec:
+  input:
+    runtime:
+      enabled: true
     prometheus:
       enabled: true
     istio:
@@ -113,7 +101,28 @@ spec:
         value: http://telemetry-receiver.self-monitor-load-test:4317
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
+kind: MetricPipeline
+metadata:
+  name: load-test-2
+spec:
+  input:
+    runtime:
+      enabled: true
+    prometheus:
+      enabled: true
+    istio:
+      enabled: true
+  output:
+    otlp:
+      tls:
+        insecure: true
+        insecureSkipVerify: true
+      endpoint:
+        value: http://telemetry-receiver.self-monitor-load-test:4317
+
+---
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: MetricPipeline
 metadata:
   name: load-test-3
@@ -135,7 +144,7 @@ spec:
 
 ---
 
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: load-test-1
@@ -149,7 +158,7 @@ spec:
         value: http://telemetry-receiver.self-monitor-load-test:4317
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: load-test-2
@@ -163,7 +172,7 @@ spec:
         value: http://telemetry-receiver.self-monitor-load-test:4317
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: load-test-3
@@ -363,6 +372,7 @@ spec:
             - "10000000"
             - --interval
             - "30s"
+            - --batch=false
             - --telemetry-attributes
             - "key1=\"SimSimulates a client generating metrics. (Stability level: Development)\""
             - --telemetry-attributes
@@ -387,9 +397,9 @@ spec:
           name: telemetrygen
           resources:
             limits:
-              memory: 256Mi
+              memory: 300Mi
             requests:
-              memory: 256Mi
+              memory: 300Mi
 
 ---
 apiVersion: apps/v1

--- a/hack/load-tests/trace-load-test-setup.yaml
+++ b/hack/load-tests/trace-load-test-setup.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: load-test-1

--- a/hack/load-tests/trace-max-pipeline.yaml
+++ b/hack/load-tests/trace-max-pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: load-test-2
@@ -12,7 +12,7 @@ spec:
         value: http://trace-receiver.trace-load-test:4317
 
 ---
-apiVersion: telemetry.kyma-project.io/v1alpha1
+apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: load-test-3


### PR DESCRIPTION


## Description

Changes proposed in this pull request (what was done and why):

- migrated perf tests to beta API
- disabled batching for metrics and load generator which got introduced by recent telemetrygen bump and caused OOM

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
