### PR TITLE
docs: fix broken commands in integration guides

### DIFF
--- a/docs/user/integration/aws-cloudwatch/README.md
+++ b/docs/user/integration/aws-cloudwatch/README.md
@@ -139,7 +139,7 @@ Use the Kyma Telemetry module to enable ingestion of the signals from your workl
    apiVersion: telemetry.kyma-project.io/v1beta1
    kind: MetricPipeline
    metadata:
-     name: awsh
+     name: aws
    spec:
      input:
        runtime:

--- a/docs/user/integration/loki/README.md
+++ b/docs/user/integration/loki/README.md
@@ -66,7 +66,7 @@ helm upgrade --install --create-namespace -n ${K8S_NAMESPACE} ${HELM_LOKI_RELEAS
   --set-string 'loki.podLabels.sidecar\.istio\.io/inject=true' \
   --set 'singleBinary.resources.requests.cpu=1' \
   --set 'loki.auth_enabled=false' \
-  --set 'log.storage.type: filesystem'
+  --set 'loki.storage.type=filesystem'
 ```
 
 The previous command uses an example [values.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/single-binary-values.yaml) from the Loki repository for setting up Loki in the 'SingleBinary' mode. Additionally, it applies:
@@ -219,7 +219,6 @@ Because Grafana provides a very good Loki integration, you might want to install
 
    ```bash
    helm delete -n ${K8S_NAMESPACE} ${HELM_LOKI_RELEASE}
-   helm delete -n ${K8S_NAMESPACE} promtail
    helm delete -n ${K8S_NAMESPACE} grafana
    ```
 

--- a/docs/user/integration/prometheus/README.md
+++ b/docs/user/integration/prometheus/README.md
@@ -207,7 +207,7 @@ The provided `values.yaml` covers the following adjustments:
 1. To remove the MetricPipeline, call kubectl:
 
     ```bash
-    helm delete MetricPipeline prometheus
+    kubectl delete MetricPipeline prometheus
     ```
 
 1. To remove the example app and all its resources from the cluster, run the following command:


### PR DESCRIPTION
## Description

Fixes incorrect commands and references in integration guide examples that would fail when executed.

Changes proposed in this pull request:

- `integration/loki/README.md`: Fix Helm `--set` syntax (`log.storage.type: filesystem` → `loki.storage.type=filesystem`) and remove `promtail` from cleanup commands (never installed in this guide)
- `integration/aws-cloudwatch/README.md`: Fix MetricPipeline name typo (`awsh` → `aws`)
- `integration/prometheus/README.md`: Fix cleanup command (`helm delete MetricPipeline` → `kubectl delete MetricPipeline`)

Verification:

**Helm `--set` syntax**: Helm requires `key=value` format, not YAML colon syntax. The key `log.storage.type` is also wrong — Loki chart nests storage under `loki.storage` (visible in other `--set` flags in the same command that use the `loki.*` prefix).

**`helm delete` → `kubectl delete`**: MetricPipeline is a Kubernetes CRD (`metricpipeline.telemetry.kyma-project.io`), not a Helm release. CRDs are managed with `kubectl`, not `helm`.

**`awsh` → `aws`**: In the same file, the namespace (`aws`), Helm release (`aws`), LogPipeline (`aws`), and TracePipeline (`aws`) all use `aws`. The MetricPipeline is the only resource with the extra `h`.

**`promtail` removal**: The guide installs two Helm releases (`${HELM_LOKI_RELEASE}` and `grafana`). No `promtail` release is installed anywhere in the guide.


Changes refer to particular issues, PRs or documents:

- https://github.com/kyma-project/telemetry-manager/issues/3734

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [x] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
