### PR TITLE
fix: add new metric after OCC OTel bump to v0.153.0

### DIFF
--- a/internal/otelcollector/config/metricagent/kubeletstats_metrics.go
+++ b/internal/otelcollector/config/metricagent/kubeletstats_metrics.go
@@ -69,6 +69,7 @@ const (
 	metricK8sPodMemRequestUtilization            = "k8s.pod.memory_request_utilization"
 	metricK8sPodUptime                           = "k8s.pod.uptime"
 	metricK8sPodVolumeUsage                      = "k8s.pod.volume.usage"
+	metricK8sContainerEphemeralStorageUsage      = "k8s.container.ephemeral_storage.usage"
 )
 
 // kubeletStatsReceiverContainerMetrics contains metrics related to container resources.
@@ -154,6 +155,7 @@ var kubeletStatsReceiverExtraMetrics = []string{
 	metricK8sPodMemRequestUtilization,
 	metricK8sPodUptime,
 	metricK8sPodVolumeUsage,
+	metricK8sContainerEphemeralStorageUsage,
 }
 
 // KubeletStatsReceiverMetrics contains all metric names that can be emitted by the kubeletStats receiver.


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Add new `metricK8sContainerEphemeralStorageUsage` metric after OCC OTel bump to v0.153.0

Changes refer to particular issues, PRs or documents:

- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47601

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
