### PR TITLE
chore: remove "pr-prevent-kustomization" job

### DIFF
--- a/.github/workflows/pr-github-checks.yml
+++ b/.github/workflows/pr-github-checks.yml
@@ -132,18 +132,3 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
           requireScope: false
-
-  pr-prevent-kustomization:
-    if: github.event.pull_request.base.ref == 'main'
-    permissions:
-      contents: read  # Only needs read for git diff
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Verify kustomization.yaml has no changes
-        run: |
-          git diff origin/main --exit-code -- config/manager/kustomization.yaml || (echo "config/manager/kustomization.yaml has changes compared to main branch. Please, revert them" && exit 1)


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The `pr-prevent-kustomization` job is doing checks for the `config/manager/kustomization.yaml` file and we don't have this file anymore since we switched to helm. In addition, this job is checking out fork pull request code from a 'pull_request_target' workflow and this has a security risk and not allowed anymore in the new `actions/checkout`. Check https://github.com/kyma-project/telemetry-manager/actions/runs/28173669530/job/83444165404?pr=3684

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
