### PR TITLE
chore: allow export failures in load-generators of perf tests

### DIFF
--- a/hack/load-tests/metric-load-test-setup.yaml
+++ b/hack/load-tests/metric-load-test-setup.yaml
@@ -52,6 +52,7 @@ spec:
           args:
           - metrics
           - --otlp-insecure
+          - --allow-export-failures
           - --otlp-endpoint
           - "telemetry-otlp-metrics.kyma-system:4317"
           - --otlp-attributes

--- a/hack/load-tests/otel-logs/base/log-generator.yaml
+++ b/hack/load-tests/otel-logs/base/log-generator.yaml
@@ -59,6 +59,7 @@ spec:
             - --severity-text
             - fatal
             - --otlp-insecure
+            - --allow-export-failures
             - --otlp-endpoint
             - "log-gateway:4317"
             - --otlp-attributes

--- a/hack/load-tests/otel-logs/big/log-generator.yaml
+++ b/hack/load-tests/otel-logs/big/log-generator.yaml
@@ -59,6 +59,7 @@ spec:
             - --severity-text
             - fatal
             - --otlp-insecure
+            - --allow-export-failures
             - --otlp-endpoint
             - "log-gateway:4317"
             - --otlp-attributes

--- a/hack/load-tests/self-monitor-test-setup.yaml
+++ b/hack/load-tests/self-monitor-test-setup.yaml
@@ -360,6 +360,7 @@ spec:
           args:
             - metrics
             - --otlp-insecure
+            - --allow-export-failures
             - --otlp-endpoint
             - "telemetry-otlp-metrics.kyma-system:4317"
             - --otlp-attributes
@@ -488,6 +489,7 @@ spec:
           args:
             - traces
             - --otlp-insecure
+            - --allow-export-failures
             - --otlp-endpoint
             - "telemetry-otlp-traces.kyma-system:4317"
             - --otlp-attributes

--- a/hack/load-tests/trace-load-test-setup.yaml
+++ b/hack/load-tests/trace-load-test-setup.yaml
@@ -52,6 +52,7 @@ spec:
           args:
           - traces
           - --otlp-insecure
+          - --allow-export-failures
           - --otlp-endpoint
           - "telemetry-otlp-traces.kyma-system:4317"
           - --otlp-attributes


### PR DESCRIPTION
## Description

After introducing the gateways as DaemonSet with VPA, the VPA takes time to upscale and will cause backpressure to clients. The telemetrygen as client cannot handle it:

The telemetrygen containers exit with code 1 (not OOMKilled — that would be exit code 137). The crash is caused by telemetrygen's behavior: any worker that hits an export error calls log.Fatal(), which immediately terminates the process.
From the logs, there are two error types:
"no healthy upstream"— Istio envoy has no available upstream (the VirtualService injects 70% faults)
"data refused due to high memory usage"— the OTel Collector gateway's memory limiter is rejecting data
The relevant telemetrygen code (metrics/worker.go:230) does this: when a gRPC export call returns an error, the worker logs at FATAL level, which in Go's zap logger calls os.Exit(1). There's no retry, no backoff — a single failed export kills the entire process.
So the sequence is:
Metric-load-generator pods start sending at 10M metrics/sec with 100 workers
The gateway's memory limiter kicks in OR Istio's fault injection returns 503
The first worker that encounters the error hitslog.Fatal→ process exits immediately
Kubernetes restarts → same thing happens → CrashLoopBackOff
This is by design in telemetrygen — it's not a resilient producer, it's a "best-effort blast" tool. It treats any export failure as fatal rather than retrying. No healthz probe is involved; the process simply dies.
If you want the load generators to survive backpressure and keep pushing, you'd need to either use a different tool (like an OTel Collector with a loadgenerator receiver that has retry/queuing) or accept that CrashLoopBackOff is the expected steady state under fault injection.

There is a flag for this: --allow-export-failures
When set, telemetrygen logs export errors at ERROR level and continues instead of calling log.Fatal. It's exactly what you need here — the metric-load-generator will keep pushing despite rejections from the gateway.

Changes proposed in this pull request (what was done and why):

- added the flag for all load-generators

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
