### PR TITLE
fix: update upgrade tests for OTLP gateway DaemonSet

### DIFF
--- a/test/e2e/upgrade/logs_upgrade_test.go
+++ b/test/e2e/upgrade/logs_upgrade_test.go
@@ -62,7 +62,7 @@ func TestLogsUpgrade(t *testing.T) {
 
 	// === VALIDATE OLD VERSION ===
 	t.Log("Validating log pipeline with old version...")
-	assert.DeploymentReady(t, kitkyma.LogGatewayName)
+	assert.DaemonSetReady(t, kitkyma.OTLPGatewayName)
 	assert.OTelLogPipelineHealthy(t, pipelineName)
 	assert.BackendReachable(t, backend)
 	assert.OTelLogsFromNamespaceDelivered(t, backend, genNs)

--- a/test/e2e/upgrade/metrics_upgrade_test.go
+++ b/test/e2e/upgrade/metrics_upgrade_test.go
@@ -62,7 +62,7 @@ func TestMetricsUpgrade(t *testing.T) {
 
 	// === VALIDATE OLD VERSION ===
 	t.Log("Validating metric pipeline with old version...")
-	assert.DeploymentReady(t, kitkyma.MetricGatewayName)
+	assert.DaemonSetReady(t, kitkyma.OTLPGatewayName)
 	assert.MetricPipelineHealthy(t, pipelineName)
 	assert.BackendReachable(t, backend)
 	assert.MetricsFromNamespaceDelivered(t, backend, genNs, telemetrygen.MetricNames)

--- a/test/e2e/upgrade/traces_upgrade_test.go
+++ b/test/e2e/upgrade/traces_upgrade_test.go
@@ -64,7 +64,7 @@ func TestTracesUpgrade(t *testing.T) {
 
 	// === VALIDATE OLD VERSION ===
 	t.Log("Validating trace pipeline with old version...")
-	assert.DeploymentReady(t, kitkyma.TraceGatewayName)
+	assert.DaemonSetReady(t, kitkyma.OTLPGatewayName)
 	assert.TracePipelineHealthy(t, pipelineName)
 	assert.BackendReachable(t, backend)
 	assert.TracesFromNamespaceDelivered(t, backend, genNs)


### PR DESCRIPTION
## Summary
- Update upgrade test pre-upgrade assertions to check for the OTLP gateway DaemonSet instead of the removed per-signal Deployment gateways (log-gateway, metric-gateway, trace-gateway)
- Since 1.63.0, the latest release already deploys the unified OTLP gateway DaemonSet, so the old `DeploymentReady` checks fail