### PR TITLE
test: bump gardener integration test k8s version to 1.35

### DIFF
--- a/.github/workflows/gardener-integration.yml
+++ b/.github/workflows/gardener-integration.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false # if one version is not working, continue tests on other versions
       matrix:
-        k8s_version: [1.34]
+        k8s_version: [1.34, 1.35]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add k8s version 1.35 to gerdener integration tests

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
