### PR TITLE
chore: group k8s.io and sigs.k8s.io renovate bumps together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,16 @@
         "https://github.com/open-telemetry/opentelemetry-collector{/,}**",
         "https://github.com/open-telemetry/opentelemetry-collector-contrib{/,}**"
       ]
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "All Kubernetes packages",
+      "matchPackagePrefixes": [
+        "k8s.io/",
+        "sigs.k8s.io/"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## What Changed

Adds a Renovate grouping rule that batches all `k8s.io/*` and `sigs.k8s.io/*` Go module dependencies into a single PR, preventing version skew between `controller-runtime`, `client-go`, `apimachinery`, and related packages.

<details>
<summary>Key Changes</summary>

- **`renovate.json`**: Adds a new `packageRules` entry that groups all `k8s.io/` and `sigs.k8s.io/` Go module updates under the group name "All Kubernetes packages".

</details>

## Notes for Reviewers

`controller-runtime` requires matching versions of `client-go` and other `k8s.io` packages. Bumping them in separate PRs risks compilation failures or subtle runtime issues caused by version skew. This change mirrors the existing grouping strategy already in place for OpenTelemetry Collector packages.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Correlation ID: `478a03c9-f8f6-4ffa-bc9e-c31a79ff81cf`
- Event Trigger: `issue_comment.edited`
</details>
