### PR TITLE
feat: enable keepalive otlpreceiver

### DIFF
--- a/internal/otelcollector/config/common/types.go
+++ b/internal/otelcollector/config/common/types.go
@@ -119,11 +119,11 @@ type Endpoint struct {
 }
 
 type HTTPConfig struct {
-	Endpoint
+	Endpoint `yaml:",inline"`
 }
 
 type GRPCConfig struct {
-	Endpoint
+	Endpoint `yaml:",inline"`
 
 	KeepAlive KeepAlive `yaml:"keepalive,omitempty"`
 }

--- a/internal/otelcollector/config/common/types.go
+++ b/internal/otelcollector/config/common/types.go
@@ -110,16 +110,21 @@ type OTLPReceiverConfig struct {
 }
 
 type ReceiverProtocols struct {
-	HTTP HTTPEndpoint `yaml:"http,omitempty"`
-	GRPC GRPCEndpoint `yaml:"grpc,omitempty"`
+	HTTP HTTPConfig `yaml:"http,omitempty"`
+	GRPC GRPCConfig `yaml:"grpc,omitempty"`
 }
 
-type HTTPEndpoint struct {
+type Endpoint struct {
 	Endpoint string `yaml:"endpoint,omitempty"`
 }
 
-type GRPCEndpoint struct {
-	Endpoint  string    `yaml:"endpoint,omitempty"`
+type HTTPConfig struct {
+	Endpoint
+}
+
+type GRPCConfig struct {
+	Endpoint
+
 	KeepAlive KeepAlive `yaml:"keepalive,omitempty"`
 }
 

--- a/internal/otelcollector/config/common/types.go
+++ b/internal/otelcollector/config/common/types.go
@@ -110,12 +110,29 @@ type OTLPReceiverConfig struct {
 }
 
 type ReceiverProtocols struct {
-	HTTP Endpoint `yaml:"http,omitempty"`
-	GRPC Endpoint `yaml:"grpc,omitempty"`
+	HTTP HTTPEndpoint `yaml:"http,omitempty"`
+	GRPC GRPCEndpoint `yaml:"grpc,omitempty"`
 }
 
-type Endpoint struct {
+type HTTPEndpoint struct {
 	Endpoint string `yaml:"endpoint,omitempty"`
+}
+
+type GRPCEndpoint struct {
+	Endpoint  string    `yaml:"endpoint,omitempty"`
+	KeepAlive KeepAlive `yaml:"keepalive,omitempty"`
+}
+
+type KeepAlive struct {
+	ServerParams ServerParams `yaml:"server_parameters,omitempty"`
+}
+
+type ServerParams struct {
+	MaxConnIdle     string `yaml:"max_connection_idle"`
+	MaxConnAge      string `yaml:"max_connection_age"`
+	MaxConnAgeGrace string `yaml:"max_connection_age_grace"`
+	Time            string `yaml:"time"`
+	Timeout         string `yaml:"timeout"`
 }
 
 // =============================================================================

--- a/internal/otelcollector/config/common/types.go
+++ b/internal/otelcollector/config/common/types.go
@@ -133,11 +133,11 @@ type KeepAlive struct {
 }
 
 type ServerParams struct {
-	MaxConnIdle     string `yaml:"max_connection_idle"`
-	MaxConnAge      string `yaml:"max_connection_age"`
-	MaxConnAgeGrace string `yaml:"max_connection_age_grace"`
-	Time            string `yaml:"time"`
-	Timeout         string `yaml:"timeout"`
+	MaxConnIdle     string `yaml:"max_connection_idle,omitempty"`
+	MaxConnAge      string `yaml:"max_connection_age,omitempty"`
+	MaxConnAgeGrace string `yaml:"max_connection_age_grace,omitempty"`
+	Time            string `yaml:"time,omitempty"`
+	Timeout         string `yaml:"timeout,omitempty"`
 }
 
 // =============================================================================

--- a/internal/otelcollector/config/otlpgateway/config_builder.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder.go
@@ -107,9 +107,14 @@ func (b *Builder) sortPipelinesByName(opts *BuildOptions) {
 func otlpReceiverConfig() *common.OTLPReceiverConfig {
 	return &common.OTLPReceiverConfig{
 		Protocols: common.ReceiverProtocols{
-			HTTP: common.HTTPEndpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP)},
-			GRPC: common.GRPCEndpoint{
-				Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC),
+			HTTP: common.HTTPConfig{
+				Endpoint: common.Endpoint{
+					Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP)},
+			},
+			GRPC: common.GRPCConfig{
+				Endpoint: common.Endpoint{
+					Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC),
+				},
 				KeepAlive: common.KeepAlive{
 					ServerParams: common.ServerParams{
 						Time:    "300s",

--- a/internal/otelcollector/config/otlpgateway/config_builder.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder.go
@@ -103,12 +103,20 @@ func (b *Builder) sortPipelinesByName(opts *BuildOptions) {
 
 // otlpReceiverConfig returns the shared OTLP receiver configuration used by all signal types.
 //
-//nolint:mnd // port numbers are defined in the ports package
+//nolint:mnd // port numbers are defined in the ports package, hardcoded time configuration
 func otlpReceiverConfig() *common.OTLPReceiverConfig {
 	return &common.OTLPReceiverConfig{
 		Protocols: common.ReceiverProtocols{
-			HTTP: common.Endpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP)},
-			GRPC: common.Endpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC)},
+			HTTP: common.HTTPEndpoint{Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPHTTP)},
+			GRPC: common.GRPCEndpoint{
+				Endpoint: fmt.Sprintf("${%s}:%d", common.EnvVarCurrentPodIP, ports.OTLPGRPC),
+				KeepAlive: common.KeepAlive{
+					ServerParams: common.ServerParams{
+						Time:    "300s",
+						Timeout: "20s",
+					},
+				},
+			},
 		},
 	}
 }

--- a/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
@@ -149,9 +149,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
@@ -156,9 +156,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
@@ -149,11 +149,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
@@ -113,9 +113,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
@@ -120,9 +120,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
@@ -113,11 +113,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
@@ -113,9 +113,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
@@ -120,9 +120,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
@@ -113,11 +113,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
@@ -113,9 +113,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
@@ -120,9 +120,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
@@ -113,11 +113,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
@@ -53,9 +53,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
@@ -46,11 +46,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
@@ -46,9 +46,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
@@ -53,9 +53,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
@@ -46,11 +46,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
@@ -46,9 +46,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
@@ -53,9 +53,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
@@ -46,11 +46,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
@@ -46,9 +46,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
@@ -45,9 +45,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
@@ -45,11 +45,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
@@ -52,9 +52,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
@@ -106,9 +106,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
@@ -99,9 +99,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 1024

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
@@ -99,11 +99,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
@@ -86,9 +86,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 1024

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
@@ -86,11 +86,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
@@ -93,9 +93,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
@@ -86,9 +86,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 1024

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
@@ -86,11 +86,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
@@ -93,9 +93,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
@@ -85,11 +85,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
@@ -92,9 +92,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
@@ -85,9 +85,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 1024

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
@@ -85,11 +85,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
@@ -92,9 +92,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
@@ -85,9 +85,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 1024

--- a/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
@@ -80,9 +80,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
@@ -73,11 +73,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
@@ -73,9 +73,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
@@ -134,11 +134,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
@@ -141,9 +141,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
@@ -134,9 +134,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
@@ -114,11 +114,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
@@ -114,9 +114,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
@@ -121,9 +121,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
@@ -113,9 +113,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
@@ -120,9 +120,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
@@ -113,11 +113,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
@@ -43,11 +43,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
@@ -43,9 +43,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
@@ -50,9 +50,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
@@ -155,11 +155,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
@@ -162,9 +162,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
@@ -155,9 +155,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
@@ -126,9 +126,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
@@ -119,9 +119,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
@@ -119,11 +119,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
@@ -155,11 +155,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
@@ -162,9 +162,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
@@ -155,9 +155,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
@@ -112,9 +112,18 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint: ${MY_POD_IP}:4318
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint: ${MY_POD_IP}:4317
+                endpoint:
+                    endpoint: ${MY_POD_IP}:4317
+                keepalive:
+                    server_parameters:
+                        max_connection_idle: ""
+                        max_connection_age: ""
+                        max_connection_age_grace: ""
+                        time: 300s
+                        timeout: 20s
 processors:
     batch:
         send_batch_size: 512

--- a/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
@@ -112,11 +112,9 @@ receivers:
     otlp:
         protocols:
             http:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4318
+                endpoint: ${MY_POD_IP}:4318
             grpc:
-                endpoint:
-                    endpoint: ${MY_POD_IP}:4317
+                endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
                         time: 300s

--- a/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
@@ -119,9 +119,6 @@ receivers:
                     endpoint: ${MY_POD_IP}:4317
                 keepalive:
                     server_parameters:
-                        max_connection_idle: ""
-                        max_connection_age: ""
-                        max_connection_age_grace: ""
                         time: 300s
                         timeout: 20s
 processors:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- As part of #3433, this PR enables keepalive configuration for the OTLP receiver. This will prevent any dead connections from piling up and consuming memory in high connection churn environments.
- Keepalive configuration set are:
  - `time`: how often the receiver sends a ping to the client to ensure it is still alive. previously it was set to default which was 2 hours, leaving connections from dead pods (which are not closed properly) in memory
  - `timeout`: how long to wait until receiver responds

Changes refer to particular issues, PRs or documents:

- #3433 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
