### PR TITLE
test: fix flaky cumulative to delta e2e test

### DIFF
--- a/test/e2e/metrics/shared/cumulative_to_delta_gauge_unaffected_test.go
+++ b/test/e2e/metrics/shared/cumulative_to_delta_gauge_unaffected_test.go
@@ -20,21 +20,22 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
 )
 
-// TestCumulativeToDelta verifies that the cumulativetodelta processor converts
-// cumulative Sum metrics to delta temporality when configured.
-func TestCumulativeToDelta(t *testing.T) {
+// TestCumulativeToDeltaGaugeUnaffected verifies that Gauge metrics are not affected
+// by the cumulativetodelta processor (Gauges have no aggregation temporality).
+func TestCumulativeToDeltaGaugeUnaffected(t *testing.T) {
 	tests := []struct {
 		name             string
 		labels           []string
 		inputBuilder     func(includeNs string) telemetryv1beta1.MetricPipelineInput
 		generatorBuilder func(ns string) []client.Object
+		metricNames      []string
 		expectAgent      bool
 	}{
 		{
 			name:   "agent",
 			labels: []string{suite.LabelMetricAgent},
 			inputBuilder: func(includeNs string) telemetryv1beta1.MetricPipelineInput {
-				return testutils.BuildMetricPipelineRuntimeInput(testutils.IncludeNamespaces(includeNs))
+				return testutils.BuildMetricPipelineAgentInput(false, true, false, testutils.IncludeNamespaces(includeNs))
 			},
 			generatorBuilder: func(ns string) []client.Object {
 				generator := prommetricgen.New(ns)
@@ -44,6 +45,7 @@ func TestCumulativeToDelta(t *testing.T) {
 					generator.Service().WithPrometheusAnnotations(prommetricgen.SchemeHTTP).K8sObject(),
 				}
 			},
+			metricNames: []string{prommetricgen.MetricCPUTemperature.Name},
 			expectAgent: true,
 		},
 		{
@@ -54,9 +56,10 @@ func TestCumulativeToDelta(t *testing.T) {
 			},
 			generatorBuilder: func(ns string) []client.Object {
 				return []client.Object{
-					telemetrygen.NewPod(ns, telemetrygen.SignalTypeMetrics, telemetrygen.WithMetricType("Sum")).K8sObject(),
+					telemetrygen.NewPod(ns, telemetrygen.SignalTypeMetrics).K8sObject(),
 				}
 			},
+			metricNames: telemetrygen.MetricNames,
 		},
 	}
 
@@ -98,20 +101,14 @@ func TestCumulativeToDelta(t *testing.T) {
 
 			assert.MetricPipelineHealthy(t, pipelineName)
 
+			// Gauge metrics should still be delivered with no aggregation temporality
 			assert.BackendDataEventuallyMatches(t, backend,
 				metricmatchers.HaveFlatMetrics(ContainElement(SatisfyAll(
-					metricmatchers.HaveType(Equal("Sum")),
-					metricmatchers.HaveAggregationTemporality(Equal("Delta")),
+					metricmatchers.HaveName(BeElementOf(tc.metricNames)),
+					metricmatchers.HaveType(Equal("Gauge")),
+					metricmatchers.HaveAggregationTemporality(BeEmpty()),
 					metricmatchers.HaveResourceAttributes(HaveKeyWithValue("k8s.namespace.name", genNs)),
 				))),
-			)
-
-			assert.BackendDataConsistentlyMatches(t, backend,
-				metricmatchers.HaveFlatMetrics(Not(ContainElement(SatisfyAll(
-					metricmatchers.HaveType(Equal("Sum")),
-					metricmatchers.HaveAggregationTemporality(Equal("Cumulative")),
-					metricmatchers.HaveResourceAttributes(HaveKeyWithValue("k8s.namespace.name", genNs)),
-				)))),
 			)
 		})
 	}

--- a/test/e2e/metrics/shared/cumulative_to_delta_mixed_pipelines_test.go
+++ b/test/e2e/metrics/shared/cumulative_to_delta_mixed_pipelines_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/kyma-project/telemetry-manager/test/testkit/unique"
 )
 
-// TestCumulativeToDelta verifies that the cumulativetodelta processor converts
-// cumulative Sum metrics to delta temporality when configured.
-func TestCumulativeToDelta(t *testing.T) {
+// TestCumulativeToDeltaMixedPipelines verifies that when two pipelines consume the same metrics,
+// the delta pipeline receives Delta temporality while the cumulative pipeline receives Cumulative.
+func TestCumulativeToDeltaMixedPipelines(t *testing.T) {
 	tests := []struct {
 		name             string
 		labels           []string
@@ -65,40 +65,54 @@ func TestCumulativeToDelta(t *testing.T) {
 			suite.SetupTest(t, tc.labels...)
 
 			var (
-				uniquePrefix = unique.Prefix(tc.name)
-				pipelineName = uniquePrefix()
-				backendNs    = uniquePrefix("backend")
-				genNs        = uniquePrefix("gen")
+				uniquePrefix  = unique.Prefix(tc.name)
+				pipelineDelta = uniquePrefix("delta")
+				pipelineCumul = uniquePrefix("cumul")
+				backendNs     = uniquePrefix("backend")
+				genNs         = uniquePrefix("gen")
 			)
 
-			backend := kitbackend.New(backendNs, kitbackend.SignalTypeMetrics)
-			pipeline := testutils.NewMetricPipelineBuilder().
-				WithName(pipelineName).
+			backendDelta := kitbackend.New(backendNs, kitbackend.SignalTypeMetrics, kitbackend.WithName("backend-delta"))
+			backendCumul := kitbackend.New(backendNs, kitbackend.SignalTypeMetrics, kitbackend.WithName("backend-cumul"))
+
+			pipelineWithDelta := testutils.NewMetricPipelineBuilder().
+				WithName(pipelineDelta).
 				WithInput(tc.inputBuilder(genNs)).
 				WithTemporality(telemetryv1beta1.TemporalityDelta).
-				WithMetricPipelineOTLPOutput(testutils.OTLPEndpoint(backend.EndpointHTTP())).
+				WithMetricPipelineOTLPOutput(testutils.OTLPEndpoint(backendDelta.EndpointHTTP())).
+				Build()
+
+			pipelineWithCumulative := testutils.NewMetricPipelineBuilder().
+				WithName(pipelineCumul).
+				WithInput(tc.inputBuilder(genNs)).
+				WithMetricPipelineOTLPOutput(testutils.OTLPEndpoint(backendCumul.EndpointHTTP())).
 				Build()
 
 			resources := []client.Object{
 				kitk8sobjects.NewNamespace(backendNs).K8sObject(),
 				kitk8sobjects.NewNamespace(genNs).K8sObject(),
-				new(pipeline),
+				new(pipelineWithDelta),
+				new(pipelineWithCumulative),
 			}
 			resources = append(resources, tc.generatorBuilder(genNs)...)
-			resources = append(resources, backend.K8sObjects()...)
+			resources = append(resources, backendDelta.K8sObjects()...)
+			resources = append(resources, backendCumul.K8sObjects()...)
 
 			Expect(kitk8s.CreateObjects(t, resources...)).To(Succeed())
 
-			assert.BackendReachable(t, backend)
+			assert.BackendReachable(t, backendDelta)
+			assert.BackendReachable(t, backendCumul)
 			assert.DaemonSetReady(t, kitkyma.OTLPGatewayName)
 
 			if tc.expectAgent {
 				assert.DaemonSetReady(t, kitkyma.MetricAgentName)
 			}
 
-			assert.MetricPipelineHealthy(t, pipelineName)
+			assert.MetricPipelineHealthy(t, pipelineDelta)
+			assert.MetricPipelineHealthy(t, pipelineCumul)
 
-			assert.BackendDataEventuallyMatches(t, backend,
+			// Delta pipeline receives Sum metrics with Delta temporality
+			assert.BackendDataEventuallyMatches(t, backendDelta,
 				metricmatchers.HaveFlatMetrics(ContainElement(SatisfyAll(
 					metricmatchers.HaveType(Equal("Sum")),
 					metricmatchers.HaveAggregationTemporality(Equal("Delta")),
@@ -106,12 +120,13 @@ func TestCumulativeToDelta(t *testing.T) {
 				))),
 			)
 
-			assert.BackendDataConsistentlyMatches(t, backend,
-				metricmatchers.HaveFlatMetrics(Not(ContainElement(SatisfyAll(
+			// Cumulative pipeline receives Sum metrics with Cumulative temporality (no conversion)
+			assert.BackendDataEventuallyMatches(t, backendCumul,
+				metricmatchers.HaveFlatMetrics(ContainElement(SatisfyAll(
 					metricmatchers.HaveType(Equal("Sum")),
 					metricmatchers.HaveAggregationTemporality(Equal("Cumulative")),
 					metricmatchers.HaveResourceAttributes(HaveKeyWithValue("k8s.namespace.name", genNs)),
-				)))),
+				))),
 			)
 		})
 	}

--- a/test/e2e/metrics/shared/cumulative_to_delta_test.go
+++ b/test/e2e/metrics/shared/cumulative_to_delta_test.go
@@ -120,7 +120,7 @@ func TestCumulativeToDelta(t *testing.T) {
 
 // TestCumulativeToDeltaMixedPipelines verifies that when two pipelines consume the same metrics,
 // the delta pipeline receives Delta temporality while the cumulative pipeline receives Cumulative.
-func TestCumulativeToDeltaMixedPipelines(t *testing.T) {
+func TestCumulativeToDelta_MixedPipelines(t *testing.T) {
 	tests := []struct {
 		name             string
 		labels           []string
@@ -232,7 +232,7 @@ func TestCumulativeToDeltaMixedPipelines(t *testing.T) {
 
 // TestCumulativeToDeltaGaugeUnaffected verifies that Gauge metrics are not affected
 // by the cumulativetodelta processor (Gauges have no aggregation temporality).
-func TestCumulativeToDeltaGaugeUnaffected(t *testing.T) {
+func TestCumulativeToDelta_GaugeUnaffected(t *testing.T) {
 	tests := []struct {
 		name             string
 		labels           []string


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Flaky e2e cumulative to delta test https://github.com/kyma-project/telemetry-manager/actions/runs/26274121406/job/77334214554
- Split cumulative_to_delta_test.go (3 test functions) into 3 separate files to avoid namespace name collisions that
  caused consistent 409 Conflict errors.
- The unique.Prefix function derives namespace uniqueness from the test file name. Having TestCumulativeToDelta,
  TestCumulativeToDeltaMixedPipelines, and TestCumulativeToDeltaGaugeUnaffected in the same file meant all three
  generated identical namespace names (e.g. cumulative-to-delta-agent-backend), causing the second/third test to fail
  when the previous test's namespace was still terminating.

Changes refer to particular issues, PRs or documents:

- #3514 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
