### PR TITLE
docs: remove legacy endpoint and enrichment references

### DIFF
--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -14,7 +14,7 @@ If you don't provide a service name, or if its value follows the pattern `unknow
 Be aware of [these OTel-specific edge case limitations](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#configuring-recommended-resource-attributes).
 
 > [!WARNING]
-> The legacy strategy for service name enrichment is deprecated and will be removed soon. The legacy strategy is active if the annotation `telemetry.kyma-project.io/service-enrichment` is set to `kyma-legacy` or is missing on the Telemetry CR. It determines the service name based on the following hierarchy:
+> The legacy strategy for service name enrichment is deprecated and will be removed in a future release. The legacy strategy is active if the annotation `telemetry.kyma-project.io/service-enrichment` is set to `kyma-legacy` or is missing on the Telemetry CR. It determines the service name based on the following hierarchy:
 > 1. `app.kubernetes.io/name`: Pod label value
 > 2. `app`: Pod label value
 > 3. Deployment/DaemonSet/StatefulSet/Job name

--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -7,21 +7,21 @@ The Telemetry gateways automatically enrich your data with OTel resource attribu
 
 ## Service Attributes
 
-The gateway enriches telemetry data with service attributes following [OTel conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes). It sets `service.namespace`, `service.name`, `service.version`, and `service.instance.id` based on Kubernetes metadata.
+By default, the gateway enriches telemetry data with service attributes following [OTel conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes). It sets `service.namespace`, `service.name`, `service.version`, and `service.instance.id` based on Kubernetes metadata.
 
 If you don't provide a service name, or if its value follows the pattern `unknown_service:<process.executable.name>` as described in the [specification](https://opentelemetry.io/docs/specs/semconv/resource/#service), the gateway generates it from Kubernetes metadata.
 
 Be aware of [these OTel-specific edge case limitations](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#configuring-recommended-resource-attributes).
 
 > [!WARNING]
-> The legacy strategy for service name enrichment is deprecated and will be removed soon. The legacy strategy determines the service name based on the following hierarchy:
+> The legacy strategy for service name enrichment is deprecated and will be removed soon. The legacy strategy is active if the annotation `telemetry.kyma-project.io/service-enrichment` is set to `kyma-legacy` or is missing on the Telemetry CR. It determines the service name based on the following hierarchy:
 > 1. `app.kubernetes.io/name`: Pod label value
 > 2. `app`: Pod label value
 > 3. Deployment/DaemonSet/StatefulSet/Job name
 > 4. Pod name
 > 5. If none of the above is available, the value is `unknown_service`
 >
-> If you still use the legacy strategy (annotation `telemetry.kyma-project.io/service-enrichment: kyma-legacy` on your Telemetry CR), migrate to the OTel-based strategy by setting the annotation to `otel` or removing it entirely.
+> To migrate, set the annotation `telemetry.kyma-project.io/service-enrichment: otel` on your Telemetry CR.
 
 
 ## Kubernetes Metadata

--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -7,27 +7,21 @@ The Telemetry gateways automatically enrich your data with OTel resource attribu
 
 ## Service Attributes
 
-The service name is the logical name of the service that emits the telemetry data. The gateway ensures that this attribute always has a valid value.
+The gateway enriches telemetry data with service attributes following [OTel conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes). It sets `service.namespace`, `service.name`, `service.version`, and `service.instance.id` based on Kubernetes metadata.
 
 If you don't provide a service name, or if its value follows the pattern `unknown_service:<process.executable.name>` as described in the [specification](https://opentelemetry.io/docs/specs/semconv/resource/#service), the gateway generates it from Kubernetes metadata.
 
-The gateway determines the service name based on the following hierarchy of labels and names:
-
-1. `app.kubernetes.io/name`: Pod label value
-2. `app`: Pod label value
-3. Deployment/DaemonSet/StatefulSet/Job name
-4. Pod name
-5. If none of the above is available, the value is `unknown_service`
-
-> [!TIP]
-> The Telemetry module also supports enrichment with service attributes matching OTel conventions (see [OTel: Service Attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#service-attributes)), which enriches `service.namespace`, `service.name`, `service.version`, and `service.instance.id`.
-> 
-> If you'd like to use that, manually set the `telemetry.kyma-project.io/service-enrichment` annotation in the Telemetry CR to `otel`. If you want to return to the previous method, set the annotation back to `kyma-legacy`.
->
-> However, if you choose to use the OTel enrichment strategy, be aware of [these OTel-specific edge case limitations](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#configuring-recommended-resource-attributes).
+Be aware of [these OTel-specific edge case limitations](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#configuring-recommended-resource-attributes).
 
 > [!WARNING]
-> The legacy strategy for service name enrichment is deprecated. To avoid disruptions, migrate to the new OTel-based enrichment strategy by adding the annotation `telemetry.kyma-project.io/service-enrichment: otel` to your Telemetry CR.
+> The legacy strategy for service name enrichment is deprecated and will be removed soon. The legacy strategy determines the service name based on the following hierarchy:
+> 1. `app.kubernetes.io/name`: Pod label value
+> 2. `app`: Pod label value
+> 3. Deployment/DaemonSet/StatefulSet/Job name
+> 4. Pod name
+> 5. If none of the above is available, the value is `unknown_service`
+>
+> If you still use the legacy strategy (annotation `telemetry.kyma-project.io/service-enrichment: kyma-legacy` on your Telemetry CR), migrate to the OTel-based strategy by setting the annotation to `otel` or removing it entirely.
 
 
 ## Kubernetes Metadata

--- a/docs/user/otlp-input.md
+++ b/docs/user/otlp-input.md
@@ -36,15 +36,6 @@ The output shows the available endpoints and the pipeline health under the statu
 
 ```yaml
   endpoints:
-    metrics:
-      grpc: http://telemetry-otlp-metrics.kyma-system:4317
-      http: http://telemetry-otlp-metrics.kyma-system:4318
-    traces:
-      grpc: http://telemetry-otlp-traces.kyma-system:4317
-      http: http://telemetry-otlp-traces.kyma-system:4318
-    logs:
-      grpc: http://telemetry-otlp-logs.kyma-system:4317
-      http: http://telemetry-otlp-logs.kyma-system:4318
     otlp:
       grpc: http://telemetry-otlp.kyma-system:4317
       http: http://telemetry-otlp.kyma-system:4318

--- a/docs/user/otlp-input.md
+++ b/docs/user/otlp-input.md
@@ -6,7 +6,7 @@ Use the default OTLP input to collect telemetry data from your instrumented appl
 
 When you create any LogPipeline, TracePipeline, or MetricPipeline, the Telemetry module automatically deploys the OTLP gateway. This opens a stable, cluster-internal [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) endpoint, ready to receive data from your applications.
 
-Each endpoint listens on port `4317` for gRPC (default) and on port `4318` for HTTP.
+The endpoint listens on port `4317` for gRPC (default) and on port `4318` for HTTP.
 
 ![OTLP Input](./assets/otlp-input.drawio.svg)
 

--- a/docs/user/otlp-input.md
+++ b/docs/user/otlp-input.md
@@ -4,7 +4,7 @@ Use the default OTLP input to collect telemetry data from your instrumented appl
 
 ## Overview
 
-When you create any LogPipeline, TracePipeline, or MetricPipeline, the Telemetry module automatically deploys the respective gateway. This opens a stable, cluster-internal [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) endpoint for each signal type, ready to receive data from your applications.
+When you create any LogPipeline, TracePipeline, or MetricPipeline, the Telemetry module automatically deploys the OTLP gateway. This opens a stable, cluster-internal [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) endpoint, ready to receive data from your applications.
 
 Each endpoint listens on port `4317` for gRPC (default) and on port `4318` for HTTP.
 

--- a/docs/user/otlp-input.md
+++ b/docs/user/otlp-input.md
@@ -26,7 +26,7 @@ Use the following environment variable to set the harmonized OTLP endpoint, whic
 
 ## Verify the Endpoints
 
-To see whether you've set up your gateways and their push endpoints successfully, check the status of the default `Telemetry` resource:
+To see whether you've set up your OTLP gateway and its push endpoints successfully, check the status of the default `Telemetry` resource:
 
 ```sh
 kubectl -n kyma-system get telemetries.operator.kyma-project.io default -oyaml

--- a/docs/user/otlp-input.md
+++ b/docs/user/otlp-input.md
@@ -4,7 +4,7 @@ Use the default OTLP input to collect telemetry data from your instrumented appl
 
 ## Overview
 
-When you create any LogPipeline, TracePipeline, or MetricPipeline, the Telemetry module automatically deploys the OTLP gateway. This opens a stable, cluster-internal [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) endpoint, ready to receive data from your applications.
+When you create any LogPipeline, TracePipeline, or MetricPipeline, the Telemetry module automatically deploys the OTLP Gateway. This opens a stable, cluster-internal [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/) endpoint, ready to receive data from your applications.
 
 The endpoint listens on port `4317` for gRPC (default) and on port `4318` for HTTP.
 
@@ -26,7 +26,7 @@ Use the following environment variable to set the harmonized OTLP endpoint, whic
 
 ## Verify the Endpoints
 
-To see whether you've set up your OTLP gateway and its push endpoints successfully, check the status of the default `Telemetry` resource:
+To see whether you've set up your OTLP Gateway and its push endpoints successfully, check the status of the default `Telemetry` resource:
 
 ```sh
 kubectl -n kyma-system get telemetries.operator.kyma-project.io default -oyaml


### PR DESCRIPTION
## Summary
- Remove deprecated per-signal OTLP endpoints (telemetry-otlp-metrics, -traces, -logs) from the OTLP input guide, advertising only the unified `telemetry-otlp` endpoint
- Promote OTel-based service enrichment as the default strategy and move the legacy strategy description into a deprecation warning