### PR TITLE
chore: run sync-external-images on push only

### DIFF
--- a/.github/workflows/sync-external-images.yml
+++ b/.github/workflows/sync-external-images.yml
@@ -9,12 +9,6 @@ on:
       - main
     paths:
       - "external-images.yaml"
-  pull_request:
-    types: [opened, edited, synchronize, reopened, ready_for_review]
-    branches:
-      - main
-    paths:
-      - "external-images.yaml"
 
 jobs:
   sync-external-images:


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Run sync-external-images on push only

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
