### PR TITLE
docs: fix a broken link in 021-refactor-performance-tests.md (#3574)

### DIFF
--- a/docs/contributor/arch/021-refactor-performance-tests.md
+++ b/docs/contributor/arch/021-refactor-performance-tests.md
@@ -25,7 +25,7 @@ A [POC](../pocs/opentelemetry-testbed/) has been implemented for using the `Load
 
 #### Disadvantages:
 - There is no [DataSender](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/testbed/datasenders) available that writes logs to stdout.
-    - The [FileLogWriter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/testbed/datasenders/stanza.go) converts OTLP logs to text lines and writes them to a temporary log file. This is not suitable for our Log Agent, because it tails logs that are only written to the stdout.
+    - The [FileLogWriter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/testbed/datasenders/stanzadatasender/sender.go) converts OTLP logs to text lines and writes them to a temporary log file. This is not suitable for our Log Agent, because it tails logs that are only written to the stdout.
     - The workaround in the POC is to write a custom `stdoutLogGenerator`, which implements the `DataSender` interface. The `stdoutLogGenerator` is very similar to the `FileLogWriter`, but it writes logs to stdout instead of a temporary log file.
 - The receiver used in the mock backend is [listening](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/testbed/testbed/receivers.go#L81) on `127.0.0.1:4317` (localhost only).
     - This works fine for the performance tests in the `opentelemetry-collector-contrib` repo, because these test are executed locally. However, we must test our Telemetry module collectors in a Kubernetes cluster.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- fix dead link in docs

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
