### PR TITLE
docs: use harmonized otel endpoint in integration guides

### DIFF
--- a/docs/user/integration/k8s-events/values.yaml
+++ b/docs/user/integration/k8s-events/values.yaml
@@ -11,7 +11,7 @@ config:
   exporters:
     # Configures the exporter to push to the OTLP Gateway
     otlp:
-      endpoint: telemetry-otlp-logs.kyma-system.svc.cluster.local:4317
+      endpoint: telemetry-otlp.kyma-system.svc.cluster.local:4317
       tls:
         # mTLS will be handled by istio
         insecure: true

--- a/docs/user/integration/sample-app/deployment/deployment-prometheus.yaml
+++ b/docs/user/integration/sample-app/deployment/deployment-prometheus.yaml
@@ -29,10 +29,8 @@ spec:
         - name: http
           containerPort: 8080
         env:
-        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-          value: "http://telemetry-otlp-traces.kyma-system:4317"
-        - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-          value: "http://telemetry-otlp-metrics.kyma-system:4317"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://telemetry-otlp.kyma-system:4317"
         - name: OTEL_METRICS_EXPORTER
           value: "prometheus"
         - name: OTEL_SERVICE_NAME

--- a/docs/user/integration/sample-app/deployment/deployment.yaml
+++ b/docs/user/integration/sample-app/deployment/deployment.yaml
@@ -29,10 +29,8 @@ spec:
         - name: http
           containerPort: 8080
         env:
-        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-          value: "http://telemetry-otlp-traces.kyma-system:4317"
-        - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-          value: "http://telemetry-otlp-metrics.kyma-system:4317"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://telemetry-otlp.kyma-system:4317"
         - name: OTEL_METRICS_EXPORTER
           value: "otlp"
         - name: OTEL_SERVICE_NAME


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- adjusted usage of per-signal endpoints to the harmonized endpoint in integration guides

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
