### PR TITLE
chore: revert non manager image build behavior

### DIFF
--- a/.github/workflows/build-directory-size-reporter-image.yml
+++ b/.github/workflows/build-directory-size-reporter-image.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     paths:
       - "dependencies/directory-size-exporter/**"
-    types: [labeled, opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -17,12 +17,11 @@ on:
 
 jobs:
   approval:
-    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'build-image')
     uses: ./.github/workflows/approval-gate.yml
 
   envs:
     needs: [approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.approval.result == 'success')
+    if: always() && (needs.approval.result == 'success' || needs.approval.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.create-tags.outputs.tags }}

--- a/.github/workflows/build-directory-size-reporter-image.yml
+++ b/.github/workflows/build-directory-size-reporter-image.yml
@@ -52,7 +52,8 @@ jobs:
     permissions:
       id-token: write # Required for requesting the JWT token
       contents: read
-    needs: envs
+    needs: [ approval, envs ]
+    if: ${{ always() && needs.envs.result == 'success' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: directory-size-exporter

--- a/.github/workflows/build-fault-backend-image.yaml
+++ b/.github/workflows/build-fault-backend-image.yaml
@@ -49,7 +49,8 @@ jobs:
     permissions:
       id-token: write # Required for requesting the JWT token
       contents: read
-    needs: envs
+    needs: [ approval, envs ]
+    if: ${{ always() && needs.envs.result == 'success' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: fault-backend

--- a/.github/workflows/build-fault-backend-image.yaml
+++ b/.github/workflows/build-fault-backend-image.yaml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     paths:
       - "dependencies/fault-backend/**"
-    types: [labeled, opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -17,12 +17,11 @@ on:
 
 jobs:
   approval:
-    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'build-image')
     uses: ./.github/workflows/approval-gate.yml
 
   envs:
     needs: [approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.approval.result == 'success')
+    if: always() && (needs.approval.result == 'success' || needs.approval.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.create-tags.outputs.tags }}

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     paths:
       - "dependencies/sample-app/**"
-    types: [labeled, opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -17,12 +17,11 @@ on:
 
 jobs:
   approval:
-    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'build-image')
     uses: ./.github/workflows/approval-gate.yml
 
   envs:
     needs: [approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.approval.result == 'success')
+    if: always() && (needs.approval.result == 'success' || needs.approval.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.create-tags.outputs.tags }}

--- a/.github/workflows/build-sample-app-image.yml
+++ b/.github/workflows/build-sample-app-image.yml
@@ -49,7 +49,8 @@ jobs:
     permissions:
       id-token: write # Required for requesting the JWT token
       contents: read
-    needs: envs
+    needs: [ approval, envs ]
+    if: ${{ always() && needs.envs.result == 'success' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: samples/telemetry-sample-app

--- a/.github/workflows/build-self-monitor-image.yml
+++ b/.github/workflows/build-self-monitor-image.yml
@@ -81,7 +81,8 @@ jobs:
     permissions:
       id-token: write # Required for requesting the JWT token
       contents: read
-    needs: envs
+    needs: [ approval, envs ]
+    if: ${{ always() && needs.envs.result == 'success' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: tpi/telemetry-self-monitor

--- a/.github/workflows/build-self-monitor-image.yml
+++ b/.github/workflows/build-self-monitor-image.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     paths:
       - "dependencies/telemetry-self-monitor/**"
-    types: [labeled, opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -17,12 +17,11 @@ on:
 
 jobs:
   approval:
-    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'build-image')
     uses: ./.github/workflows/approval-gate.yml
 
   envs:
     needs: [approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.approval.result == 'success')
+    if: always() && (needs.approval.result == 'success' || needs.approval.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       build-args: ${{ steps.prepare-envs.outputs.build-args }}

--- a/.github/workflows/build-stdout-log-generator-image.yaml
+++ b/.github/workflows/build-stdout-log-generator-image.yaml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     paths:
       - "dependencies/stdout-log-generator/**"
-    types: [labeled, opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -17,12 +17,11 @@ on:
 
 jobs:
   approval:
-    if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'build-image')
     uses: ./.github/workflows/approval-gate.yml
 
   envs:
     needs: [approval]
-    if: always() && (github.event_name != 'pull_request_target' || needs.approval.result == 'success')
+    if: always() && (needs.approval.result == 'success' || needs.approval.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.create-tags.outputs.tags }}

--- a/.github/workflows/build-stdout-log-generator-image.yaml
+++ b/.github/workflows/build-stdout-log-generator-image.yaml
@@ -49,7 +49,8 @@ jobs:
     permissions:
       id-token: write # Required for requesting the JWT token
       contents: read
-    needs: envs
+    needs: [ approval, envs ]
+    if: ${{ always() && needs.envs.result == 'success' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: stdout-log-generator


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- We need to always run non build-image on non-manager images because they're not tested anywhere

Changes refer to particular issues, PRs or documents:

- #3605 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
