### PR TITLE
chore: enable automatic PR summary generation, exclude renovate[bot]

### DIFF
--- a/.hyperspace/pull_request_bot.json
+++ b/.hyperspace/pull_request_bot.json
@@ -16,11 +16,14 @@
   "features": {
     "control_panel": true,
     "summarize": {
-      "auto_generate_summary": false,
-      "auto_insert_summary": false,
+      "auto_generate_summary": true,
+      "auto_insert_summary": true,
       "use_custom_summarize_prompt": true,
       "use_custom_summarize_output_template": true,
-      "excluded_paths": []
+      "excluded_paths": [],
+      "auto_exclude_authors": [
+        "renovate[bot]"
+      ]
     },
     "review": {
       "auto_generate_review": false,


### PR DESCRIPTION
## What Changed

Enables automatic PR summary generation and insertion via the Hyperspace PR bot, and excludes `renovate[bot]` from triggering automatic summaries to reduce noise from dependency update PRs.

<details>
<summary>Key Changes</summary>

- **`.hyperspace/pull_request_bot.json`**: Sets `auto_generate_summary` and `auto_insert_summary` to `true`, and adds `renovate[bot]` to `auto_exclude_authors` so dependency update PRs do not trigger automatic summaries (manual `/summarize` still works for those).

</details>

## Notes for Reviewers

This is a tooling-only change with no impact on operator logic or pipelines. The `renovate[bot]` exclusion prevents automatic summaries on dependency bumps while still allowing manual summarization when needed.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.8`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `d66e568b-4b9a-4dab-9784-0eaf6c21add4`
</details>
