### PR TITLE
fix: use high priority class for OTLP gateway DaemonSet

### DIFF
--- a/main.go
+++ b/main.go
@@ -571,7 +571,7 @@ func setupOTLPGatewayController(globals config.Global, envCfg envConfig, mgr man
 			Global:                       globals,
 			RestConfig:                   mgr.GetConfig(),
 			OTelCollectorImage:           envCfg.OTelCollectorImage,
-			OTLPGatewayPriorityClassName: normalPriorityClassName,
+			OTLPGatewayPriorityClassName: highPriorityClassName,
 		},
 		mgr.GetClient(),
 		reconcileTriggerChan,


### PR DESCRIPTION
## What Changed

Fixes the OTLP gateway DaemonSet priority class from `normalPriorityClassName` to `highPriorityClassName` to match all other telemetry agent DaemonSets (Fluent Bit, OTel log and metric agents) and prevent its Pods from being evicted or blocked by unschedulable non-DaemonSet workloads.

<details>
<summary>Key Changes</summary>

- **`main.go`**: Changes `OTLPGatewayPriorityClassName` from `normalPriorityClassName` to `highPriorityClassName` in the OTLP gateway controller setup.

</details>

## Notes for Reviewers

This was an oversight introduced when the OTLP gateway was converted from a Deployment to a DaemonSet. All other agent DaemonSets already use the high priority class. The fix is a one-line change with no logic implications.

## Release Notes Input

None.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- Correlation ID: `ff676848-9b33-4282-8b8c-ae30a53b894e`
- Output Template: [PR Template File](https://github.com/kyma-project/telemetry-manager/blob/d12ac67fdcc677e12a49519c162168f0af944cc9/.hyperspace/pull_request_bot_summarize_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [PR Prompt File](https://github.com/kyma-project/telemetry-manager/blob/d12ac67fdcc677e12a49519c162168f0af944cc9/.hyperspace/pull_request_bot_summarize_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.edited`
</details>
