### PR TITLE
chore: use correct pre-release version in submit-module workflow

### DIFF
--- a/.github/workflows/submit-module.yml
+++ b/.github/workflows/submit-module.yml
@@ -251,8 +251,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           CHANNEL: ${{ inputs.channel }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          ../telemetry-manager/hack/module-release.sh update-releases "${VERSION}" "${CHANNEL}"
+          ../telemetry-manager/hack/module-release.sh update-releases "${VERSION}" "${CHANNEL}" "${RELEASE_TAG}"
 
       - name: Verify changes
         working-directory: module-manifests

--- a/hack/module-release.sh
+++ b/hack/module-release.sh
@@ -34,7 +34,7 @@ fi
 #   check-duplicate <version> <channel>     Check if version is already released
 #   setup-folder <version> <channel>        Setup version folder (create or reuse)
 #   update-config <version> <channel> [folder] [repository-tag]  Update module-config.yaml
-#   update-releases <version> <channel>     Update module-releases.yaml
+#   update-releases <version> <channel> [release-tag]     Update module-releases.yaml
 #   create-pr <version> <channel> <output-file> [repository-tag]  Create or reuse PR for release
 #
 # Channels: regular, fast, experimental, dev
@@ -49,7 +49,7 @@ if [ -z "${COMMAND}" ]; then
   echo "  check-duplicate <version> <channel>     Check if version is released"
   echo "  setup-folder <version> <channel>        Setup version folder"
   echo "  update-config <version> <channel> [folder] [repository-tag]  Update module-config.yaml"
-  echo "  update-releases <version> <channel>     Update module-releases.yaml"
+  echo "  update-releases <version> <channel> [release-tag]     Update module-releases.yaml"
   echo "  create-pr <version> <channel> <output-file> [repository-tag]  Create PR"
   echo ""
   echo "Channels: regular, fast, experimental"
@@ -484,6 +484,7 @@ update_config() {
 update_releases() {
   local version="$1"
   local channel="$2"
+  local release_tag_override="${3:-}"
 
   if [ ! -f "${MODULE_RELEASES}" ]; then
     echo "::error::module-releases.yaml not found at ${MODULE_RELEASES}"
@@ -492,7 +493,12 @@ update_releases() {
 
   echo "Updating ${MODULE_RELEASES}..."
 
-  local VERSION_TAG=$(get_version_tag "${version}" "${channel}")
+  # If release_tag_override is provided, use it; otherwise compute VERSION_TAG
+  if [ -n "${release_tag_override}" ]; then
+    local VERSION_TAG="${release_tag_override}"
+  else
+    local VERSION_TAG=$(get_version_tag "${version}" "${channel}")
+  fi
 
   echo "Updating channel '${channel}' to version: ${VERSION_TAG}"
 
@@ -600,10 +606,14 @@ create_pr() {
     FOLDER_PATH="modules/telemetry/${VERSION}"
   fi
 
-  local PR_TITLE="bump telemetry version to ${VERSION} on ${CHANNEL}"
   local EFFECTIVE_REPOSITORY_TAG="${REPOSITORY_TAG_OVERRIDE:-${VERSION}}"
+
+  # For module-releases.yaml, use REPOSITORY_TAG_OVERRIDE if provided
+  local MODULE_RELEASES_VERSION="${EFFECTIVE_REPOSITORY_TAG}"
+
+  local PR_TITLE="bump telemetry version to ${EFFECTIVE_REPOSITORY_TAG} on ${CHANNEL}"
   local PR_BODY=$(cat <<EOF
-Bump telemetry version to ${VERSION} on ${CHANNEL} channel.
+Bump telemetry version to ${EFFECTIVE_REPOSITORY_TAG} on ${CHANNEL} channel.
 
 **Changes:**
 - Created/Updated folder: ${FOLDER_PATH}
@@ -611,7 +621,7 @@ Bump telemetry version to ${VERSION} on ${CHANNEL} channel.
   - version: ${VERSION_TAG}
   - repositoryTag: ${EFFECTIVE_REPOSITORY_TAG}
 - Updated module-releases.yaml:
-  - channels.${CHANNEL}.version: ${VERSION_TAG}
+  - channels.${CHANNEL}.version: ${MODULE_RELEASES_VERSION}
 EOF
 )
 
@@ -663,11 +673,11 @@ case "${COMMAND}" in
     update_config "$@"
     ;;
   update-releases)
-    if [ $# -ne 2 ]; then
-      echo "Usage: module-release.sh update-releases <version> <channel>"
+    if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+      echo "Usage: module-release.sh update-releases <version> <channel> [release-tag]"
       exit 1
     fi
-    update_releases "$1" "$2"
+    update_releases "$@"
     ;;
   create-pr)
     if [ $# -lt 3 ] || [ $# -gt 4 ]; then


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- in submit-module we should create version based on rc.X if present

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
