### PR TITLE
chore: collapse key changes and reduce to component-level bullets in hyperspace PR template

### DIFF
--- a/.hyperspace/pull_request_bot_summarize_output_template.md
+++ b/.hyperspace/pull_request_bot_summarize_output_template.md
@@ -7,9 +7,13 @@ One or two sentences describing the change at a high level.
 (optional) List which pipeline types are affected: logs, metrics, traces, or all. Omit this section entirely if the change is infrastructure (build, CI, dependencies), tooling, or operator-level with no signal-specific impact.
 
 
-## Key Changes
-- **`package/or/file`**: Description of what changed and why.
-- **`package/or/file`**: Description of what changed and why.
+<details>
+<summary>Key Changes</summary>
+
+- **`component-or-package`**: Description of what changed and why.
+- **`component-or-package`**: Description of what changed and why.
+
+</details>
 
 ## Breaking Changes
 (optional) Any breaking changes to CRD fields, API types, or behavior. Omit this section entirely if there are none — do not write "None".
@@ -44,17 +48,13 @@ Configures the `k8sattributes` processor with a node filter across all OTel Coll
 
 Logs, Metrics, Traces
 
-## Key Changes
+<details>
+<summary>Key Changes</summary>
 
-Processor Configuration:
-- **`internal/otelcollector/config/common/processor_builders.go`**: Adds `filter.node_from_env_var: MY_NODE_NAME` to the `k8sattributes` processor builder so all collector types pick up the node filter.
-- **`internal/otelcollector/config/common/types.go`**: Extends the `K8sAttributesConfig` struct with the new filter field.
+- **`internal/otelcollector/config/common`**: Adds `filter.node_from_env_var: MY_NODE_NAME` to the `k8sattributes` processor builder and extends the `K8sAttributesConfig` struct with the new filter field.
+- **`internal/resources/otelcollector`**: Injects the `MY_NODE_NAME` environment variable (sourced from `spec.nodeName`) into each agent DaemonSet so the filter has a value at runtime.
 
-Resource Generation:
-- **`internal/resources/otelcollector/agent.go`**: Injects the `MY_NODE_NAME` environment variable (sourced from `spec.nodeName`) into each agent DaemonSet so the filter has a value at runtime.
-
-Golden Files:
-- **`internal/otelcollector/config/logagent/testdata/`**, **`internal/otelcollector/config/metricagent/testdata/`**, **`internal/otelcollector/config/otlpgateway/testdata/`**, **`internal/resources/otelcollector/testdata/`**: Updated to reflect the new processor and environment variable in all collector configurations.
+</details>
 
 ## Notes for Reviewers
 
@@ -75,10 +75,12 @@ Metrics, Traces, Logs: The `k8sattributes` processor now limits each collector i
 
 Adds `NoExecute` and `NoSchedule` tolerations to the OTLP gateway DaemonSet so its Pods are scheduled on tainted Nodes, matching the existing behavior of the OTel agent and Fluent Bit DaemonSets.
 
-## Key Changes
+<details>
+<summary>Key Changes</summary>
 
-- **`internal/resources/otelcollector/otlp_gateway.go`**: Adds critical tolerations to the DaemonSet Pod spec.
-- **`internal/resources/otelcollector/testdata/`**: Updates golden files to include the new tolerations in all OTLP gateway variants.
+- **`internal/resources/otelcollector`**: Adds `NoExecute` and `NoSchedule` tolerations to the OTLP gateway DaemonSet Pod spec.
+
+</details>
 
 ## Notes for Reviewers
 

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -15,7 +15,7 @@ One or two sentences describing the change at a high level.
 (optional) List which pipeline types are affected: logs, metrics, traces, or all. Omit this section entirely if the change is infrastructure (build, CI, dependencies), tooling, or operator-level with no signal-specific impact.
 
 ## Key Changes
-Bullet points covering the most important code changes. Format each bullet as **`path/to/file-or-package`**: description, where the path is the most relevant file, package, or component (for example, `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`). Use the file path for small changes, the package path for larger changes spanning multiple files.
+One bullet per logical component or area changed. Use the package or component path (for example, `internal/reconciler/metricpipeline`, `internal/otelcollector/config`, `controllers/telemetry`) — never individual file paths. Keep each bullet to one sentence. Do not mention test data, golden file updates, or mock regeneration unless they are the only thing that changed.
 
 ## Breaking Changes
 (optional) List any breaking changes to CRD fields, API types, or behavior. Omit this section entirely if there are none — do not write "None".


### PR DESCRIPTION
## What Changed

Updates the PR summarization bot template and prompt to wrap the "Key Changes" section in a collapsible `<details>` block and restricts bullets to one per logical component using package paths instead of individual file paths.

<details>
<summary>Key Changes</summary>

- **`.hyperspace/pull_request_bot_summarize_output_template.md`**: Wraps the "Key Changes" section in a `<details>`/`<summary>` block in both the template and both examples, and collapses per-file sub-groupings into single component-level bullets.
- **`.hyperspace/pull_request_bot_summarize_prompt.md`**: Rewrites the "Key Changes" instruction to require one bullet per logical component using package paths, ban individual file paths, and exclude test data and golden file mentions unless they are the only change.

</details>

## Notes for Reviewers

The prompt change is intentionally prescriptive: it forbids file paths and golden file bullets to keep PR descriptions focused on meaningful logic changes rather than generated artifact updates. The `<details>` wrapper keeps the description compact for reviewers who want a quick overview.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `3eacfcc4-bae5-4cb6-93e8-1fcfff52f8d7`
</details>
