### PR TITLE
chore: use pre-release image in pre-release flow

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,9 +10,12 @@ set -o pipefail # prevents errors in a pipeline from being masked
 readonly LOCALBIN=${LOCALBIN:-$(pwd)/bin}
 readonly HELM=${HELM:-$LOCALBIN/helm}
 readonly GORELEASER_VERSION="${GORELEASER_VERSION:-$ENV_GORELEASER_VERSION}"
-readonly MANAGER_IMAGE="${MANAGER_IMAGE:-$ENV_MANAGER_IMAGE}"
-readonly MANAGER_IMAGE_EXPERIMENTAL=${MANAGER_IMAGE}-experimental
 readonly CURRENT_VERSION="$1"
+# Extract image repository without tag from ENV_MANAGER_IMAGE
+readonly MANAGER_IMAGE_REPO=$(echo "${ENV_MANAGER_IMAGE}" | cut -d':' -f1)
+# Use CURRENT_VERSION (release tag) as image tag, not the version from .env
+readonly MANAGER_IMAGE="${MANAGER_IMAGE:-${MANAGER_IMAGE_REPO}:${CURRENT_VERSION}}"
+readonly MANAGER_IMAGE_EXPERIMENTAL=${MANAGER_IMAGE}-experimental
 
 function prepare_release_artefacts() {
   echo "Preparing release artefacts"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The telemetry manager manifest should use rc.X image, in the pre-release flow.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
