### PR TITLE
chore: increased timeout and order of component rollout in perf test

### DIFF
--- a/hack/load-tests/run-load-test.sh
+++ b/hack/load-tests/run-load-test.sh
@@ -199,7 +199,7 @@ function wait_for_rollout() {
     local namespace=$1
     local resource=$2
     local label=${3:-$(echo "$resource" | sed 's|.*/||')}
-    if ! kubectl -n "$namespace" rollout status "$resource" --timeout=60s; then
+    if ! kubectl -n "$namespace" rollout status "$resource" --timeout=90s; then
         echo -e "\nERROR: Rollout timed out for $resource in namespace $namespace"
         echo -e "\nPod status:"
         kubectl -n "$namespace" get pods -o wide
@@ -216,22 +216,22 @@ function wait_for_prometheus_resources() {
 }
 
 function wait_for_trace_resources() {
+    wait_for_rollout ${TRACE_NAMESPACE} "deployment/trace-receiver"
     wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
     wait_for_rollout ${TRACE_NAMESPACE} "deployment/trace-load-generator"
-    wait_for_rollout ${TRACE_NAMESPACE} "deployment/trace-receiver"
 }
 
 function wait_for_metric_resources() {
+    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-receiver"
     wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
     wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-load-generator"
-    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-receiver"
 }
 
 function wait_for_metric_agent_resources() {
+    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-receiver"
     wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
     wait_for_rollout kyma-system "daemonset/telemetry-metric-agent"
     wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-agent-load-generator"
-    wait_for_rollout ${METRIC_NAMESPACE} "deployment/metric-receiver"
 }
 
 function wait_for_fluentbit_resources() {
@@ -247,10 +247,10 @@ function wait_for_otel_log_resources() {
 }
 
 function wait_for_selfmonitor_resources() {
+  wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/telemetry-receiver"
     wait_for_rollout kyma-system "daemonset/telemetry-otlp-gateway"
     wait_for_rollout kyma-system "daemonset/telemetry-metric-agent"
     wait_for_rollout kyma-system "daemonset/telemetry-fluent-bit" "fluent-bit"
-    wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/telemetry-receiver"
     wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/trace-load-generator"
     wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/metric-load-generator"
     wait_for_rollout ${SELF_MONITOR_NAMESPACE} "deployment/metric-agent-load-generator"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- changed order of components to first have the receiver running, then the agent and then the generator, to avoid unneeded unreachability situations
- increased the component timeout as fluentbit seem to require more time

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
