### PR TITLE
docs: fix descriptions that contradict code behavior

### DIFF
--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -1,6 +1,6 @@
 # Automatic Data Enrichment
 
-The Telemetry gateways automatically enrich your data with OTel resource attributes, so you can easily identify the source of the data in your backend.
+The Telemetry module automatically enriches your data with OTel resource attributes, so you can easily identify the source of the data in your backend.
 
 > [!TIP]
 > For custom enrichment, such as adding your own business-specific attributes, see [Transform and Filter with OTTL](./ottl-transform-and-filter/README.md).
@@ -65,7 +65,7 @@ spec:
 
 If data is available, the gateway automatically adds [cloud provider](https://opentelemetry.io/docs/specs/semconv/resource/cloud/) attributes to the telemetry data:
 
-- `cloud.provider`: Cloud provider name
+- `cloud.provider`: Cloud provider name (from the Gardener `shoot-info` ConfigMap in `kube-system`)
 - `cloud.region`: Region where the Node runs (from Node label `topology.kubernetes.io/region`)
 - `cloud.availability_zone`: Zone where the Node runs (from Node label `topology.kubernetes.io/zone`)
 

--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -1,6 +1,6 @@
 # Automatic Data Enrichment
 
-The Telemetry module automatically enriches your data with OTel resource attributes at different pipeline stages, so you can easily identify the source of the data in your backend.
+The Telemetry module automatically enriches your data with OTel resource attributes, so you can easily identify the source of the data in your backend.
 
 > [!TIP]
 > For custom enrichment, such as adding your own business-specific attributes, see [Transform and Filter with OTTL](./ottl-transform-and-filter/README.md).
@@ -65,7 +65,7 @@ spec:
 
 If data is available, the gateway automatically adds [cloud provider](https://opentelemetry.io/docs/specs/semconv/resource/cloud/) attributes to the telemetry data:
 
-- `cloud.provider`: Cloud provider name (from the Gardener `shoot-info` ConfigMap in `kube-system`; only available on Gardener-managed clusters)
+- `cloud.provider`: Cloud provider name. Sourced from the Gardener `shoot-info` ConfigMap in `kube-system`. Only available on Gardener-managed clusters.
 - `cloud.region`: Region where the Node runs (from Node label `topology.kubernetes.io/region`)
 - `cloud.availability_zone`: Zone where the Node runs (from Node label `topology.kubernetes.io/zone`)
 

--- a/docs/user/filter-and-process/automatic-data-enrichment.md
+++ b/docs/user/filter-and-process/automatic-data-enrichment.md
@@ -1,6 +1,6 @@
 # Automatic Data Enrichment
 
-The Telemetry module automatically enriches your data with OTel resource attributes, so you can easily identify the source of the data in your backend.
+The Telemetry module automatically enriches your data with OTel resource attributes at different pipeline stages, so you can easily identify the source of the data in your backend.
 
 > [!TIP]
 > For custom enrichment, such as adding your own business-specific attributes, see [Transform and Filter with OTTL](./ottl-transform-and-filter/README.md).
@@ -65,7 +65,7 @@ spec:
 
 If data is available, the gateway automatically adds [cloud provider](https://opentelemetry.io/docs/specs/semconv/resource/cloud/) attributes to the telemetry data:
 
-- `cloud.provider`: Cloud provider name (from the Gardener `shoot-info` ConfigMap in `kube-system`)
+- `cloud.provider`: Cloud provider name (from the Gardener `shoot-info` ConfigMap in `kube-system`; only available on Gardener-managed clusters)
 - `cloud.region`: Region where the Node runs (from Node label `topology.kubernetes.io/region`)
 - `cloud.availability_zone`: Zone where the Node runs (from Node label `topology.kubernetes.io/zone`)
 

--- a/docs/user/filter-and-process/filter-logs.md
+++ b/docs/user/filter-and-process/filter-logs.md
@@ -93,8 +93,7 @@ By default, application logs from `kube-system`, `istio-system`, and
 You can also filter logs based on the container name with `include` and
 `exclude` filters. These filters apply in addition to any namespace filters.
 
-The following pipeline collects input from all namespaces excluding `kyma-system` and only from the
-`istio-proxy` containers:
+The following pipeline excludes logs from a specific namespace and container:
 
 ```yaml
 ...

--- a/docs/user/filter-and-process/transformation-to-otlp-logs.md
+++ b/docs/user/filter-and-process/transformation-to-otlp-logs.md
@@ -81,7 +81,7 @@ After JSON parsing, the OTLP record looks like the following example:
 
 ## Severity Parsing
 
-Typically, a log message includes a log level in the `level` field. Based on this, the agent parses the `level` log attribute with a severity parser. If parsing succeeds, the agent transforms the log attribute into the OTel attributes `severityText` and `severityNumber`.
+Typically, a log message includes a log level in the `level` or `log.level` field. Based on this, the agent parses the matching log attribute with a severity parser. If parsing succeeds, the agent transforms the log attribute into the OTel attributes `severityText` and `severityNumber`.
 
 ## Trace Parsing
 

--- a/docs/user/filter-and-process/transformation-to-otlp-logs.md
+++ b/docs/user/filter-and-process/transformation-to-otlp-logs.md
@@ -81,7 +81,7 @@ After JSON parsing, the OTLP record looks like the following example:
 
 ## Severity Parsing
 
-Typically, a log message includes a log level in the `level` or `log.level` field. Based on this, the agent parses the matching log attribute with a severity parser. If parsing succeeds, the agent transforms the log attribute into the OTel attributes `severityText` and `severityNumber`.
+Typically, a log message includes a log level in the `level` or `log.level` field (`log.level` takes precedence if both are present). Based on this, the agent parses the matching log attribute with a severity parser. If parsing succeeds, the agent transforms the log attribute into the OTel attributes `severityText` and `severityNumber`.
 
 ## Trace Parsing
 

--- a/docs/user/filter-and-process/transformation-to-otlp-logs.md
+++ b/docs/user/filter-and-process/transformation-to-otlp-logs.md
@@ -81,7 +81,7 @@ After JSON parsing, the OTLP record looks like the following example:
 
 ## Severity Parsing
 
-Typically, a log message includes a log level in the `level` or `log.level` field (`log.level` takes precedence if both are present). Based on this, the agent parses the matching log attribute with a severity parser. If parsing succeeds, the agent transforms the log attribute into the OTel attributes `severityText` and `severityNumber`.
+Typically, a log message includes a log level in the `level` or `log.level` field. If both are present, `log.level` takes precedence. Based on the matching field, the agent parses it with a severity parser. If parsing succeeds, the agent transforms the log attribute into the OTel attributes `severityText` and `severityNumber`.
 
 ## Trace Parsing
 

--- a/docs/user/integrate-otlp-backend/migration-to-otlp-logs.md
+++ b/docs/user/integrate-otlp-backend/migration-to-otlp-logs.md
@@ -115,8 +115,8 @@ See how the deprecated fields map to their new OTLP-based counterparts:
          statements:
          - set(log.attributes["tenant"], "myTenant")
      filter:
-       conditions:
-         - log.attributes["path"] == "/healthz/ready"
+       - conditions:
+           - log.attributes["path"] == "/healthz/ready"
      output:
        otlp:
          ...

--- a/docs/user/integrate-otlp-backend/migration-to-otlp-logs.md
+++ b/docs/user/integrate-otlp-backend/migration-to-otlp-logs.md
@@ -111,9 +111,9 @@ See how the deprecated fields map to their new OTLP-based counterparts:
    spec:
      transform:
        - conditions:
-         - log.attributes["tenant"] == ""
+           - log.attributes["tenant"] == ""
          statements:
-         - set(log.attributes["tenant"], "myTenant")
+           - set(log.attributes["tenant"], "myTenant")
      filter:
        - conditions:
            - log.attributes["path"] == "/healthz/ready"


### PR DESCRIPTION
## Description

Fixes documentation text and examples that contradict the actual implementation. Each fix was verified against the source code.

Changes proposed in this pull request:

- `filter-and-process/filter-logs.md`: Fix container filter description that claimed "only from istio-proxy" while the YAML example shows an `exclude` filter
- `filter-and-process/transformation-to-otlp-logs.md`: Add `log.level` as a severity parsing source alongside `level`
- `integrate-otlp-backend/migration-to-otlp-logs.md`: Add missing array notation (`-`) to `filter` field in OTLP migration example
- `filter-and-process/automatic-data-enrichment.md`: Fix intro that claimed only "gateways" enrich data (Log Agent also enriches), and add source for `cloud.provider` attribute

Verification:

**Severity parsing fields**: `internal/otelcollector/config/logagent/filelog_receiver.go:20-21` defines both `attributeKeyLevel = "level"` and `attributeKeyLogLevel = "log.level"`. Two separate severity parsers are configured (lines 259-296).

**Filter array notation**: `apis/telemetry/v1beta1/shared_types.go:199` defines `Filter []FilterSpec` as a slice, requiring YAML array notation. The `transform` field in the same example already uses it correctly.

**Log Agent enrichment**: `internal/otelcollector/config/logagent/config_builder.go:85-87` adds `k8sAttributesProcessor` and `InsertClusterAttributesProcessor` to the Log Agent pipeline — the same enrichment processors used in gateways.

**`cloud.provider` source**: `internal/utils/k8s/cluster_info_getter.go:29-52` reads from Gardener ConfigMap `shoot-info` in `kube-system`, not from node labels like `cloud.region` and `cloud.availability_zone`.


Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/3734

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
