### PR TITLE
chore: use ubuntu-latest runners for pr-integration workflow

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -68,7 +68,7 @@ env:
 
 jobs:
   setup:
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     outputs:
       manager-image: ${{ steps.set-env.outputs.manager-image }}
     steps:
@@ -153,7 +153,7 @@ jobs:
   # e2e-logs split by fluent-bit vs otel AND by set labels for parallel execution
   e2e-logs:
     needs: setup
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -192,7 +192,7 @@ jobs:
   # e2e-metrics split by set labels for parallel execution
   e2e-metrics:
     needs: setup
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +226,7 @@ jobs:
   # All e2e suites with experimental flavor
   e2e-experimental:
     needs: setup
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -262,7 +262,7 @@ jobs:
   # e2e-traces and e2e-misc (non-experimental) without set splitting
   e2e:
     needs: setup
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -294,7 +294,7 @@ jobs:
   # Upgrade and integration tests
   e2e-other:
     needs: setup
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -390,7 +390,7 @@ jobs:
 
   summary:
     needs: [e2e-logs, e2e-metrics, e2e-experimental, e2e, e2e-other, selfmonitor-healthy, selfmonitor]
-    runs-on: telemetry-4core
+    runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Replace all `telemetry-4core` runner references in `.github/workflows/pr-integration.yml` with `ubuntu-latest`
- Affects `setup`, `e2e-logs`, `e2e-metrics`, `e2e-experimental`, `e2e`, `e2e-other`, and `summary` jobs

## Test plan
- [ ] Verify PR integration workflow runs successfully with the new runner configuration