### PR TITLE
chore: release preparation: bump version to 1.67.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ### Default Environment Variables
 ## General
-ENV_HELM_RELEASE_VERSION=0.0.1-main
+ENV_HELM_RELEASE_VERSION=1.67.0
 
 # Use k3d tools image from registry to prevent timeouts
 ENV_K3D_IMAGE_TOOLS=europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/k3d-io/k3d-tools:5.8.3
@@ -18,13 +18,13 @@ ENV_GORELEASER_VERSION=v1.23.0
 
 ## Docker Images
 # Production images — included in sec-scanners-config.yaml and component-config.yaml
-ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main"
+ENV_MANAGER_IMAGE=europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.67.0
+ENV_FLUENTBIT_EXPORTER_IMAGE="europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260605-0cf1a38e"
 ENV_FLUENTBIT_IMAGE="europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4"
-ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main"
-ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main"
+ENV_OTEL_COLLECTOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.153.0-1.67.0"
+ENV_SELFMONITOR_IMAGE="europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260625-b6ae649a"
 ENV_SELFMONITOR_FIPS_IMAGE="europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.12.0"
-ENV_CHOWN_IMAGE="europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:main"
+ENV_CHOWN_IMAGE="europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:v20260609-7b408c48"
 
 # Test-only images — not shipped to production
 ENV_TEST_TELEMETRYGEN_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.152.0"

--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,10 +1,10 @@
 name: kyma-project.io/module/telemetry
 team: kyma/Huskies
 images:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.67.0
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260605-0cf1a38e
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.153.0-1.67.0
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260625-b6ae649a
   - europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.12.0
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:v20260609-7b408c48

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: telemetry-manager
 description: Kyma Telemetry Manager Helm Chart
-version: 0.0.1-main
+version: 1.67.0
 type: application
-appVersion: "0.0.1-main"
+appVersion: "1.67.0"
 keywords:
   - kyma
   - telemetry
@@ -17,8 +17,8 @@ maintainers:
     url: https://kyma-project.io
 dependencies:
   - name: experimental
-    version: 0.0.1-main
+    version: 1.67.0
     condition: experimental.enabled
   - name: default
-    version: 0.0.1-main
+    version: 1.67.0
     condition: default.enabled

--- a/helm/charts/default/Chart.yaml
+++ b/helm/charts/default/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: default
 description: Telemetry Manager Default CRDs
-version: 0.0.1-main
+version: 1.67.0

--- a/helm/charts/experimental/Chart.yaml
+++ b/helm/charts/experimental/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: experimental
 description: Telemetry Manager Experimental CRDs
-version: 0.0.1-main
+version: 1.67.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,17 +16,17 @@ manager:
       high-priority-class-name: "telemetry-priority-class-high"
       normal-priority-class-name: "telemetry-priority-class"
     env:
-      chownImage: europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:main
+      chownImage: europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:v20260609-7b408c48
       appLogLevel: info
-      fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
+      fluentBitExporterImage: europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260605-0cf1a38e
       fluentBitImage: europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4
       gomemlimit: 300MiB
-      otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
-      selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main
+      otelCollectorImage: europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.153.0-1.67.0
+      selfMonitorImage: europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260625-b6ae649a
       operateInFipsMode: false
       selfMonitorFIPSImage: europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.12.0
     image:
-      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
+      repository: europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.67.0
       pullPolicy: "IfNotPresent"
     resources:
       limits:

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,13 +1,13 @@
 module-name: telemetry
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-manager:1.67.0
+  - europe-docker.pkg.dev/kyma-project/prod/directory-size-exporter:v20260605-0cf1a38e
   - europe-docker.pkg.dev/kyma-project/prod/external/fluent/fluent-bit:5.0.4
-  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main
+  - europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.153.0-1.67.0
+  - europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260625-b6ae649a
   - europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.12.0
-  - europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:main
+  - europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:v20260609-7b408c48
 mend:
   language: golang-mod
   exclude:

--- a/test/testkit/images.go
+++ b/test/testkit/images.go
@@ -6,10 +6,10 @@ package testkit
 const (
 	DefaultTelemetryGenImage         = "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.152.0"
 	DefaultOTelCollectorContribImage = "otel/opentelemetry-collector-contrib:latest"
-	DefaultOTelCollectorImage        = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:main"
-	SelfMonitorImage                 = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:main"
+	DefaultOTelCollectorImage        = "europe-docker.pkg.dev/kyma-project/prod/kyma-otel-collector:0.153.0-1.67.0"
+	SelfMonitorImage                 = "europe-docker.pkg.dev/kyma-project/prod/tpi/telemetry-self-monitor:v20260625-b6ae649a"
 	SelfMonitorFIPSImage             = "europe-docker.pkg.dev/kyma-project/restricted-prod/sap.com/prometheus-fips:3.12.0"
 	FaultBackendImage                = "europe-docker.pkg.dev/kyma-project/prod/fault-backend:main"
 	AlpineImage                      = "europe-docker.pkg.dev/kyma-project/prod/external/library/alpine:3.23.4"
-	ChownImage                       = "europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:main"
+	ChownImage                       = "europe-docker.pkg.dev/kyma-project/prod/telemetry-chown:v20260609-7b408c48"
 )


### PR DESCRIPTION
## Release Preparation for 1.67.0

This PR prepares the release branch for version **1.67.0**.

### Changes
- Updated `ENV_HELM_RELEASE_VERSION` to `1.67.0`
- Updated `ENV_MANAGER_IMAGE` tag to `1.67.0`
- Updated `ENV_OTEL_COLLECTOR_IMAGE` tag to `0.153.0-1.67.0`
- Updated `ENV_SELFMONITOR_IMAGE` tag to `v20260625-b6ae649a`
- Updated `ENV_FLUENTBIT_EXPORTER_IMAGE` tag to `v20260605-0cf1a38e`
- Updated `ENV_CHOWN_IMAGE` tag to `v20260609-7b408c48`

### Review Checklist
- [ ] Version numbers are correct
- [ ] Generated files are up to date
- [ ] No unintended changes

**Merge this PR to continue with the release workflow.**