### PR TITLE
chore: avoid running E2E tests on release version bump PRs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Check if milestone exists and is closed
         if: ${{ inputs.pre_release != true }}
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           VERSION: ${{ github.event.inputs.version }}
         run: |
           echo "Checking milestone for version ${VERSION}..."
@@ -211,7 +211,7 @@ jobs:
       - name: Check if release already exists
         if: ${{ inputs.force != true && inputs.pre_release != true }}
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           VERSION: ${{ github.event.inputs.version }}
         run: |
           echo "Checking if release ${VERSION} already exists..."
@@ -224,7 +224,7 @@ jobs:
       - name: Delete existing release (force mode)
         if: ${{ inputs.force == true }}
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           VERSION: ${{ github.event.inputs.version }}
         run: |
           echo "FORCE MODE: Checking for existing release ${VERSION}..."
@@ -275,7 +275,7 @@ jobs:
         if: ${{ inputs.pre_release == true && inputs.force != true }}
         env:
           VERSION: ${{ github.event.inputs.version }}
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           git fetch --tags
           k=1
@@ -291,7 +291,7 @@ jobs:
         if: ${{ inputs.pre_release == true && inputs.force == true }}
         env:
           VERSION: ${{ github.event.inputs.version }}
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           git fetch --tags
           k=1
@@ -368,7 +368,7 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_PAT }}
           ref: ${{ needs.validate-and-prepare-branch.outputs.release-branch }}
           fetch-depth: 0
 
@@ -455,7 +455,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           VERSION: ${{ github.event.inputs.version }}
           RELEASE_BRANCH: ${{ needs.validate-and-prepare-branch.outputs.release-branch }}
           OCC_IMAGE_VERSION: ${{ github.event.inputs.occ_image_version }}
@@ -536,7 +536,7 @@ jobs:
 
       - name: Wait for PR to be merged
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           RELEASE_BRANCH: ${{ needs.validate-and-prepare-branch.outputs.release-branch }}
         timeout-minutes: 120
         run: |
@@ -582,7 +582,7 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           VERSION: ${{ github.event.inputs.version }}
         run: |
           BUMP_BRANCH="rel-prep-${VERSION}"
@@ -598,7 +598,7 @@ jobs:
         id: create-and-push-tag
         if: ${{ inputs.dry_run != true }}
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           VERSION: ${{ github.event.inputs.version }}
           RELEASE_BRANCH: ${{ needs.validate-and-prepare-branch.outputs.release-branch }}
           PRE_RELEASE_TAG: ${{ needs.validate-and-prepare-branch.outputs.pre-release-tag }}
@@ -739,7 +739,7 @@ jobs:
       - name: Verify we're on the merged PR commit
         if: ${{ inputs.force != true }}
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           PR_NUMBER: ${{ needs.prepare-release.outputs.pr-number }}
         run: |
           MERGE_SHA=$(gh pr view "${PR_NUMBER}" --json mergeCommit --jq .mergeCommit.oid)
@@ -760,7 +760,7 @@ jobs:
           RELEASE_TAG="${{ inputs.pre_release == true && needs.validate-and-prepare-branch.outputs.pre-release-tag || inputs.version }}"
           hack/release.sh "${RELEASE_TAG}"
         env:
-          GITHUB_TOKEN: "${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.WORKFLOW_PAT }}"
           GORELEASER_CURRENT_TAG: "${{ inputs.pre_release == true && needs.validate-and-prepare-branch.outputs.pre-release-tag || inputs.version }}"
 
       - name: Skip GitHub release (dry run)
@@ -780,7 +780,7 @@ jobs:
       - name: Upload Helm chart to release
         if: ${{ inputs.dry_run != true && inputs.pre_release != true }}
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           [[ ! -e ${HELM_CHART} ]] && echo "::error ::Packaged Helm chart does not exist" && exit 1
           gh release upload ${{ inputs.version }} --clobber ${HELM_CHART}
@@ -811,7 +811,7 @@ jobs:
       - name: Trigger module submission for dev channel
         if: ${{ inputs.dry_run != true && inputs.module_release == true }}
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           RELEASE_TAG="${{ inputs.pre_release == true && needs.validate-and-prepare-branch.outputs.pre-release-tag || inputs.version }}"
           echo "Triggering module release for dev channel (version=${RELEASE_TAG}, pre_release=${{ inputs.pre_release }})..."
@@ -827,7 +827,7 @@ jobs:
       - name: Trigger module submission for fast channel
         if: ${{ inputs.dry_run != true && inputs.module_release == true && inputs.pre_release != true }}
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           echo "Triggering module release for fast channel..."
           gh workflow run submit-module.yml \
@@ -841,7 +841,7 @@ jobs:
       - name: Trigger module submission for experimental channel
         if: ${{ inputs.dry_run != true && inputs.module_release == true && inputs.pre_release != true }}
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           echo "Triggering module release for experimental channel..."
           gh workflow run submit-module.yml \

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -70,7 +70,24 @@ env:
   ARTIFACT_PREFIX: "pr-"
 
 jobs:
+  check-skip-e2e:
+    runs-on: ubuntu-latest
+    outputs:
+      skip-e2e: ${{ steps.check.outputs.skip-e2e }}
+    steps:
+      - name: Check if E2E tests should be skipped
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.user.login }}" == "github-actions[bot]" && ( "${{ github.base_ref }}" == release-* || "${{ github.base_ref }}" == pre-release-* ) ]]; then
+            echo "Skipping E2E tests for automated PR targeting ${{ github.base_ref }}"
+            echo "skip-e2e=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip-e2e=false" >> $GITHUB_OUTPUT
+          fi
+
   setup:
+    needs: check-skip-e2e
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: ubuntu-latest
     outputs:
       manager-image: ${{ steps.set-env.outputs.manager-image }}
@@ -155,7 +172,8 @@ jobs:
 
   # e2e-logs split by fluent-bit vs otel AND by set labels for parallel execution
   e2e-logs:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -194,7 +212,8 @@ jobs:
 
   # e2e-metrics split by set labels for parallel execution
   e2e-metrics:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -228,7 +247,8 @@ jobs:
 
   # All e2e suites with experimental flavor
   e2e-experimental:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -264,7 +284,8 @@ jobs:
 
   # e2e-traces and e2e-misc (non-experimental) without set splitting
   e2e:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -296,7 +317,8 @@ jobs:
 
   # Upgrade and integration tests
   e2e-other:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -328,7 +350,8 @@ jobs:
 
   # Selfmonitor tests
   selfmonitor-healthy:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: telemetry-4core
     name: selfmonitor-healthy
     steps:
@@ -350,7 +373,8 @@ jobs:
           google-credentials: ${{ secrets.GOOGLE_CLOUD_SA_KEY }}
 
   selfmonitor:
-    needs: setup
+    needs: [setup, check-skip-e2e]
+    if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
     runs-on: telemetry-4core
     strategy:
       fail-fast: false
@@ -392,15 +416,20 @@ jobs:
           artifact-prefix: ${{ env.ARTIFACT_PREFIX }}
 
   summary:
-    needs: [e2e-logs, e2e-metrics, e2e-experimental, e2e, e2e-other, selfmonitor-healthy, selfmonitor]
+    needs: [check-skip-e2e, e2e-logs, e2e-metrics, e2e-experimental, e2e, e2e-other, selfmonitor-healthy, selfmonitor]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Checkout code
+        if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-
       - name: Generate test summary
+        if: needs.check-skip-e2e.outputs.skip-e2e == 'false'
         uses: "./.github/template/test-summary"
         with:
           artifact-prefix: ${{ env.ARTIFACT_PREFIX }}
+
+      - name: Skip notice
+        if: needs.check-skip-e2e.outputs.skip-e2e == 'true'
+        run: echo "✓ E2E tests were skipped (automated PR targeting release branch)"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Check if E2E tests should be skipped
         id: check
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.user.login }}" == "github-actions[bot]" && ( "${{ github.base_ref }}" == release-* || "${{ github.base_ref }}" == pre-release-* ) ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.user.login }}" == "kyma-telemetry-serviceuser" && ( "${{ github.base_ref }}" == release-* || "${{ github.base_ref }}" == pre-release-* ) ]]; then
             echo "Skipping E2E tests for automated PR targeting ${{ github.base_ref }}"
             echo "skip-e2e=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- For the PRs targeting release branches (`release-*` or `pre-release-*`) and created by `kyma-telemetry-serviceuser`, avoid running the e2e tests.
- These PRs are only version bumps and the e2e tests will anyway run in the release workflow itself.
- Remove the fallback to `secrets.GITHUB_TOKEN` in the `Create Release` workflow. The `secrets.WORKFLOW_PAT` must exist in order for the `Build Manager Image` to be triggered after the release tag is pushed

Changes refer to particular issues, PRs or documents:

- #3518 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
