### PR TITLE
chore: fix typo in echo statement in check-skip-e2e job

### DIFF
--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -79,7 +79,7 @@ jobs:
         id: check
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.user.login }}" == "kyma-telemetry-serviceuser" && ( "${{ github.base_ref }}" == release-* || "${{ github.base_ref }}" == pre-release-* ) ]]; then
-            echo "Skipping E2E tests for automated PR targeting ${{ github.base_ref }}" branch
+            echo "Skipping E2E tests for automated PR targeting ${{ github.base_ref }} branch"
             echo "skip-e2e=true" >> $GITHUB_OUTPUT
           else
             echo "E2E tests will run normally because this is NOT an automated PR targeting a release branch"


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The last word (`branch`) in one of the echo statements was mistakenly outside the double quotation, so it was not printed

Changes refer to particular issues, PRs or documents:

- #3518 

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
