### PR TITLE
chore: allow to skip deletion of load test cluster after test is executed

### DIFF
--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -33,7 +33,7 @@ on:
         description: "Skip deletion of test resources and cluster after test execution"
         default: false
 
-run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }} (scripts from ${{ github.ref_name }})"
+run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }}"
 
 env:
   MANAGER_IMAGE: europe-docker.pkg.dev/kyma-project/dev/telemetry-manager:PR-${{ github.event.inputs.pr_number }}
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.ref }}
+          ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
           repository: ${{ github.repository }}
       - id: set-matrix
         run: |
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.ref }}
+          ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
           repository: ${{ github.repository }}
 
       - name: Setup Golang
@@ -138,7 +138,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.ref }}
+          ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
           repository: ${{ github.repository }}
       - name: Download results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -28,6 +28,10 @@ on:
         type: boolean
         description: "Use self-monitor image built from the PR"
         default: false
+      skip_deletion:
+        type: boolean
+        description: "Skip deletion of test resources and cluster after test execution"
+        default: false
 
 run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }}"
 
@@ -105,7 +109,12 @@ jobs:
         run: hack/deploy-istio.sh
 
       - name: Run load test
-        run: hack/load-tests/run-load-test.sh -n ${{ matrix.name }} -t ${{ matrix.type }} -m ${{ matrix.multi }} -b ${{ matrix.backpressure }} -d ${{ github.event.inputs.duration }} -o "${{ matrix.overlay }}"
+        run: |
+          SKIP_DELETION_FLAG=""
+          if [ "${{ github.event.inputs.skip_deletion }}" = "true" ]; then
+            SKIP_DELETION_FLAG="-k"
+          fi
+          hack/load-tests/run-load-test.sh -n ${{ matrix.name }} -t ${{ matrix.type }} -m ${{ matrix.multi }} -b ${{ matrix.backpressure }} -d ${{ github.event.inputs.duration }} -o "${{ matrix.overlay }}" $SKIP_DELETION_FLAG
 
       - name: Upload results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -116,8 +125,8 @@ jobs:
 
       - name: Deprovision gardener cluster
         run: make deprovision-gardener
-        # always run the deprovision step, even if the previous steps failed
-        if: always()
+        # always run the deprovision step, even if the previous steps failed, unless skip_deletion is enabled
+        if: ${{ always() && github.event.inputs.skip_deletion != 'true' }}
         env:
           GARDENER_SA_PATH: /tmp/gardener-sa.yaml
 

--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -33,7 +33,7 @@ on:
         description: "Skip deletion of test resources and cluster after test execution"
         default: false
 
-run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }}"
+run-name: "Load Test for ${{ inputs.image }} on PR-${{ inputs.pr_number }} (scripts from ${{ github.ref_name }})"
 
 env:
   MANAGER_IMAGE: europe-docker.pkg.dev/kyma-project/dev/telemetry-manager:PR-${{ github.event.inputs.pr_number }}
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
+          ref: ${{ github.ref }}
           repository: ${{ github.repository }}
       - id: set-matrix
         run: |
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
+          ref: ${{ github.ref }}
           repository: ${{ github.repository }}
 
       - name: Setup Golang
@@ -138,7 +138,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: "refs/pull/${{ github.event.inputs.pr_number }}/head"
+          ref: ${{ github.ref }}
           repository: ${{ github.repository }}
       - name: Download results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/hack/load-tests/run-load-test.sh
+++ b/hack/load-tests/run-load-test.sh
@@ -26,6 +26,7 @@ LOG_RATE=1000
 PROMAPI=""
 DOMAIN=""
 OVERLAY=""
+SKIP_CLEANUP="false"
 
 function help() {
     echo "Usage: $0 -m <max_pipeline> -b <backpressure_test> -n <test_name> -t <test_target> -d <test_duration> -r <log_rate> -s <log_size>"
@@ -38,10 +39,11 @@ function help() {
     echo "  -r <log_rate>             Rate of log generation in logs-otel test"
     echo "  -s <log_size>             Size of log in logs-otel test"
     echo "  -o <config>               Use alternative overlay (batch) for logs-otel test"
+    echo "  -k                        Skip cleanup/deletion of test resources after test execution"
     exit 1
 }
 
-while getopts m:b:n:t:d:r:s:o: flag; do
+while getopts m:b:n:t:d:r:s:o:k flag; do
     case "$flag" in
         m) MAX_PIPELINE="${OPTARG}" ;;
         b) BACKPRESSURE_TEST="${OPTARG}" ;;
@@ -51,6 +53,7 @@ while getopts m:b:n:t:d:r:s:o: flag; do
         r) LOG_RATE=${OPTARG} ;;
         s) LOG_SIZE=${OPTARG} ;;
         o) OVERLAY=${OPTARG} ;;
+        k) SKIP_CLEANUP="true" ;;
         *) help ;;
     esac
 done
@@ -75,6 +78,7 @@ function print_config() {
     echo "  Log Rate: $LOG_RATE"
     echo "  Log Size: $LOG_SIZE"
     echo "  Overlay: $OVERLAY"
+    echo "  Skip Cleanup: $SKIP_CLEANUP"
     echo "  Results File: $RESULTS_FILE"
 }
 
@@ -307,8 +311,12 @@ EOF
 
     echo "$template" | jq . | tee -a "$RESULTS_FILE"
 
-    helm delete -n "$PROMETHEUS_NAMESPACE" "$HELM_PROM_RELEASE"
-    kubectl delete namespace "$PROMETHEUS_NAMESPACE"
+    if [[ "$SKIP_CLEANUP" == "false" ]]; then
+      helm delete -n "$PROMETHEUS_NAMESPACE" "$HELM_PROM_RELEASE"
+      kubectl delete namespace "$PROMETHEUS_NAMESPACE"
+    else
+      echo -e "Skipping cleanup of Prometheus stack (SKIP_CLEANUP=true)"
+    fi
 }
 
 function get_result_and_cleanup_trace() {
@@ -333,14 +341,18 @@ function get_result_and_cleanup_trace() {
     kill %1
   fi
 
-  if [[ "$MAX_PIPELINE" == "true" ]]; then
-    kubectl delete -f hack/load-tests/trace-max-pipeline.yaml
-  fi
-  if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
-    kubectl delete -f hack/load-tests/trace-backpressure-config.yaml
-  fi
+  if [[ "$SKIP_CLEANUP" == "false" ]]; then
+    if [[ "$MAX_PIPELINE" == "true" ]]; then
+      kubectl delete -f hack/load-tests/trace-max-pipeline.yaml
+    fi
+    if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
+      kubectl delete -f hack/load-tests/trace-backpressure-config.yaml
+    fi
 
-  kubectl delete -f hack/load-tests/trace-load-test-setup.yaml
+    kubectl delete -f hack/load-tests/trace-load-test-setup.yaml
+  else
+    echo -e "Skipping cleanup of test resources (SKIP_CLEANUP=true)"
+  fi
 }
 
 function get_result_and_cleanup_metric() {
@@ -365,15 +377,19 @@ function get_result_and_cleanup_metric() {
       kill %1
     fi
 
-    if [[ "$MAX_PIPELINE" == "true" ]]; then
-      kubectl delete -f hack/load-tests/metric-max-pipeline.yaml
-    fi
+    if [[ "$SKIP_CLEANUP" == "false" ]]; then
+      if [[ "$MAX_PIPELINE" == "true" ]]; then
+        kubectl delete -f hack/load-tests/metric-max-pipeline.yaml
+      fi
 
-    if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
-      kubectl delete -f hack/load-tests/metric-backpressure-config.yaml
-    fi
+      if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
+        kubectl delete -f hack/load-tests/metric-backpressure-config.yaml
+      fi
 
-    kubectl delete -f hack/load-tests/metric-load-test-setup.yaml
+      kubectl delete -f hack/load-tests/metric-load-test-setup.yaml
+    else
+      echo -e "Skipping cleanup of test resources (SKIP_CLEANUP=true)"
+    fi
 }
 
 function get_result_and_cleanup_metricagent() {
@@ -399,10 +415,14 @@ function get_result_and_cleanup_metricagent() {
       kill %1
     fi
 
-    if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
-      kubectl delete -f hack/load-tests/metric-agent-backpressure-config.yaml
+    if [[ "$SKIP_CLEANUP" == "false" ]]; then
+      if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
+        kubectl delete -f hack/load-tests/metric-agent-backpressure-config.yaml
+      fi
+      kubectl delete -f hack/load-tests/metric-agent-test-setup.yaml
+    else
+      echo -e "Skipping cleanup of test resources (SKIP_CLEANUP=true)"
     fi
-    kubectl delete -f hack/load-tests/metric-agent-test-setup.yaml
 }
 
 function get_result_and_cleanup_log_otel() {
@@ -428,10 +448,14 @@ function get_result_and_cleanup_log_otel() {
     kill %1
   fi
 
-  if [[ "$OVERLAY" == "batch" ]]; then
-    kubectl delete -k hack/load-tests/otel-logs/batch
+  if [[ "$SKIP_CLEANUP" == "false" ]]; then
+    if [[ "$OVERLAY" == "batch" ]]; then
+      kubectl delete -k hack/load-tests/otel-logs/batch
+    else
+      kubectl delete -k hack/load-tests/otel-logs/base
+    fi
   else
-    kubectl delete -k hack/load-tests/otel-logs/base
+    echo -e "Skipping cleanup of test resources (SKIP_CLEANUP=true)"
   fi
 }
 
@@ -462,14 +486,18 @@ function get_result_and_cleanup_fluentbit() {
     kill %1
   fi
 
-  if [[ "$MAX_PIPELINE" == "true" ]]; then
-    kubectl delete -f hack/load-tests/log-fluentbit-max-pipeline.yaml
-  fi
-  if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
-    kubectl delete -f hack/load-tests/log-fluentbit-backpressure-config.yaml
-  fi
+  if [[ "$SKIP_CLEANUP" == "false" ]]; then
+    if [[ "$MAX_PIPELINE" == "true" ]]; then
+      kubectl delete -f hack/load-tests/log-fluentbit-max-pipeline.yaml
+    fi
+    if [[ "$BACKPRESSURE_TEST" == "true" ]]; then
+      kubectl delete -f hack/load-tests/log-fluentbit-backpressure-config.yaml
+    fi
 
-  kubectl delete -f hack/load-tests/log-fluentbit-test-setup.yaml
+    kubectl delete -f hack/load-tests/log-fluentbit-test-setup.yaml
+  else
+    echo -e "Skipping cleanup of test resources (SKIP_CLEANUP=true)"
+  fi
 }
 
 function get_result_and_cleanup_selfmonitor() {
@@ -493,7 +521,11 @@ function get_result_and_cleanup_selfmonitor() {
       kill %1
     fi
 
-    kubectl delete -f hack/load-tests/self-monitor-test-setup.yaml
+    if [[ "$SKIP_CLEANUP" == "false" ]]; then
+      kubectl delete -f hack/load-tests/self-monitor-test-setup.yaml
+    else
+      echo -e "Skipping cleanup of test resources (SKIP_CLEANUP=true)"
+    fi
 }
 
 
@@ -532,7 +564,7 @@ wait_for_resources
 echo -e "Test setup is ready, starting test"
 
 for (( c=$TEST_DURATION; c>=0; c=c-60 ))
-do  
+do
   echo "Time remaining: $c seconds"
   sleep 60
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- allow skip_deletion option such that load test clusters are not deleted after the execution of load test

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
