### PR TITLE
chore: scope gardener workflows to github-actions environment

### DIFF
--- a/.github/workflows/gardener-integration.yml
+++ b/.github/workflows/gardener-integration.yml
@@ -72,6 +72,7 @@ jobs:
   gardener-integration-test:
     needs: check-trigger
     if: needs.check-trigger.outputs.run-gardener-tests == 'true'
+    environment: github-actions
     strategy:
       fail-fast: false # if one version is not working, continue tests on other versions
       matrix:
@@ -131,8 +132,8 @@ jobs:
       - name: Provision Gardener
         run: make provision-gardener
         env:
-          GARDENER_SECRET_NAME: ${{ secrets.GARDENER_SECRET_NAME }}
-          GARDENER_PROJECT: ${{ secrets.GARDENER_PROJECT }}
+          GARDENER_SECRET_NAME: ${{ vars.GARDENER_SECRET_NAME }}
+          GARDENER_PROJECT: ${{ vars.GARDENER_PROJECT }}
           GARDENER_SA_PATH: /tmp/gardener-sa.yaml
           GARDENER_K8S_VERSION: ${{ matrix.k8s_version }}
 

--- a/.github/workflows/pr-loadtest.yml
+++ b/.github/workflows/pr-loadtest.yml
@@ -57,6 +57,7 @@ jobs:
 
   load-test:
     needs: prepare-matrix
+    environment: github-actions
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -92,8 +93,8 @@ jobs:
       - name: Provision gardener cluster
         run: make provision-gardener
         env:
-          GARDENER_SECRET_NAME: ${{ secrets.GARDENER_SECRET_NAME }}
-          GARDENER_PROJECT: ${{ secrets.GARDENER_PROJECT }}
+          GARDENER_SECRET_NAME: ${{ vars.GARDENER_SECRET_NAME }}
+          GARDENER_PROJECT: ${{ vars.GARDENER_PROJECT }}
           GARDENER_SA_PATH: /tmp/gardener-sa.yaml
           GARDENER_MIN_NODES: 2
           GARDENER_MAX_NODES: 2


### PR DESCRIPTION
## What Changed

Scopes the Gardener integration test and load test GitHub Actions jobs to the `github-actions` environment and updates `GARDENER_PROJECT` and `GARDENER_SECRET_NAME` to read from repository variables (`vars.*`) instead of secrets (`secrets.*`), reflecting their conversion from secrets to plain variables.

<details>
<summary>Key Changes</summary>

- **`.github/workflows/gardener-integration.yml`**: Adds `environment: github-actions` to the `gardener-integration-test` job and switches `GARDENER_PROJECT` and `GARDENER_SECRET_NAME` from `secrets.*` to `vars.*`.
- **`.github/workflows/pr-loadtest.yml`**: Adds `environment: github-actions` to the `load-test` job and switches `GARDENER_PROJECT` and `GARDENER_SECRET_NAME` from `secrets.*` to `vars.*`.

</details>

## Notes for Reviewers

`GARDENER_SA` remains a secret because it contains sensitive credentials. Only `GARDENER_PROJECT` and `GARDENER_SECRET_NAME` were promoted to repository variables and are now accessed via `vars.*`.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Correlation ID: `87fee52a-bd6d-4c1a-be7e-65c9e795e56e`
- Event Trigger: `issue_comment.edited`
</details>
