### PR TITLE
fix: add critical tolerations to OTLP gateway DaemonSet

### DIFF
--- a/internal/resources/otelcollector/otlp_gateway.go
+++ b/internal/resources/otelcollector/otlp_gateway.go
@@ -398,6 +398,7 @@ func (o *OTLPGatewayApplierDeleter) makeGatewayPodSpec(opts GatewayApplyOptions)
 
 	podOptions := make([]commonresources.PodSpecOption, 0)
 	podOptions = append(podOptions, o.podOpts...)
+	podOptions = append(podOptions, commonresources.WithTolerations(commonresources.CriticalDaemonSetTolerations))
 	podOptions = append(podOptions, commonresources.WithImagePullSecretName(o.globals.ImagePullSecretName()),
 		commonresources.WithClusterTrustBundleVolume(o.globals.ClusterTrustBundleName()),
 	)

--- a/internal/resources/otelcollector/testdata/otlp-gateway-fips-enabled.yaml
+++ b/internal/resources/otelcollector/testdata/otlp-gateway-fips-enabled.yaml
@@ -283,6 +283,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-otlp-gateway
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:

--- a/internal/resources/otelcollector/testdata/otlp-gateway-istio.yaml
+++ b/internal/resources/otelcollector/testdata/otlp-gateway-istio.yaml
@@ -293,6 +293,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-otlp-gateway
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:

--- a/internal/resources/otelcollector/testdata/otlp-gateway-vpa-zero-max-memory.yaml
+++ b/internal/resources/otelcollector/testdata/otlp-gateway-vpa-zero-max-memory.yaml
@@ -291,6 +291,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-otlp-gateway
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:

--- a/internal/resources/otelcollector/testdata/otlp-gateway-vpa.yaml
+++ b/internal/resources/otelcollector/testdata/otlp-gateway-vpa.yaml
@@ -291,6 +291,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-otlp-gateway
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:

--- a/internal/resources/otelcollector/testdata/otlp-gateway.yaml
+++ b/internal/resources/otelcollector/testdata/otlp-gateway.yaml
@@ -291,6 +291,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-otlp-gateway
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:

--- a/internal/resources/otelcollector/testdata/otlp-multi-instance-gateway-vpa.yaml
+++ b/internal/resources/otelcollector/testdata/otlp-multi-instance-gateway-vpa.yaml
@@ -291,6 +291,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: telemetry-otlp-gateway
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - configMap:
           items:


### PR DESCRIPTION
## Summary
- Added `NoExecute` and `NoSchedule` tolerations to the OTLP gateway DaemonSet, matching the behavior already present in the OTel agent and Fluent Bit DaemonSets.
- Without these tolerations, the OTLP gateway pods would not be scheduled on tainted nodes, breaking telemetry collection on those nodes.