### PR TITLE
fix: attribute enrichment for OTLP Gateway

### DIFF
--- a/internal/otelcollector/config/common/processor_builders.go
+++ b/internal/otelcollector/config/common/processor_builders.go
@@ -208,6 +208,20 @@ func TraceTransformProcessor(statements []TransformProcessorStatements) *Transfo
 	}
 }
 
+// AllSignalsTransformProcessor creates a TransformProcessorConfig that applies the same statements to
+// all three signal types (logs, metrics, traces). Use this for processors with static component IDs
+// that are shared across signal-type builders, since ComponentBuilder stores only the first-registered
+// config: populating all three statement sets ensures the processor works regardless of which signal
+// type happens to register first.
+func AllSignalsTransformProcessor(statements []TransformProcessorStatements) *TransformProcessorConfig {
+	return &TransformProcessorConfig{
+		ErrorMode:        defaultTransformProcessorErrorMode,
+		LogStatements:    statements,
+		MetricStatements: statements,
+		TraceStatements:  statements,
+	}
+}
+
 // TransformSpecsToProcessorStatements converts transform specs to processor statements
 func TransformSpecsToProcessorStatements(specs []telemetryv1beta1.TransformSpec) []TransformProcessorStatements {
 	result := make([]TransformProcessorStatements, 0, len(specs))

--- a/internal/otelcollector/config/otlpgateway/config_builder_logs.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_logs.go
@@ -35,6 +35,7 @@ func (b *Builder) buildLogPipelines(ctx context.Context, builder *common.Compone
 			b.addSetObsTimeIfZeroProcessor(builder),
 			b.addLogDropUnknownServiceNameProcessor(builder, opts),
 			b.addLogK8sAttributesProcessor(builder, opts),
+			b.addLogRestoreOtelServiceAttrsProcessor(builder, opts),
 			b.addLogIstioNoiseFilterProcessor(builder),
 			b.addDropIfInputSourceOTLPProcessor(builder),
 			b.addNamespaceFilterProcessor(builder),
@@ -95,7 +96,7 @@ func (b *Builder) addLogDropUnknownServiceNameProcessor(builder *common.Componen
 				return nil // Kyma legacy enrichment selected, skip this processor
 			}
 
-			return common.LogTransformProcessor(common.DropUnknownServiceNameProcessorStatements())
+			return common.AllSignalsTransformProcessor(common.DropUnknownServiceNameProcessorStatements())
 		},
 	)
 }
@@ -105,6 +106,19 @@ func (b *Builder) addLogK8sAttributesProcessor(builder *common.ComponentBuilder[
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
 			return k8sAttributesProcessorConfig(opts)
+		},
+	)
+}
+
+func (b *Builder) addLogRestoreOtelServiceAttrsProcessor(builder *common.ComponentBuilder[*telemetryv1beta1.LogPipeline], opts BuildOptions) buildLogComponentFunc {
+	return builder.AddProcessor(
+		builder.StaticComponentID(common.ComponentIDRestoreOtelServiceAttrsProcessor),
+		func(lp *telemetryv1beta1.LogPipeline) any {
+			if opts.ServiceEnrichment != commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
+				return nil
+			}
+
+			return common.AllSignalsTransformProcessor(common.RestoreOtelServiceAnnotationsProcessorStatements())
 		},
 	)
 }
@@ -150,7 +164,7 @@ func (b *Builder) addLogInsertClusterAttributesProcessor(builder *common.Compone
 		builder.StaticComponentID(common.ComponentIDInsertClusterAttributesProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
 			transformStatements := common.InsertClusterAttributesProcessorStatements(opts.Cluster)
-			return common.LogTransformProcessor(transformStatements)
+			return common.AllSignalsTransformProcessor(transformStatements)
 		},
 	)
 }
@@ -169,7 +183,7 @@ func (b *Builder) addLogDropKymaAttributesProcessor(builder *common.ComponentBui
 		builder.StaticComponentID(common.ComponentIDDropKymaAttributesProcessor),
 		func(lp *telemetryv1beta1.LogPipeline) any {
 			transformStatements := common.DropKymaAttributesProcessorStatements()
-			return common.LogTransformProcessor(transformStatements)
+			return common.AllSignalsTransformProcessor(transformStatements)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_metrics.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_metrics.go
@@ -57,6 +57,7 @@ func (b *Builder) buildMetricPipelines(ctx context.Context, builder *common.Comp
 		b.addMetricSetInstrumentationScopeToKymaProcessor(builder, opts),
 		b.addMetricDropUnknownServiceNameProcessor(builder, opts),
 		b.addMetricK8sAttributesProcessor(builder, opts),
+		b.addMetricRestoreOtelServiceAttrsProcessor(builder, opts),
 		b.addMetricServiceEnrichmentProcessor(builder, opts),
 		b.addMetricInsertClusterAttributesProcessor(builder, opts),
 		b.addMetricExporterForEnrichmentForwarder(builder),
@@ -182,7 +183,7 @@ func (b *Builder) addMetricDropUnknownServiceNameProcessor(builder *common.Compo
 				return nil
 			}
 
-			return common.MetricTransformProcessor(common.DropUnknownServiceNameProcessorStatements())
+			return common.AllSignalsTransformProcessor(common.DropUnknownServiceNameProcessorStatements())
 		},
 	)
 }
@@ -192,6 +193,19 @@ func (b *Builder) addMetricK8sAttributesProcessor(builder *common.ComponentBuild
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
 			return k8sAttributesProcessorConfig(opts)
+		},
+	)
+}
+
+func (b *Builder) addMetricRestoreOtelServiceAttrsProcessor(builder *common.ComponentBuilder[*telemetryv1beta1.MetricPipeline], opts BuildOptions) buildMetricComponentFunc {
+	return builder.AddProcessor(
+		builder.StaticComponentID(common.ComponentIDRestoreOtelServiceAttrsProcessor),
+		func(mp *telemetryv1beta1.MetricPipeline) any {
+			if opts.ServiceEnrichment != commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
+				return nil
+			}
+
+			return common.AllSignalsTransformProcessor(common.RestoreOtelServiceAnnotationsProcessorStatements())
 		},
 	)
 }
@@ -210,7 +224,7 @@ func (b *Builder) addMetricInsertClusterAttributesProcessor(builder *common.Comp
 		builder.StaticComponentID(common.ComponentIDInsertClusterAttributesProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
 			transformStatements := common.InsertClusterAttributesProcessorStatements(opts.Cluster)
-			return common.MetricTransformProcessor(transformStatements)
+			return common.AllSignalsTransformProcessor(transformStatements)
 		},
 	)
 }
@@ -273,7 +287,7 @@ func (b *Builder) addMetricDropKymaAttributesProcessor(builder *common.Component
 		builder.StaticComponentID(common.ComponentIDDropKymaAttributesProcessor),
 		func(mp *telemetryv1beta1.MetricPipeline) any {
 			transformStatements := common.DropKymaAttributesProcessorStatements()
-			return common.MetricTransformProcessor(transformStatements)
+			return common.AllSignalsTransformProcessor(transformStatements)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/config_builder_traces.go
+++ b/internal/otelcollector/config/otlpgateway/config_builder_traces.go
@@ -34,6 +34,7 @@ func (b *Builder) buildTracePipelines(ctx context.Context, builder *common.Compo
 			b.addDropIstioServiceEnrichmentProcessor(builder, opts),
 			b.addTraceDropUnknownServiceNameProcessor(builder, opts),
 			b.addTraceK8sAttributesProcessor(builder, opts),
+			b.addTraceRestoreOtelServiceAttrsProcessor(builder, opts),
 			b.addTraceIstioNoiseFilterProcessor(builder),
 			b.addTraceInsertClusterAttributesProcessor(builder, opts),
 			b.addTraceServiceEnrichmentProcessor(builder, opts),
@@ -96,7 +97,7 @@ func (b *Builder) addTraceDropUnknownServiceNameProcessor(builder *common.Compon
 				return nil
 			}
 
-			return common.TraceTransformProcessor(common.DropUnknownServiceNameProcessorStatements())
+			return common.AllSignalsTransformProcessor(common.DropUnknownServiceNameProcessorStatements())
 		},
 	)
 }
@@ -106,6 +107,19 @@ func (b *Builder) addTraceK8sAttributesProcessor(builder *common.ComponentBuilde
 		builder.StaticComponentID(common.ComponentIDK8sAttributesProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
 			return k8sAttributesProcessorConfig(opts)
+		},
+	)
+}
+
+func (b *Builder) addTraceRestoreOtelServiceAttrsProcessor(builder *common.ComponentBuilder[*telemetryv1beta1.TracePipeline], opts BuildOptions) buildTraceComponentFunc {
+	return builder.AddProcessor(
+		builder.StaticComponentID(common.ComponentIDRestoreOtelServiceAttrsProcessor),
+		func(tp *telemetryv1beta1.TracePipeline) any {
+			if opts.ServiceEnrichment != commonresources.AnnotationValueTelemetryServiceEnrichmentOtel {
+				return nil
+			}
+
+			return common.AllSignalsTransformProcessor(common.RestoreOtelServiceAnnotationsProcessorStatements())
 		},
 	)
 }
@@ -124,7 +138,7 @@ func (b *Builder) addTraceInsertClusterAttributesProcessor(builder *common.Compo
 		builder.StaticComponentID(common.ComponentIDInsertClusterAttributesProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
 			transformStatements := common.InsertClusterAttributesProcessorStatements(opts.Cluster)
-			return common.TraceTransformProcessor(transformStatements)
+			return common.AllSignalsTransformProcessor(transformStatements)
 		},
 	)
 }
@@ -143,7 +157,7 @@ func (b *Builder) addTraceDropKymaAttributesProcessor(builder *common.ComponentB
 		builder.StaticComponentID(common.ComponentIDDropKymaAttributesProcessor),
 		func(tp *telemetryv1beta1.TracePipeline) any {
 			transformStatements := common.DropKymaAttributesProcessorStatements()
-			return common.TraceTransformProcessor(transformStatements)
+			return common.AllSignalsTransformProcessor(transformStatements)
 		},
 	)
 }

--- a/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/all-signals-multi-backend.yaml
@@ -213,11 +213,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/compression.yaml
@@ -177,11 +177,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-with-custom-path.yaml
@@ -177,11 +177,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/http-protocol-without-custom-path.yaml
@@ -177,11 +177,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-excluded.yaml
@@ -118,9 +118,25 @@ processors:
         log_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
         log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-namespace-included.yaml
@@ -118,9 +118,25 @@ processors:
         log_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
         log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-otlp-input-disabled.yaml
@@ -118,9 +118,25 @@ processors:
         log_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
         log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/log-single-pipeline.yaml
@@ -112,9 +112,25 @@ processors:
         log_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
         log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-comprehensive.yaml
@@ -180,12 +180,28 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-namespace-filters.yaml
@@ -153,12 +153,28 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-disabled.yaml
@@ -152,12 +152,28 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-otlp-only.yaml
@@ -146,12 +146,28 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/metric-single-pipeline.yaml
@@ -146,12 +146,28 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/mixed-pipelines.yaml
@@ -137,11 +137,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/oauth2-authentication.yaml
@@ -198,11 +198,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
@@ -23,6 +23,7 @@ service:
                 - transform/set-observed-time-if-zero
                 - transform/drop-unknown-service-name
                 - k8s_attributes
+                - transform/restore-otel-service-attrs
                 - istio_noise_filter
                 - transform/insert-cluster-attributes
                 - transform/drop-kyma-attributes
@@ -38,6 +39,7 @@ service:
                 - transform/set-instrumentation-scope-kyma
                 - transform/drop-unknown-service-name
                 - k8s_attributes
+                - transform/restore-otel-service-attrs
                 - transform/insert-cluster-attributes
             exporters:
                 - forward/enrichment
@@ -71,6 +73,7 @@ service:
                 - transform/drop-istio-service-enrichment
                 - transform/drop-unknown-service-name
                 - k8s_attributes
+                - transform/restore-otel-service-attrs
                 - istio_noise_filter
                 - transform/insert-cluster-attributes
                 - transform/drop-kyma-attributes
@@ -186,21 +189,63 @@ processors:
                 - delete_matching_keys(resource.attributes, "service.*") where span.attributes["component"] == "proxy"
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/drop-unknown-service-name:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and HasPrefix(resource.attributes["service.name"], "unknown_service")
+        metric_statements:
+            - statements:
+                - delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and HasPrefix(resource.attributes["service.name"], "unknown_service")
         trace_statements:
             - statements:
                 - delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and HasPrefix(resource.attributes["service.name"], "unknown_service")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
                 - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
                 - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+    transform/restore-otel-service-attrs:
+        error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["service.name"], resource.attributes["kyma.otel.annotation.service.name"]) where resource.attributes["kyma.otel.annotation.service.name"] != nil and resource.attributes["kyma.otel.annotation.service.name"] != ""
+                - delete_key(resource.attributes, "kyma.otel.annotation.service.name")
+                - set(resource.attributes["service.version"], resource.attributes["kyma.otel.annotation.service.version"]) where resource.attributes["kyma.otel.annotation.service.version"] != nil and resource.attributes["kyma.otel.annotation.service.version"] != ""
+                - delete_key(resource.attributes, "kyma.otel.annotation.service.version")
+        metric_statements:
+            - statements:
+                - set(resource.attributes["service.name"], resource.attributes["kyma.otel.annotation.service.name"]) where resource.attributes["kyma.otel.annotation.service.name"] != nil and resource.attributes["kyma.otel.annotation.service.name"] != ""
+                - delete_key(resource.attributes, "kyma.otel.annotation.service.name")
+                - set(resource.attributes["service.version"], resource.attributes["kyma.otel.annotation.service.version"]) where resource.attributes["kyma.otel.annotation.service.version"] != nil and resource.attributes["kyma.otel.annotation.service.version"] != ""
+                - delete_key(resource.attributes, "kyma.otel.annotation.service.version")
+        trace_statements:
+            - statements:
+                - set(resource.attributes["service.name"], resource.attributes["kyma.otel.annotation.service.name"]) where resource.attributes["kyma.otel.annotation.service.name"] != nil and resource.attributes["kyma.otel.annotation.service.name"] != ""
+                - delete_key(resource.attributes, "kyma.otel.annotation.service.name")
+                - set(resource.attributes["service.version"], resource.attributes["kyma.otel.annotation.service.version"]) where resource.attributes["kyma.otel.annotation.service.version"] != nil and resource.attributes["kyma.otel.annotation.service.version"] != ""
+                - delete_key(resource.attributes, "kyma.otel.annotation.service.version")
     transform/set-instrumentation-scope-kyma:
         error_mode: ignore
         metric_statements:

--- a/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/single-pipeline.yaml
@@ -177,11 +177,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/trace-single-pipeline.yaml
@@ -105,11 +105,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-filters.yaml
@@ -249,11 +249,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transform-filter.yaml
@@ -198,11 +198,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/user-defined-transforms.yaml
@@ -219,11 +219,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/vpa-active-all-signals.yaml
@@ -176,11 +176,27 @@ processors:
             - kyma.app_name
     transform/drop-kyma-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
+        metric_statements:
+            - statements:
+                - delete_matching_keys(resource.attributes, "kyma.*")
         trace_statements:
             - statements:
                 - delete_matching_keys(resource.attributes, "kyma.*")
     transform/insert-cluster-attributes:
         error_mode: ignore
+        log_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
+        metric_statements:
+            - statements:
+                - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""
+                - set(resource.attributes["k8s.cluster.uid"], "") where resource.attributes["k8s.cluster.uid"] == nil or resource.attributes["k8s.cluster.uid"] == ""
+                - set(resource.attributes["cloud.provider"], "test-cloud-provider") where resource.attributes["cloud.provider"] == nil or resource.attributes["cloud.provider"] == ""
         trace_statements:
             - statements:
                 - set(resource.attributes["k8s.cluster.name"], "${KUBERNETES_SERVICE_HOST}") where resource.attributes["k8s.cluster.name"] == nil or resource.attributes["k8s.cluster.name"] == ""

--- a/test/e2e/logs/shared/service_enrichment_test.go
+++ b/test/e2e/logs/shared/service_enrichment_test.go
@@ -175,6 +175,14 @@ func TestServiceEnrichment_OTel(t *testing.T) {
 					kitk8sobjects.NewPod(podWithUnknownServiceName, genNs).WithPodSpec(podSpecWithUnknownServiceName).K8sObject(),
 					kitk8sobjects.NewPod(podWithUnknownServicePatternName, genNs).WithPodSpec(podSpecWithUnknownServiceNamePattern).K8sObject(),
 					kitk8sobjects.NewPod(podWithCustomServiceAttributesName, genNs).WithPodSpec(podSpecWithCustomServiceAttributes).K8sObject(),
+					// Pod with conflicting k8s labels (lower priority) and OTel annotations (higher priority).
+					// Tests that the gateway's restore processor ensures annotation > label priority for OTLP-pushed logs.
+					kitk8sobjects.NewPod(podWithAnnotationPriorityName, genNs).
+						WithAnnotation(annotationServiceName, customServiceName).
+						WithAnnotation(annotationServiceVersion, customServiceVersion).
+						WithLabel(labelK8sName, labelServiceName).
+						WithLabel(labelK8sVersion, labelVersion).
+						WithPodSpec(telemetrygen.PodSpec(telemetrygen.SignalTypeLogs, telemetrygen.WithServiceName(""))).K8sObject(),
 				)
 			}
 
@@ -234,13 +242,11 @@ func TestServiceEnrichment_OTel(t *testing.T) {
 				ServiceInstanceID: customServiceInstanceID,
 			})
 
-			// Annotation-level service attributes should take priority over app.kubernetes.io/* pod labels (agent only)
-			if suite.ExpectAgent(tc.label) {
-				verifyServiceAttributes(t, backend, podWithAnnotationPriorityName, ServiceAttributes{
-					ServiceName:    customServiceName,
-					ServiceVersion: customServiceVersion,
-				})
-			}
+			// Annotation-level service attributes should take priority over app.kubernetes.io/* pod labels
+			verifyServiceAttributes(t, backend, podWithAnnotationPriorityName, ServiceAttributes{
+				ServiceName:    customServiceName,
+				ServiceVersion: customServiceVersion,
+			})
 
 			// Verify that temporary kyma resource attributes are removed from the logs
 			assert.BackendDataConsistentlyMatches(t, backend,

--- a/test/e2e/metrics/agent/service_enrichment_test.go
+++ b/test/e2e/metrics/agent/service_enrichment_test.go
@@ -35,6 +35,7 @@ func TestServiceEnrichment(t *testing.T) {
 		podWithUnknownServicePatternName   = "pod-with-unknown-service-pattern"
 		podWithCustomServiceAttributesName = "pod-with-custom-service"
 		podWithAnnotationPriorityName      = "pod-with-annotation-priority"
+		podWithAnnotationPriorityOTLPName  = "pod-with-annotation-priority-otlp"
 
 		// annotation keys
 		annotationServiceName    = "resource.opentelemetry.io/service.name"
@@ -95,6 +96,12 @@ func TestServiceEnrichment(t *testing.T) {
 	// OTel annotations provide the high-priority service attributes; k8s labels are the competing lower priority.
 	// Tests that the agent's k8sattributes enrichment respects annotation > label priority.
 	podSpecWithAnnotationPriority := stdoutloggen.PodSpec()
+	// Pushes OTLP metrics through the gateway with empty service.name so k8sattributes enriches from pod metadata.
+	// OTel annotations provide the high-priority service attributes; k8s labels are the competing lower priority.
+	// Tests that the gateway's restore processor ensures annotation > label priority for OTLP-pushed metrics.
+	podSpecWithAnnotationPriorityOTLP := telemetrygen.PodSpec(telemetrygen.SignalTypeMetrics,
+		telemetrygen.WithServiceName(""),
+	)
 
 	// Enable OTel service enrichment strategy
 	// TODO(TeodorSAP): Remove this block after deprecation period ends and OTel strategy becomes default enrichment strategy
@@ -122,6 +129,12 @@ func TestServiceEnrichment(t *testing.T) {
 			WithLabel(labelK8sInstance, labelInstanceName).
 			WithLabel(labelK8sVersion, labelVersion).
 			WithPodSpec(podSpecWithAnnotationPriority).K8sObject(),
+		kitk8sobjects.NewPod(podWithAnnotationPriorityOTLPName, genNs).
+			WithAnnotation(annotationServiceName, customServiceName).
+			WithAnnotation(annotationServiceVersion, customServiceVersion).
+			WithLabel(labelK8sName, labelServiceName).
+			WithLabel(labelK8sVersion, labelVersion).
+			WithPodSpec(podSpecWithAnnotationPriorityOTLP).K8sObject(),
 	}
 	resources = append(resources, backend.K8sObjects()...)
 
@@ -159,6 +172,12 @@ func TestServiceEnrichment(t *testing.T) {
 
 	// Annotation-level service attributes should take priority over app.kubernetes.io/* pod labels
 	verifyServiceAttributes(t, backend, podWithAnnotationPriorityName, ServiceAttributes{
+		ServiceName:    customServiceName,
+		ServiceVersion: customServiceVersion,
+	})
+
+	// Annotation-level service attributes should take priority for OTLP-pushed metrics through the gateway
+	verifyServiceAttributes(t, backend, podWithAnnotationPriorityOTLPName, ServiceAttributes{
 		ServiceName:    customServiceName,
 		ServiceVersion: customServiceVersion,
 	})

--- a/test/e2e/traces/service_enrichment_test.go
+++ b/test/e2e/traces/service_enrichment_test.go
@@ -32,6 +32,15 @@ func TestServiceEnrichment(t *testing.T) {
 		podWithUnknownServiceName          = "pod-with-unknown-service"
 		podWithUnknownServicePatternName   = "pod-with-unknown-service-pattern"
 		podWithCustomServiceAttributesName = "pod-with-custom-service"
+		podWithAnnotationPriorityName      = "pod-with-annotation-priority"
+
+		// annotation keys
+		annotationServiceName    = "resource.opentelemetry.io/service.name"
+		annotationServiceVersion = "resource.opentelemetry.io/service.version"
+
+		// label keys
+		labelK8sName    = "app.kubernetes.io/name"
+		labelK8sVersion = "app.kubernetes.io/version"
 
 		// misc
 		unknownService          = "unknown_service"
@@ -40,6 +49,8 @@ func TestServiceEnrichment(t *testing.T) {
 		customServiceNamespace  = "custom-namespace"
 		customServiceVersion    = "v1.2.3"
 		customServiceInstanceID = "instance-1234"
+		labelServiceName        = "label-service-name"
+		labelVersion            = "label-version"
 	)
 
 	var (
@@ -75,6 +86,12 @@ func TestServiceEnrichment(t *testing.T) {
 		telemetrygen.WithServiceVersion(customServiceVersion),
 		telemetrygen.WithServiceInstanceID(customServiceInstanceID),
 	)
+	// Empty service.name so k8sattributes enriches from pod metadata.
+	// OTel annotations provide the high-priority service attributes; k8s labels are the competing lower priority.
+	// Tests that the gateway's restore processor ensures annotation > label priority.
+	podSpecWithAnnotationPriority := telemetrygen.PodSpec(telemetrygen.SignalTypeTraces,
+		telemetrygen.WithServiceName(""),
+	)
 
 	// Enable OTel service enrichment strategy
 	// TODO(TeodorSAP): Remove this block after deprecation period ends and OTel strategy becomes default enrichment strategy
@@ -95,6 +112,12 @@ func TestServiceEnrichment(t *testing.T) {
 		kitk8sobjects.NewPod(podWithUnknownServiceName, genNs).WithPodSpec(podSpecWithUnknownServiceName).K8sObject(),
 		kitk8sobjects.NewPod(podWithUnknownServicePatternName, genNs).WithPodSpec(podSpecWithUnknownServiceNamePattern).K8sObject(),
 		kitk8sobjects.NewPod(podWithCustomServiceAttributesName, genNs).WithPodSpec(podSpecWithCustomServiceAttributes).K8sObject(),
+		kitk8sobjects.NewPod(podWithAnnotationPriorityName, genNs).
+			WithAnnotation(annotationServiceName, customServiceName).
+			WithAnnotation(annotationServiceVersion, customServiceVersion).
+			WithLabel(labelK8sName, labelServiceName).
+			WithLabel(labelK8sVersion, labelVersion).
+			WithPodSpec(podSpecWithAnnotationPriority).K8sObject(),
 	}
 	resources = append(resources, backend.K8sObjects()...)
 
@@ -126,6 +149,12 @@ func TestServiceEnrichment(t *testing.T) {
 		ServiceNamespace:  customServiceNamespace,
 		ServiceVersion:    customServiceVersion,
 		ServiceInstanceID: customServiceInstanceID,
+	})
+
+	// Annotation-level service attributes should take priority over app.kubernetes.io/* pod labels
+	verifyServiceAttributes(t, backend, podWithAnnotationPriorityName, ServiceAttributes{
+		ServiceName:    customServiceName,
+		ServiceVersion: customServiceVersion,
 	})
 
 	// Verify that temporary kyma resource attributes are removed from the spans


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix attribute enrichment for OTLP Gateway
  - Bug 1: Only `trace_statemenets` were previously defined for the OTel transform processors
  - Bug 2: Trace configuration was missing "restore-otel-service-attrs" transform processor

Changes refer to particular issues, PRs or documents:

- Resolves https://github.com/kyma-project/telemetry-manager/issues/3507

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
