### PR TITLE
chore: create hyperspace config

### DIFF
--- a/.hyperspace/pull_request_bot.json
+++ b/.hyperspace/pull_request_bot.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://devops-insights-pr-bot.cfapps.eu10-004.hana.ondemand.com/schema/pull_request_bot.json",
+  "excluded_paths": [
+    "go.sum",
+    "**/go.sum",
+    "**/*.mod",
+    "zz_generated.*",
+    "**/zz_generated.*",
+    "*.pb.go",
+    "**/*.pb.go",
+    "helm/charts/**",
+    "config/crd/bases/**",
+    "testdata/**",
+    "**/testdata/**"
+  ],
+  "features": {
+    "control_panel": true,
+    "summarize": {
+      "auto_generate_summary": false,
+      "auto_insert_summary": false,
+      "use_custom_summarize_prompt": true,
+      "excluded_paths": [
+        "test/**",
+        "**/*_test.go"
+      ]
+    },
+    "review": {
+      "auto_generate_review": false,
+      "auto_run_on_draft_pr": false,
+      "use_custom_review_focus": true
+    }
+  }
+}

--- a/.hyperspace/pull_request_bot.json
+++ b/.hyperspace/pull_request_bot.json
@@ -19,6 +19,7 @@
       "auto_generate_summary": false,
       "auto_insert_summary": false,
       "use_custom_summarize_prompt": true,
+      "use_custom_summarize_output_template": true,
       "excluded_paths": [
         "test/**",
         "**/*_test.go"

--- a/.hyperspace/pull_request_bot_review_focus.md
+++ b/.hyperspace/pull_request_bot_review_focus.md
@@ -16,7 +16,7 @@
 - Verify that pipeline validation logic lives in `internal/validators/` not in controllers
 - Flag direct use of `client.Update` where `client.Patch` (status subresource) should be used for status updates
 - Check that golden file tests are updated (`make update-golden-files`) when config builders change
-- Verify test helpers are placed in `test/testkit/` not duplicated inline in test files
+- Verify that e2e and integration test helpers are placed in `test/testkit/` not duplicated inline in test files; unit-test helpers in `internal/utils/test/` are also acceptable
 
 ## Documentation Checks
 

--- a/.hyperspace/pull_request_bot_review_focus.md
+++ b/.hyperspace/pull_request_bot_review_focus.md
@@ -1,0 +1,25 @@
+# Telemetry Manager Review Focus
+
+## Project Structure Rules
+
+1. Controllers in `controllers/telemetry/` must only serve as composition roots (dependency injection, watcher setup) — business logic belongs in `internal/reconciler/`
+2. Configuration builders live in `internal/otelcollector/config/` or `internal/fluentbit/config/` — no config construction elsewhere
+3. Kubernetes resources are generated via `ApplierDeleters` in `internal/resources/` — avoid inline resource construction in reconcilers
+4. Mocks are generated with mockery (`.mockery.yml`) — do not hand-write mocks
+
+## Review Priorities
+
+- Verify reconciler changes do not skip error handling for Kubernetes API calls
+- Flag missing or incorrect RBAC annotations when new resource types are accessed
+- Check that new CRD fields have corresponding DeepCopy generation (via `make generate`)
+- Ensure new environment variables added to the manager are declared in `main.go` envConfig struct
+- Verify that pipeline validation logic lives in `internal/validators/` not in controllers
+- Flag direct use of `client.Update` where `client.Patch` (status subresource) should be used for status updates
+- Check that golden file tests are updated (`make update-golden-files`) when config builders change
+- Verify test helpers are placed in `test/testkit/` not duplicated inline in test files
+
+## Documentation Checks
+
+- New or changed environment variables must be documented (e.g. in `docs/` or the relevant reference page) — flag any that are only declared in code without a corresponding docs update
+- New or changed manager flags (command-line flags passed to the manager binary) must be documented — check `docs/` for a flags or configuration reference
+- New or changed self-monitoring metrics (Prometheus metrics exposed by the manager) must be documented — check `docs/user/` for a metrics reference page and flag missing entries

--- a/.hyperspace/pull_request_bot_summarize_output_template.md
+++ b/.hyperspace/pull_request_bot_summarize_output_template.md
@@ -1,6 +1,6 @@
 {{summary}}
 
-## Key changes
+## Key Changes
 {{code_changes}}
 
 ## Release Notes Input

--- a/.hyperspace/pull_request_bot_summarize_output_template.md
+++ b/.hyperspace/pull_request_bot_summarize_output_template.md
@@ -1,0 +1,7 @@
+{{summary}}
+
+## Key changes
+{{code_changes}}
+
+## Release Notes Input
+{{additional_context}}

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -29,6 +29,7 @@ User-facing changes include, but are not limited to:
 - Changes to OTel Collector or Fluent Bit configuration
 - Deprecations or removals (deletions) of features or APIs
 - Changes that require user action (migration steps, config updates)
+- Changes that have a recommended (optional) user action (opt-in improvements, early adoption steps)
 - RBAC or permission changes
 - Service name or endpoint changes (breaks users hardcoding addresses)
 - Workload kind changes (Deployment ↔ DaemonSet; affects HPA, PDB, external selectors)
@@ -43,3 +44,5 @@ If the change affects only specific signal types, start with the appropriate sco
 If this PR has no user-facing changes (tests, docs, internal refactoring), write "None".
 
 If this PR deprecates or removes a feature, describe what is deprecated or removed, why, and what users must migrate to.
+
+If this PR introduces a feature where users should take an optional action (for example, enabling a new capability, adopting a new approach early, or updating dashboards), describe the recommended action and why it is beneficial.

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -1,5 +1,7 @@
 Summarize this pull request for the telemetry-manager project — a Kubernetes operator that manages telemetry pipelines (logs, metrics, traces) in Kyma clusters using OpenTelemetry Collectors and Fluent Bit.
 
+Do not include a file-by-file list of changes. All change details belong in the "Key changes" section below.
+
 Always include all of the following sections in this exact order. Only the sections marked as "(optional)" may be omitted when not applicable.
 
 ## What changed
@@ -16,9 +18,6 @@ Bullet points covering the most important code changes. For each point, mention 
 
 ## Notes for reviewers
 Highlight anything non-obvious: tricky logic, deliberate trade-offs, areas needing extra scrutiny, or follow-up issues.
-
-## Release Notes Input
-See instructions below.
 
 ## Release Notes Input
 Required — always include this section. Describe any user-facing changes introduced by this PR for the release notes.

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -2,27 +2,27 @@ Summarize this pull request for the telemetry-manager project — a Kubernetes o
 
 Do not include a file-by-file list of changes. All change details belong in the "Key changes" section below.
 
-Always include all of the following sections in this exact order. Only the sections marked as "(optional)" may be omitted when not applicable.
+Include all sections listed here, in this exact order. You can omit only sections marked as "(optional)" when they are not applicable.
 
-## What changed
+## What Changed
 One or two sentences describing the change at a high level.
 
-## Affected signal types
+## Affected Signal Types
 (optional) List which pipeline types are affected: logs, metrics, traces, or all. Omit this section entirely if the change is infrastructure (build, CI, dependencies), tooling, or operator-level with no signal-specific impact.
 
-## Key changes
-Bullet points covering the most important code changes. For each point, mention the relevant package or component (e.g. `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`).
+## Key Changes
+Bullet points covering the most important code changes. For each point, mention the relevant package or component (for example, `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`).
 
-## Breaking changes
+## Breaking Changes
 (optional) List any breaking changes to CRD fields, API types, or behavior. Omit this section if there are none.
 
-## Notes for reviewers
-Highlight anything non-obvious: tricky logic, deliberate trade-offs, areas needing extra scrutiny, or follow-up issues.
+## Notes for Reviewers
+Highlight anything non-obvious: tricky logic, deliberate trade-offs, areas that need extra scrutiny, or follow-up issues.
 
 ## Release Notes Input
-Required — always include this section. Describe any user-facing changes introduced by this PR for the release notes.
+Always include this section. Describe any user-facing changes introduced by this PR for the release notes.
 
-User-facing changes include (but are not limited to):
+User-facing changes include, but are not limited to:
 - New or changed pipeline behavior (logs, metrics, traces)
 - New or changed CRD fields or API
 - New or changed metrics, attributes, or resource enrichment
@@ -42,4 +42,4 @@ If the change affects only specific signal types, start with the appropriate sco
 
 If this PR has no user-facing changes (tests, docs, internal refactoring), write "None".
 
-If this PR deprecates or removes a feature, describe what is deprecated/removed, why, and what users should migrate to.
+If this PR deprecates or removes a feature, describe what is deprecated or removed, why, and what users must migrate to.

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -6,7 +6,7 @@ Structure the summary as follows:
 One or two sentences describing the change at a high level.
 
 ## Affected signal types
-List which pipeline types are affected: logs, metrics, traces, or all. If the change is infrastructure (build, CI, dependencies) or operator-level, state that instead.
+List which pipeline types are affected: logs, metrics, traces, or all. Omit this section entirely if the change is infrastructure (build, CI, dependencies), tooling, or operator-level with no signal-specific impact.
 
 ## Key changes
 Bullet points covering the most important code changes. For each point, mention the relevant package or component (e.g. `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`).

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -1,24 +1,27 @@
 Summarize this pull request for the telemetry-manager project — a Kubernetes operator that manages telemetry pipelines (logs, metrics, traces) in Kyma clusters using OpenTelemetry Collectors and Fluent Bit.
 
-Structure the summary as follows:
+Always include all of the following sections in this exact order. Only the sections marked as "(optional)" may be omitted when not applicable.
 
 ## What changed
 One or two sentences describing the change at a high level.
 
 ## Affected signal types
-List which pipeline types are affected: logs, metrics, traces, or all. Omit this section entirely if the change is infrastructure (build, CI, dependencies), tooling, or operator-level with no signal-specific impact.
+(optional) List which pipeline types are affected: logs, metrics, traces, or all. Omit this section entirely if the change is infrastructure (build, CI, dependencies), tooling, or operator-level with no signal-specific impact.
 
 ## Key changes
 Bullet points covering the most important code changes. For each point, mention the relevant package or component (e.g. `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`).
 
 ## Breaking changes
-List any breaking changes to CRD fields, API types, or behavior. If none, omit this section.
+(optional) List any breaking changes to CRD fields, API types, or behavior. Omit this section if there are none.
 
 ## Notes for reviewers
 Highlight anything non-obvious: tricky logic, deliberate trade-offs, areas needing extra scrutiny, or follow-up issues.
 
 ## Release Notes Input
-Required. Describe any user-facing changes introduced by this PR for the release notes.
+See instructions below.
+
+## Release Notes Input
+Required — always include this section. Describe any user-facing changes introduced by this PR for the release notes.
 
 User-facing changes include (but are not limited to):
 - New or changed pipeline behavior (logs, metrics, traces)

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -1,0 +1,43 @@
+Summarize this pull request for the telemetry-manager project — a Kubernetes operator that manages telemetry pipelines (logs, metrics, traces) in Kyma clusters using OpenTelemetry Collectors and Fluent Bit.
+
+Structure the summary as follows:
+
+## What changed
+One or two sentences describing the change at a high level.
+
+## Affected signal types
+List which pipeline types are affected: logs, metrics, traces, or all. If the change is infrastructure (build, CI, dependencies) or operator-level, state that instead.
+
+## Key changes
+Bullet points covering the most important code changes. For each point, mention the relevant package or component (e.g. `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`).
+
+## Breaking changes
+List any breaking changes to CRD fields, API types, or behavior. If none, omit this section.
+
+## Notes for reviewers
+Highlight anything non-obvious: tricky logic, deliberate trade-offs, areas needing extra scrutiny, or follow-up issues.
+
+## Release Notes Input
+Required. Describe any user-facing changes introduced by this PR for the release notes.
+
+User-facing changes include (but are not limited to):
+- New or changed pipeline behavior (logs, metrics, traces)
+- New or changed CRD fields or API
+- New or changed metrics, attributes, or resource enrichment
+- Changes to OTel Collector or Fluent Bit configuration
+- Deprecations or removals of features or APIs
+- Changes that require user action (migration steps, config updates)
+- RBAC or permission changes
+- Service name or endpoint changes (breaks users hardcoding addresses)
+- Workload kind changes (Deployment ↔ DaemonSet; affects HPA, PDB, external selectors)
+
+If the change affects only specific signal types, start with the appropriate scope prefix:
+- `Logs:` — log pipelines only
+- `Metrics:` — metric pipelines only
+- `Traces:` — trace pipelines only
+- `Logs and Metrics:`, `Logs and Traces:`, `Metrics and Traces:` — two signal types
+- No prefix — all signal types or non-signal-specific
+
+If this PR has no user-facing changes (tests, docs, internal refactoring), write "None".
+
+If this PR deprecates or removes a feature, describe what is deprecated/removed, why, and what users should migrate to.

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -27,7 +27,7 @@ User-facing changes include, but are not limited to:
 - New or changed CRD fields or API
 - New or changed metrics, attributes, or resource enrichment
 - Changes to OTel Collector or Fluent Bit configuration
-- Deprecations or removals of features or APIs
+- Deprecations or removals (deletions) of features or APIs
 - Changes that require user action (migration steps, config updates)
 - RBAC or permission changes
 - Service name or endpoint changes (breaks users hardcoding addresses)


### PR DESCRIPTION
## What Changed
Added Hyperspace PR bot configuration to the repository, enabling AI-assisted pull request summarization and code review tailored to the telemetry-manager project's architecture and conventions.

## Key Changes
- Added `.hyperspace/pull_request_bot.json`: Configures the Hyperspace PR bot with path exclusions for generated files (`zz_generated.*`, `*.pb.go`, `go.sum`), test data, Helm charts, and CRD bases. Enables the control panel, summarization (with a custom prompt and output template), and review (with a custom focus); auto-generation of summaries and reviews is disabled by default.
- Added `.hyperspace/pull_request_bot_review_focus.md`: Encodes project-specific review guidelines covering architecture rules (`controllers/telemetry/` as composition roots, config builders in `internal/otelcollector/config/` or `internal/fluentbit/config/`, resource generation via `internal/resources/`, mockery-generated mocks), review priorities (error handling, RBAC annotations, CRD DeepCopy, status update patterns, golden file tests), and documentation checks for env vars, manager flags, and self-monitoring metrics.
- Added `.hyperspace/pull_request_bot_summarize_prompt.md`: Defines the custom prompt instructing the bot to produce structured PR summaries with fixed sections (What Changed, Affected Signal Types, Key Changes, Breaking Changes, Notes for Reviewers, Release Notes Input) and signal-type scope prefixes.
- Added `.hyperspace/pull_request_bot_summarize_output_template.md`: Specifies the output template (`{{summary}}`, `{{code_changes}}`, `{{additional_context}}`) used when inserting generated summaries into PR descriptions.

## Notes for Reviewers
The review focus document encodes institutional knowledge about the project's architecture constraints. It is worth verifying that all listed rules accurately reflect current conventions (e.g., validator placement, status update patterns, test helper locations) before merging, as they will guide all future automated reviews. Auto-generation is intentionally disabled so summaries and reviews are only triggered on demand via the control panel.

## Release Notes Input
None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.46`

- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [PR Template File](https://github.com/kyma-project/telemetry-manager/blob/08aa6420f98a50cbf712bd0862f6aa7616bf3f97/.hyperspace/pull_request_bot_summarize_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.edited`
- Correlation ID: `2d3fd977-bd59-43aa-acd0-336ca0a1e074`
- Summary Prompt: [PR Prompt File](https://github.com/kyma-project/telemetry-manager/blob/08aa6420f98a50cbf712bd0862f6aa7616bf3f97/.hyperspace/pull_request_bot_summarize_prompt.md)
</details>
