### PR TITLE
fix: revert fluent bit to use 5.0.4

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ ENV_GORELEASER_VERSION=v1.23.0
 
 ## Default Docker Images
 ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main"
-ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.6"
+ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4"
 ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main"
 # ENV_OTEL_COLLECTOR_CONTRIB_IMAGE is used for OAuth2 E2E tests only, since they require the OIDC extension, which is not needed in production code.
 ENV_OTEL_COLLECTOR_CONTRIB_IMAGE="otel/opentelemetry-collector-contrib:latest"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,7 +19,7 @@ manager:
       alpineImage: europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.4
       appLogLevel: info
       fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
-      fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.6
+      fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4
       gomemlimit: 300MiB
       otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
       selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -3,7 +3,7 @@ kind: kyma
 bdba:
   - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
   - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
-  - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.6
+  - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4
   - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
   - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main
   - europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.11.3


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Seems like fluent bit 5.0.6 is causing memory leaks https://github.com/fluent/fluent-bit/issues/11846

Changes refer to particular issues, PRs or documents:

- https://github.com/fluent/fluent-bit/issues/11846

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
