### PR TITLE
chore: include test files in PR description generation

### DIFF
--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -16,6 +16,7 @@ on:
       - "OWNERS"
       - "CODEOWNERS"
       - "external-images.yaml"
+      - ".hyperspace/**"
   push:
     branches:
       - "main"
@@ -28,6 +29,7 @@ on:
       - "OWNERS"
       - "CODEOWNERS"
       - "external-images.yaml"
+      - ".hyperspace/**"
 
 jobs:
   envs:

--- a/.github/workflows/pr-code-checks.yml
+++ b/.github/workflows/pr-code-checks.yml
@@ -15,6 +15,7 @@ on:
       - "OWNERS"
       - "CODEOWNERS"
       - "external-images.yaml"
+      - ".hyperspace/**"
   workflow_dispatch:
 
 jobs:

--- a/.hyperspace/pull_request_bot.json
+++ b/.hyperspace/pull_request_bot.json
@@ -20,10 +20,7 @@
       "auto_insert_summary": false,
       "use_custom_summarize_prompt": true,
       "use_custom_summarize_output_template": true,
-      "excluded_paths": [
-        "test/**",
-        "**/*_test.go"
-      ]
+      "excluded_paths": []
     },
     "review": {
       "auto_generate_review": false,


### PR DESCRIPTION
## What Changed

Removes the exclusion of test files and test directories from the PR summary bot configuration so that PR descriptions now cover test-related changes alongside production code.

<details>
<summary>Key Changes</summary>

- **`.hyperspace/pull_request_bot.json`**: Removes `test/**` and `**/*_test.go` from the `excluded_paths` list, replacing it with an empty array so the bot includes test files when generating PR summaries.

</details>

## Notes for Reviewers

This is a pure tooling change with no impact on runtime behavior. The motivation is to avoid incomplete PR summaries when a PR contains meaningful test logic changes.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `dc159eee-e7fb-41cb-bfbd-1dd878854398`
</details>
