### PR TITLE
docs: explicitly enable otlp input in CLS integration guide

### DIFF
--- a/docs/user/integration/sap-cloud-logging/README.md
+++ b/docs/user/integration/sap-cloud-logging/README.md
@@ -67,6 +67,8 @@ You can set up ingestion of logs from applications and the Istio service mesh to
        input:
          runtime:
            enabled: true
+         otlp:
+           enabled: true
        output:
          otlp:
            endpoint:


### PR DESCRIPTION
## Description

The LogPipeline example in the SAP Cloud Logging integration guide previously only set the `runtime` input explicitly, while the `otlp` input was implicitly enabled by default. Because the subsequent "Set Up Istio Access Logs" section relies on the OTLP input being active, this could mislead readers into thinking only runtime logs are collected.

This PR makes both inputs explicit in the YAML sample so the relationship between the OTLP input and Istio access logs is immediately clear.

## Changes

- Added `otlp: enabled: true` to the LogPipeline input section in `docs/user/integration/sap-cloud-logging/README.md`

## Related Issues

https://github.tools.sap/kyma/backlog/issues/8465