### PR TITLE
chore: fix submit-module GHA in pre-release process

### DIFF
--- a/.github/workflows/submit-module.yml
+++ b/.github/workflows/submit-module.yml
@@ -300,8 +300,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           CHANNEL: ${{ inputs.channel }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          BRANCH_NAME="bump-telemetry-${VERSION}-${CHANNEL}"
+          BRANCH_NAME="bump-telemetry-${RELEASE_TAG:-${VERSION}}-${CHANNEL}"
 
           # Check if branch exists on remote
           if git ls-remote --heads origin "${BRANCH_NAME}" | grep -q "refs/heads/${BRANCH_NAME}$"; then
@@ -397,6 +398,7 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           DRY_RUN: ${{ inputs.dry_run }}
           AUTO_MERGE: ${{ inputs.auto_merge }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           if [ "${CHANNEL}" = "experimental" ]; then
             VERSION_TAG="${VERSION}-experimental"
@@ -413,7 +415,7 @@ jobs:
           **Channel**: ${CHANNEL}
           **Version Tag**: ${VERSION_TAG}
           **Folder**: ${FOLDER_PATH}
-          **Branch**: bump-telemetry-${VERSION}-${CHANNEL}
+          **Branch**: bump-telemetry-${RELEASE_TAG:-${VERSION}}-${CHANNEL}
           **Dry Run**: ${DRY_RUN}
           **Auto-Merge**: ${AUTO_MERGE}
           EOF


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

Root cause: the "Push branch" step constructed `BRANCH_NAME` from `${VERSION}` only, but the branch was created using `release_tag || version` (so it was named `bump-telemetry-1.66.0-rc.2-dev` while the push tried `bump-telemetry-1.66.0-dev`). Three places in the workflow needed `RELEASE_TAG` added to env and the branch name expression updated to `${RELEASE_TAG:-${VERSION}}`:
1. Push branch — `env` block and `BRANCH_NAME= `line (this was the actual crash)
2. Workflow summary — `env` block and the `**Branch**:` line in the summary markdown (cosmetic, but would show the wrong branch name)

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/3517

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
