### PR TITLE
chore: remove deprecated deployment_name_from_replicaset setting

### DIFF
--- a/internal/otelcollector/config/common/processor_builders.go
+++ b/internal/otelcollector/config/common/processor_builders.go
@@ -47,11 +47,10 @@ func K8sAttributesProcessor(enrichments *operatorv1beta1.EnrichmentSpec, useOTel
 			NodeFromEnvVar: EnvVarCurrentNodeName,
 		},
 		Extract: ExtractK8sMetadata{
-			Metadata:                     k8sAttributes,
-			Labels:                       append(extractLabels(useOTelServiceEnrichment), extractPodLabels(enrichments)...),
-			Annotations:                  extractOtelServiceAnnotations(useOTelServiceEnrichment),
-			OTelAnnotations:              useOTelServiceEnrichment,
-			DeploymentNameFromReplicaset: useOTelServiceEnrichment,
+			Metadata:        k8sAttributes,
+			Labels:          append(extractLabels(useOTelServiceEnrichment), extractPodLabels(enrichments)...),
+			Annotations:     extractOtelServiceAnnotations(useOTelServiceEnrichment),
+			OTelAnnotations: useOTelServiceEnrichment,
 		},
 		PodAssociation: podAssociations,
 	}

--- a/internal/otelcollector/config/common/types.go
+++ b/internal/otelcollector/config/common/types.go
@@ -219,11 +219,10 @@ type CumulativeToDeltaProcessorConfig struct {
 }
 
 type ExtractK8sMetadata struct {
-	Metadata                     []string       `yaml:"metadata"`
-	Labels                       []ExtractLabel `yaml:"labels"`
-	Annotations                  []ExtractLabel `yaml:"annotations,omitempty"`
-	OTelAnnotations              bool           `yaml:"otel_annotations,omitempty"`
-	DeploymentNameFromReplicaset bool           `yaml:"deployment_name_from_replicaset,omitempty"`
+	Metadata        []string       `yaml:"metadata"`
+	Labels          []ExtractLabel `yaml:"labels"`
+	Annotations     []ExtractLabel `yaml:"annotations,omitempty"`
+	OTelAnnotations bool           `yaml:"otel_annotations,omitempty"`
 }
 
 type ExtractLabel struct {

--- a/internal/otelcollector/config/logagent/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/logagent/testdata/service-enrichment-otel.yaml
@@ -209,7 +209,6 @@ processors:
                   key: resource.opentelemetry.io/service.version
                   tag_name: kyma.otel.annotation.service.version
             otel_annotations: true
-            deployment_name_from_replicaset: true
         pod_association:
             - sources:
                 - from: resource_attribute

--- a/internal/otelcollector/config/metricagent/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/metricagent/testdata/service-enrichment-otel.yaml
@@ -208,7 +208,6 @@ processors:
                   key: resource.opentelemetry.io/service.version
                   tag_name: kyma.otel.annotation.service.version
             otel_annotations: true
-            deployment_name_from_replicaset: true
         pod_association:
             - sources:
                 - from: resource_attribute

--- a/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
+++ b/internal/otelcollector/config/otlpgateway/testdata/service-enrichment-otel.yaml
@@ -173,7 +173,6 @@ processors:
                   key: resource.opentelemetry.io/service.version
                   tag_name: kyma.otel.annotation.service.version
             otel_annotations: true
-            deployment_name_from_replicaset: true
         pod_association:
             - sources:
                 - from: resource_attribute


### PR DESCRIPTION
## Description

Remove the `deployment_name_from_replicaset` configuration from the OTel Collector k8sattributes processor config builder.

## Why

The upstream `k8sattributesprocessor` in otelcol-contrib has:
1. **Improved the heuristic** (PR [#47431](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47431)) — deployment name is now reliably derived using the `pod-template-hash` label instead of fragile regex matching on the ReplicaSet name suffix.
2. **Changed the default to `true`** and deprecated the setting (PR [#48534](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48534), merged 2026-05-20) — the heuristic is the default behaviour, and the setting will be removed in a future release.

Since the upstream default is now `true`, explicitly setting `deployment_name_from_replicaset: true` is redundant. Removing it avoids deprecation warnings in collector logs and keeps the config clean.