### PR TITLE
chore: optimize GitHub Actions trigger path filters

### DIFF
--- a/.github/workflows/build-manager-image.yml
+++ b/.github/workflows/build-manager-image.yml
@@ -12,10 +12,13 @@ on:
       - "release-[0-9]+.[0-9]+"
     paths-ignore:
       - "docs/**"
+      - "dependencies/**"
       - "**/*.md"
       - "OWNERS"
       - "CODEOWNERS"
       - "external-images.yaml"
+      - "renovate.json"
+      - "sec-scanners-config.yaml"
       - ".hyperspace/**"
   push:
     branches:
@@ -29,6 +32,8 @@ on:
       - "OWNERS"
       - "CODEOWNERS"
       - "external-images.yaml"
+      - "renovate.json"
+      - "sec-scanners-config.yaml"
       - ".hyperspace/**"
 
 jobs:

--- a/.github/workflows/periodic-codeql.yaml
+++ b/.github/workflows/periodic-codeql.yaml
@@ -15,10 +15,28 @@ on:
     branches:
       - "main"
       - "release-*"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "OWNERS"
+      - "CODEOWNERS"
+      - "external-images.yaml"
+      - "sec-scanners-config.yaml"
+      - "renovate.json"
+      - ".hyperspace/**"
   pull_request:
     branches:
       - "main"
       - "release-*"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "OWNERS"
+      - "CODEOWNERS"
+      - "external-images.yaml"
+      - "sec-scanners-config.yaml"
+      - "renovate.json"
+      - ".hyperspace/**"
   schedule:
     - cron: '35 7 * * 1'
 

--- a/.github/workflows/pr-docu-checks.yml
+++ b/.github/workflows/pr-docu-checks.yml
@@ -8,11 +8,14 @@ on:
     branches:
       - "main"
       - "release-*"
-    paths-ignore:
-      - "dependencies/**"
-      - "OWNERS"
-      - "CODEOWNERS"
-      - "external-images.yaml"
+    paths:
+      - "docs/**"
+      - "**/*.md"
+      - "apis/**"
+      - "webhook/**"
+      - "config/**"
+      - "helm/**"
+      - ".github/workflows/pr-docu-checks.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What Changed

Tightens GitHub Actions path filters for three workflows to avoid triggering expensive CI jobs (multi-arch image builds, CodeQL scans, documentation manifest verification) on changes to files that have no effect on the compiled binary or kubebuilder-generated manifests.

<details>
<summary>Key Changes</summary>

- **`.github/workflows/build-manager-image.yml`**: Adds `dependencies/**`, `renovate.json`, and `sec-scanners-config.yaml` to the `paths-ignore` list for both `pull_request_target` and `push` triggers so Renovate dependency-pin PRs and scanner config updates no longer trigger a multi-arch image build.
- **`.github/workflows/periodic-codeql.yaml`**: Adds a `paths-ignore` block to both the `push` and `pull_request` triggers to skip docs, metadata, and config-only changes that contain no scannable application code.
- **`.github/workflows/pr-docu-checks.yml`**: Replaces the broad `paths-ignore` filter with a precise positive `paths` filter targeting `docs/**`, `**/*.md`, `apis/**`, `webhook/**`, `config/**`, `helm/**`, and the workflow file itself, so pure Go logic changes in `internal/**` no longer trigger CRD manifest verification.

</details>

## Notes for Reviewers

The `pr-docu-checks` change is the most impactful: switching from `paths-ignore` to `paths` means the workflow only runs when documentation or kubebuilder-marker-bearing files change. Kubebuilder markers exist only in `apis/` and `webhook/`, confirmed by grep, so excluding `internal/**` is safe. If new marker-bearing directories are added in the future, they must be added to the `paths` list explicitly.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `6e798747-be96-4fb7-9435-43e85da7c026`
</details>
