### PR TITLE
chore: add release notes input section to PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -8,6 +8,33 @@ Changes refer to particular issues, PRs or documents:
 
 - 
 
+## Release Notes Input
+<!--
+Required. Describe any user-facing changes introduced by this PR for the release notes.
+
+User-facing changes include (but are not limited to):
+- New or changed pipeline behavior (logs, metrics, traces)
+- New or changed CRD fields or API
+- New or changed metrics, attributes, or resource enrichment
+- Changes to OTel Collector or Fluent Bit configuration
+- Deprecations or removals of features or APIs
+- Changes that require user action (migration steps, config updates)
+- RBAC or permission changes
+- Service name or endpoint changes (breaks users hardcoding addresses)
+- Workload kind changes (Deployment ↔ DaemonSet; affects HPA, PDB, external selectors)
+
+If the change affects only specific signal types, start with the appropriate scope prefix:
+- `Logs:` — log pipelines only
+- `Metrics:` — metric pipelines only
+- `Traces:` — trace pipelines only
+- `Logs and Metrics:`, `Logs and Traces:`, `Metrics and Traces:` — two signal types
+- No prefix — all signal types or non-signal-specific
+
+If this PR has no user-facing changes (tests, docs, internal refactoring), write "None".
+
+If this PR deprecates or removes a feature, describe what is deprecated/removed, why, and what users should migrate to.
+-->
+
 ## Traceability
 - [ ] The PR is linked to a GitHub issue.
 - [ ] The follow-up issues (if any) are linked in the `Related Issues` section.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Adds a `Release Notes Input` section to the PR template to collect user-facing change descriptions at PR time, feeding the release notes generation workflow
- Includes guidance on signal-type scope prefixes (`Logs:`, `Metrics:`, `Traces:`), deprecation/removal descriptions, and a "None" escape hatch for internal-only PRs

Changes refer to particular issues, PRs or documents:

- Aligned with the `gen-release-notes` skill's PR body parsing and the `write-pr` skill's signal category scanning

## Release Notes Input

None

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.