### PR TITLE
docs: fix incorrect values in user documentation

### DIFF
--- a/docs/user/_sidebar.ts
+++ b/docs/user/_sidebar.ts
@@ -42,7 +42,6 @@ export default [
     ]
   },
   { text: 'Monitor Pipeline Health', link: './monitor-pipeline-health' },
-  { text: 'Manage Pipeline Resources', link: './manage-pipeline-resources' },
   { text: 'Troubleshooting the Telemetry Module', link: './troubleshooting' },
   {
     text: 'Architecture',

--- a/docs/user/collecting-logs/README.md
+++ b/docs/user/collecting-logs/README.md
@@ -30,7 +30,8 @@ apiVersion: telemetry.kyma-project.io/v1beta1
 kind: LogPipeline
 metadata:
   name: backend
-output:
+spec:
+  output:
     otlp:
       endpoint:
         value: http://myEndpoint:4317

--- a/docs/user/collecting-metrics/prometheus-input.md
+++ b/docs/user/collecting-metrics/prometheus-input.md
@@ -36,7 +36,7 @@ To enable automatic metrics collection, apply the following annotations. If your
 | `prometheus.io/scrape` (mandatory) | true, false (no default value)                                   | Set to true to enable scraping for this target.                                                                                    |
 | `prometheus.io/port` (mandatory)   | 8080, 9100 (no default value)                                    | Specify the port on the Pod where your application exposes metrics.                                                                |
 | `prometheus.io/path`               | /metrics (default), /custom_metrics                              | Set the HTTP path for the metrics endpoint.                                                                                        |
-| `prometheus.io/scheme`             | https-metrics (default with Istio), http (default without Istio) | Define the protocol for scraping: Either HTTPS with mTLS, or plain HTTP.                                                           |
+| `prometheus.io/scheme`             | https (default with Istio), http (default without Istio)         | Define the protocol for scraping: Either HTTPS with mTLS, or plain HTTP.                                                           |
 | `prometheus.io/param_<name>`       | Example: format: prometheus (no default)                         | Add a URL parameter to the scrape request. For example, prometheus.io/param_format: prometheus adds ?format=prometheus to the URL. |
 
 For example, see the following `Service` configuration:

--- a/docs/user/collecting-metrics/runtime-metrics.md
+++ b/docs/user/collecting-metrics/runtime-metrics.md
@@ -5,7 +5,7 @@
 If `pod` metrics are enabled, the following metrics are collected:
 
 - From the [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver):
-  - `k8s.pod.cpu.capacity`
+  - `k8s.pod.cpu.time`
   - `k8s.pod.cpu.usage`
   - `k8s.pod.filesystem.available`
   - `k8s.pod.filesystem.capacity`

--- a/docs/user/collecting-traces/README.md
+++ b/docs/user/collecting-traces/README.md
@@ -29,7 +29,8 @@ apiVersion: telemetry.kyma-project.io/v1beta1
 kind: TracePipeline
 metadata:
   name: backend
-output:
+spec:
+  output:
     otlp:
       endpoint:
         value: http://myEndpoint:4317

--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -35,7 +35,6 @@ Be aware of [these OTel-specific edge case limitations](https://github.com/open-
 - `k8s.cluster.name`: A logical identifier of the cluster, which, by default, is the API Server URL. To set a custom name, configure the `enrichments.cluster.name` field in the Telemetry CRD.
 - `k8s.cluster.uid`: A unique identifier of the cluster, realized by the UID of the `kube-system` namespace.
 - `k8s.node.name`: The Kubernetes Node name to which the emitting Pod is scheduled.
-- `k8s.node.uid`: The Kubernetes Node ID to which the emitting Pod belongs.
 
 ## Pod Label Attributes
 

--- a/docs/user/filter-and-process/transformation-to-otlp-logs.md
+++ b/docs/user/filter-and-process/transformation-to-otlp-logs.md
@@ -52,7 +52,7 @@ The agent enriches all information identifying the log source (such as container
 
 ## JSON Parsing
 
-If the `body` value is a JSON document, the agent parses the value and enriches all JSON root attributes as additional log attributes. The agent moves the original body into the **log.original** attribute (managed with the LogPipeline attribute `input.application.keepOriginalBody: true`).
+If the `body` value is a JSON document, the agent parses the value and enriches all JSON root attributes as additional log attributes. The agent moves the original body into the **log.original** attribute (managed with the LogPipeline attribute `input.runtime.keepOriginalBody: true`).
 
 After JSON parsing, the OTLP record looks like the following example:
 


### PR DESCRIPTION
## Description

Fixes incorrect values, broken YAML examples, and phantom references in user documentation. Each fix was verified against the source code.

Changes proposed in this pull request (what was done and why):

- `collecting-logs/README.md`: Add missing `spec:` to minimal LogPipeline YAML example
- `collecting-traces/README.md`: Add missing `spec:` to minimal TracePipeline YAML example
- `filter-and-process/transformation-to-otlp-logs.md`: Replace deprecated `input.application.keepOriginalBody` with current `input.runtime.keepOriginalBody`
- `collecting-metrics/runtime-metrics.md`: Replace `k8s.pod.cpu.capacity` (does not exist) with `k8s.pod.cpu.time`
- `collecting-metrics/prometheus-input.md`: Replace `https-metrics` with `https` for `prometheus.io/scheme` annotation value
- `filter-and-process/automatic-data-enrichment.md`: Remove `k8s.node.uid` from enrichment list
- `_sidebar.ts`: Remove broken link to non-existent `manage-pipeline-resources`


Verification for changes that require code-level proof:

**`k8s.pod.cpu.capacity` → `k8s.pod.cpu.time`**: The metric `k8s.pod.cpu.capacity` does not exist in the kubeletstatsreceiver configuration. The default pod metrics list is defined in `internal/otelcollector/config/metricagent/kubeletstats_metrics.go:105-119` and starts with `metricK8sPodCPUTime` ("k8s.pod.cpu.time"), not "capacity".

**`https-metrics` → `https`**: The Prometheus receiver processes the `prometheus.io/scheme` annotation through a relabel rule with regex `(https?)` (`internal/otelcollector/config/metricagent/prometheus_receiver.go:235`). This regex only matches `http` or `https`. The value `https-metrics` would not match and would be silently ignored.

**`k8s.node.uid` removed**: The k8sAttributesProcessor metadata extraction list (`internal/otelcollector/config/common/processor_builders.go:15-24`) does not include `k8s.node.uid`. Zero references to this attribute exist anywhere in the codebase. Only `k8s.node.name` is extracted.

Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/3734

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
