### PR TITLE
docs: the OTTL does not support Golang based time format anymore

### DIFF
--- a/docs/user/filter-and-process/ottl-transform-and-filter/ottl-transform.md
+++ b/docs/user/filter-and-process/ottl-transform-and-filter/ottl-transform.md
@@ -85,7 +85,7 @@ spec:
     - conditions:
         - log.attributes["timestamp"] != nil
       statements:
-        - set(log.time, Time(log.attributes["timestamp"], "2006-01-02T15:04:05.000Z"))
+        - set(log.time, Time(log.attributes["timestamp"], "%Y-%m-%dT%H:%M:%S.%LZ"))
         - delete_key(log.attributes, "timestamp")
     - conditions:
         - log.attributes["level"] != nil


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- With version 0.155.0 golang based time format is not supported by OTTL, use strptime format strings

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
