### PR TITLE
chore: remove "deploy-otlp-gateway" feature flag

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -67,7 +67,6 @@ spec:
         - --cluster-trust-bundle-name={{ .Values.global.caBundle.name }}
         {{- end }}
         {{- if .Values.experimental.enabled }}
-        - --deploy-otlp-gateway=true
         - --unlimited-pipelines=true
         {{- end }}
         command:

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -35,13 +35,7 @@ func IsValidationError(err error) bool {
 	return errors.As(err, &validationErr)
 }
 
-type Experimental struct {
-	deployOTLPGateway bool
-}
-
 type Global struct {
-	Experimental
-
 	managerNamespace                 string
 	targetNamespace                  string
 	operateInFIPSMode                bool
@@ -117,12 +111,6 @@ func WithAdditionalWorkloadPodAnnotations(annotations map[string]string) Option 
 	}
 }
 
-func WithDeployOTLPGateway(enable bool) Option {
-	return func(g *Global) {
-		g.deployOTLPGateway = enable
-	}
-}
-
 func WithUnlimitedPipelines(enable bool) Option {
 	return func(g *Global) {
 		g.unlimitedPipelines = enable
@@ -180,10 +168,6 @@ func (g *Global) OperateInFIPSMode() bool {
 // Version returns the version of the Telemetry Manager.
 func (g *Global) Version() string {
 	return g.version
-}
-
-func (g *Global) DeployOTLPGateway() bool {
-	return g.deployOTLPGateway
 }
 
 func (g *Global) ImagePullSecretName() string {

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -329,7 +329,6 @@ func TestGettersForOptionalFields(t *testing.T) {
 		WithAdditionalWorkloadAnnotations(annotations),
 		WithAdditionalWorkloadPodLabels(podLabels),
 		WithAdditionalWorkloadPodAnnotations(podAnnotations),
-		WithDeployOTLPGateway(false),
 		WithUnlimitedPipelines(true),
 	)
 
@@ -339,7 +338,6 @@ func TestGettersForOptionalFields(t *testing.T) {
 	require.Equal(t, annotations, g.AdditionalWorkloadAnnotations())
 	require.Equal(t, podLabels, g.AdditionalWorkloadPodLabels())
 	require.Equal(t, podAnnotations, g.AdditionalWorkloadPodAnnotations())
-	require.False(t, g.DeployOTLPGateway())
 	require.True(t, g.UnlimitedPipelines())
 }
 

--- a/internal/featureflags/featureflag_string.go
+++ b/internal/featureflags/featureflag_string.go
@@ -9,13 +9,12 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[placeholder-0]
-	_ = x[DeployOTLPGateway-1]
-	_ = x[UnlimitedPipelineCount-2]
+	_ = x[UnlimitedPipelineCount-1]
 }
 
-const _FeatureFlag_name = "placeholderDeployOTLPGatewayUnlimitedPipelineCount"
+const _FeatureFlag_name = "placeholderUnlimitedPipelineCount"
 
-var _FeatureFlag_index = [...]uint8{0, 11, 28, 50}
+var _FeatureFlag_index = [...]uint8{0, 11, 33}
 
 func (i FeatureFlag) String() string {
 	idx := int(i) - 0

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -4,8 +4,7 @@ type FeatureFlag int
 
 const (
 	// keeping the code with a placeholder feature flag to make introducing feature flags in the future easier
-	placeholder            FeatureFlag = iota // placeholder feature flag for testing purposes and make sure the codegen works correctly
-	DeployOTLPGateway      FeatureFlag = iota
+	placeholder            FeatureFlag = iota // placeholder feature flag for testing purposes and make sure the codegen works correctly iota
 	UnlimitedPipelineCount FeatureFlag = iota
 )
 

--- a/main.go
+++ b/main.go
@@ -101,7 +101,6 @@ var (
 	additionalWorkloadAnnotations    cliflags.Map
 	additionalWorkloadPodLabels      cliflags.Map
 	additionalWorkloadPodAnnotations cliflags.Map
-	deployOTLPGateway                bool
 	unlimitedPipelines               bool
 )
 
@@ -185,7 +184,6 @@ func run() error {
 		config.WithAdditionalWorkloadAnnotations(additionalWorkloadAnnotations),
 		config.WithAdditionalWorkloadPodLabels(additionalWorkloadPodLabels),
 		config.WithAdditionalWorkloadPodAnnotations(additionalWorkloadPodAnnotations),
-		config.WithDeployOTLPGateway(featureflags.IsEnabled(featureflags.DeployOTLPGateway)),
 		config.WithUnlimitedPipelines(featureflags.IsEnabled(featureflags.UnlimitedPipelineCount)),
 	)
 
@@ -431,7 +429,6 @@ func logBuildAndProcessInfo() {
 
 func initializeFeatureFlags() {
 	// Placeholder for future feature flag initializations.
-	featureflags.Set(featureflags.DeployOTLPGateway, deployOTLPGateway)
 	featureflags.Set(featureflags.UnlimitedPipelineCount, unlimitedPipelines)
 }
 
@@ -447,7 +444,6 @@ func parseFlags() {
 	flag.Var(&additionalWorkloadPodLabels, "additional-workload-pod-label", "Additional label to add to all created workload pods in key=value format")
 	flag.Var(&additionalWorkloadPodAnnotations, "additional-workload-pod-annotation", "Additional annotation to add to all created workload pods in key=value format")
 
-	flag.BoolVar(&deployOTLPGateway, "deploy-otlp-gateway", false, "Enable deploying unified OTLP Gateway")
 	flag.BoolVar(&unlimitedPipelines, "unlimited-pipelines", false, "Allow unlimited number of OTEL pipelines")
 
 	flag.Parse()


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Since the OTLP gateway is not an experimental feature anymore, we don't need the `deploy-otlp-gateway` feature flag anymore. So, it is removed in this PR.

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
